### PR TITLE
Document private items to fix non-exhaustive false-positives.

### DIFF
--- a/scripts/regenerate_test_rustdocs.sh
+++ b/scripts/regenerate_test_rustdocs.sh
@@ -24,7 +24,7 @@ for crate_pair in $(find "$TOPLEVEL/test_crates/" -maxdepth 1 -mindepth 1 -type 
         echo "Generating: $crate"
 
         pushd "$TOPLEVEL/test_crates/$crate"
-        RUSTC_BOOTSTRAP=1 $RUSTDOC_CMD -- -Zunstable-options --output-format json
+        RUSTC_BOOTSTRAP=1 $RUSTDOC_CMD -- -Zunstable-options --document-private-items --document-hidden-items --output-format=json
         mkdir -p "$TARGET_DIR/$crate"
         mv "$RUSTDOC_OUTPUT_DIR/$crate_pair.json" "$TARGET_DIR/$crate/rustdoc.json"
         popd

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -84,7 +84,7 @@ impl RustDocCommand {
         cmd.env("RUSTC_BOOTSTRAP", "1")
             .env(
                 "RUSTDOCFLAGS",
-                "-Z unstable-options --document-hidden-items --output-format=json",
+                "-Z unstable-options --document-private-items --document-hidden-items --output-format=json",
             )
             .stdout(std::process::Stdio::null()) // Don't pollute output
             .stderr(stderr)

--- a/test_outputs/struct_marked_non_exhaustive.output.ron
+++ b/test_outputs/struct_marked_non_exhaustive.output.ron
@@ -33,27 +33,5 @@
             "struct_type": String("plain"),
             "visibility_limit": String("public"),
         },
-        {
-            "name": String("NonExternallyConstructibleTupleStruct"),
-            "path": List([
-                String("non_exhaustive"),
-                String("NonExternallyConstructibleTupleStruct"),
-            ]),
-            "span_begin_line": Uint64(25),
-            "span_filename": String("src/lib.rs"),
-            "struct_type": String("tuple"),
-            "visibility_limit": String("public"),
-        },
-        {
-            "name": String("NonExternallyConstructibleStruct"),
-            "path": List([
-                String("non_exhaustive"),
-                String("NonExternallyConstructibleStruct"),
-            ]),
-            "span_begin_line": Uint64(28),
-            "span_filename": String("src/lib.rs"),
-            "struct_type": String("plain"),
-            "visibility_limit": String("public"),
-        },
     ],
 }


### PR DESCRIPTION
Fixes the false-positive lint on `#[non_exhaustive]` structs identified in https://github.com/obi1kenobi/cargo-semver-checks/pull/203#discussion_r1045174565
