### PR TITLE
Log raw lint evaluation output values.

### DIFF
--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -314,7 +314,7 @@ pub(super) fn run_check_release(
                         .expect("print failed");
 
                     config
-                        .verbose(|config| {
+                        .extra_verbose(|config| {
                             colored_ln(config.stdout(), |w| {
                                 let serde_pretty = serde_json::to_string_pretty(&pretty_result)
                                     .expect("serde failed");

--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -2,6 +2,7 @@ use std::{collections::BTreeMap, env, io::Write, iter::Peekable, sync::Arc, time
 
 use anyhow::Context;
 use clap::crate_version;
+use itertools::Itertools;
 use termcolor::Color;
 use termcolor_output::{colored, colored_ln};
 use trustfall_core::ir::{FieldValue, TransparentValue};
@@ -312,11 +313,20 @@ pub(super) fn run_check_release(
                     colored_ln(config.stdout(), |w| colored!(w, "  {}", message,))
                         .expect("print failed");
 
-                    config.verbose(|config| {
-                        colored_ln(config.stdout(), |w| {
-                            colored!(w, "    lint rule output values: {:?}", &pretty_result)
-                        }).map_err(|e| e.into())
-                    }).expect("print failed");
+                    config
+                        .verbose(|config| {
+                            colored_ln(config.stdout(), |w| {
+                                let serde_pretty = serde_json::to_string_pretty(&pretty_result)
+                                    .expect("serde failed");
+                                let indented_serde = serde_pretty
+                                    .split('\n')
+                                    .map(|line| format!("    {}", line))
+                                    .join("\n");
+                                colored!(w, "    lint rule output values:\n{}", indented_serde)
+                            })
+                            .map_err(|e| e.into())
+                        })
+                        .expect("print failed");
                 } else {
                     colored_ln(config.stdout(), |w| {
                         colored!(

--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -311,6 +311,12 @@ pub(super) fn run_check_release(
                         .expect("could not materialize template");
                     colored_ln(config.stdout(), |w| colored!(w, "  {}", message,))
                         .expect("print failed");
+
+                    config.verbose(|config| {
+                        colored_ln(config.stdout(), |w| {
+                            colored!(w, "    lint rule output values: {:?}", &pretty_result)
+                        }).map_err(|e| e.into())
+                    }).expect("print failed");
                 } else {
                     colored_ln(config.stdout(), |w| {
                         colored!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,6 +68,20 @@ impl GlobalConfig {
         Ok(())
     }
 
+    pub fn is_extra_verbose(&self) -> bool {
+        log::Level::Trace <= self.level.unwrap_or(log::Level::Error)
+    }
+
+    pub fn extra_verbose(
+        &mut self,
+        callback: impl Fn(&mut Self) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        if self.is_extra_verbose() {
+            callback(self)?;
+        }
+        Ok(())
+    }
+
     pub fn is_stderr_tty(&self) -> bool {
         self.is_stderr_tty
     }


### PR DESCRIPTION
Issue #193 was difficult to triage in part because not all of the values output by the lint query were included in the error message: the error message accidentally omitted the method name with the reported error, and only reported the type on which that method was defined.

It would make future triage easier if all values output by the lint query were made available together with their corresponding error messages.

This is "debug"-level logging output, extremely verbose even by the standards of the current `--verbose` flag. Should we add it to `--verbose` anyway, or should we add a new even-more-verbose setting (e.g. `--debug` or `--verbose --verbose`, whatever is better CLI design) and only output it in that case?

