### PR TITLE
Add lints for removing `const` from functions and methods.

### DIFF
--- a/src/lints/function_const_removed.ron
+++ b/src/lints/function_const_removed.ron
@@ -11,7 +11,7 @@ SemverQuery(
                 item {
                     ... on Function {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        const @filter(op: "=", value: ["$true"]) @output
+                        const @filter(op: "=", value: ["$true"])
                         name @output @tag
 
                         importable_path {

--- a/src/lints/function_const_removed.ron
+++ b/src/lints/function_const_removed.ron
@@ -1,0 +1,49 @@
+SemverQuery(
+    id: "function_const_removed",
+    human_readable_name: "pub fn is no longer const",
+    description: "A function can no longer be called in a const context.",
+    required_update: Major,
+    reference_link: Some("https://doc.rust-lang.org/reference/const_eval.html"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Function {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        const @filter(op: "=", value: ["$true"]) @output
+                        name @output @tag
+
+                        importable_path {
+                            path @output @tag
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Function {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @filter(op: "=", value: ["%name"])
+                        const @filter(op: "!=", value: ["$true"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+    },
+    error_message: "A publicly-visible function is no longer `const` and can no longer be used in a `const` context.",
+    per_result_error_template: Some("function {{join \"::\" path}} in file {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/lints/inherent_method_const_removed.ron
+++ b/src/lints/inherent_method_const_removed.ron
@@ -1,0 +1,72 @@
+SemverQuery(
+    id: "inherent_method_const_removed",
+    human_readable_name: "pub method is no longer const",
+    description: "A method or associated fn can no longer be called in a const context.",
+    required_update: Major,
+    reference_link: Some("https://doc.rust-lang.org/reference/const_eval.html"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on ImplOwner {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        name @output @tag
+
+                        importable_path {
+                            path @output @tag
+                        }
+
+                        inherent_impl {
+                            method {
+                                method_visibility: visibility_limit @filter(op: "=", value: ["$public"]) @output
+                                method_name: name @output @tag
+                                const @filter(op: "=", value: ["$true"])
+                            }
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on ImplOwner {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @filter(op: "=", value: ["%name"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                        }
+
+                        # We use "impl" instead of "inherent_impl" here because moving
+                        # an inherently-implemented method to a trait is not necessarily
+                        # a breaking change, so we don't want to report it.
+                        #
+                        # We look for "zero matching const methods" rather than
+                        # "methods that are not const" since multiple methods with the same name
+                        # are allowed to exist on the same type (e.g. via traits).
+                        impl @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            method {
+                                visibility_limit @filter(op: "one_of", value: ["$public_or_default"])
+                                name @filter(op: "=", value: ["%method_name"])
+                                const @filter(op: "=", value: ["$true"])
+                            }
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "public_or_default": ["public", "default"],
+        "zero": 0,
+        "true": true,
+    },
+    error_message: "A publicly-visible method or associated fn is no longer `const` and can no longer be used in a `const` context.",
+    per_result_error_template: Some("{{name}}::{{method_name}} in file {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -343,6 +343,7 @@ add_lints!(
     enum_variant_added,
     enum_variant_missing,
     enum_struct_variant_field_missing,
+    function_const_removed,
     function_missing,
     function_parameter_count_changed,
     inherent_method_missing,

--- a/src/query.rs
+++ b/src/query.rs
@@ -346,6 +346,7 @@ add_lints!(
     function_const_removed,
     function_missing,
     function_parameter_count_changed,
+    inherent_method_const_removed,
     inherent_method_missing,
     method_parameter_count_changed,
     sized_impl_removed,

--- a/test_crates/function_const_removed/new/Cargo.toml
+++ b/test_crates/function_const_removed/new/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "function_const_removed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/function_const_removed/new/src/lib.rs
+++ b/test_crates/function_const_removed/new/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn add(x: i64, y: i64) -> i64 {
+    x + y
+}

--- a/test_crates/function_const_removed/old/Cargo.toml
+++ b/test_crates/function_const_removed/old/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "function_const_removed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/function_const_removed/old/src/lib.rs
+++ b/test_crates/function_const_removed/old/src/lib.rs
@@ -1,0 +1,3 @@
+pub const fn add(x: i64, y: i64) -> i64 {
+    x + y
+}

--- a/test_crates/inherent_method_const_removed/new/Cargo.toml
+++ b/test_crates/inherent_method_const_removed/new/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "inherent_method_const_removed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/inherent_method_const_removed/new/src/lib.rs
+++ b/test_crates/inherent_method_const_removed/new/src/lib.rs
@@ -1,0 +1,11 @@
+pub struct Foo;
+
+impl Foo {
+    pub fn associated_fn(x: i64, y: i64) -> i64 {
+        x + y
+    }
+
+    pub fn method(&self, x: i64) -> i64 {
+        x
+    }
+}

--- a/test_crates/inherent_method_const_removed/old/Cargo.toml
+++ b/test_crates/inherent_method_const_removed/old/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "inherent_method_const_removed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/inherent_method_const_removed/old/src/lib.rs
+++ b/test_crates/inherent_method_const_removed/old/src/lib.rs
@@ -1,0 +1,11 @@
+pub struct Foo;
+
+impl Foo {
+    pub const fn associated_fn(x: i64, y: i64) -> i64 {
+        x + y
+    }
+
+    pub const fn method(&self, x: i64) -> i64 {
+        x
+    }
+}

--- a/test_outputs/function_const_removed.output.ron
+++ b/test_outputs/function_const_removed.output.ron
@@ -1,0 +1,15 @@
+{
+    "./test_crates/function_const_removed/": [
+        {
+            "const": Boolean(true),
+            "name": String("add"),
+            "path": List([
+                String("function_const_removed"),
+                String("add"),
+            ]),
+            "span_begin_line": Uint64(1),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+    ],
+}

--- a/test_outputs/function_const_removed.output.ron
+++ b/test_outputs/function_const_removed.output.ron
@@ -1,7 +1,6 @@
 {
     "./test_crates/function_const_removed/": [
         {
-            "const": Boolean(true),
             "name": String("add"),
             "path": List([
                 String("function_const_removed"),

--- a/test_outputs/inherent_method_const_removed.output.ron
+++ b/test_outputs/inherent_method_const_removed.output.ron
@@ -1,0 +1,28 @@
+{
+    "./test_crates/inherent_method_const_removed/": [
+        {
+            "method_name": String("associated_fn"),
+            "method_visibility": String("public"),
+            "name": String("Foo"),
+            "path": List([
+                String("inherent_method_const_removed"),
+                String("Foo"),
+            ]),
+            "span_begin_line": Uint64(1),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "method_name": String("method"),
+            "method_visibility": String("public"),
+            "name": String("Foo"),
+            "path": List([
+                String("inherent_method_const_removed"),
+                String("Foo"),
+            ]),
+            "span_begin_line": Uint64(1),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+    ],
+}


### PR DESCRIPTION
Add "function const removed" and "inherent method const removed" semver major lints.

Resolves #190.
