### PR TITLE
Bugfix of printed baseline version when ran on given Manifest

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -25,6 +25,23 @@ pub(crate) fn get_package_name(manifest: &Manifest) -> anyhow::Result<String> {
     Ok(package.name.clone())
 }
 
+pub(crate) fn get_package_version(manifest: &Manifest) -> anyhow::Result<String> {
+    let package = manifest.parsed.package.as_ref().ok_or_else(|| {
+        anyhow::format_err!(
+            "Failed to parse {}: no `package` table",
+            manifest.path.display()
+        )
+    })?;
+    let version = package.version.get().map_err(|e| {
+        anyhow::format_err!(
+            "Failed to retrieve package version from {}: {}",
+            manifest.path.display(),
+            e
+        )
+    })?;
+    Ok(version.clone())
+}
+
 pub(crate) fn get_lib_target_name(manifest: &Manifest) -> anyhow::Result<String> {
     // If there's a [lib] section, return the name it specifies, if any.
     if let Some(product) = &manifest.parsed.lib {


### PR DESCRIPTION
When the baseline was specified through a path to the manifest, the output of `cargo-semver-check` was as follows:
```
     Parsing clap v4.0.32 (current)
     Parsing clap v4.0.32 (baseline)
    Checking clap v4.0.31 -> v4.0.32 (patch change)
```
The version of the baseline was wrongly printed on the second line (though on the third line it is correct). This PR fixes it. Only the printing logic was wrong -- all of the logic of generating rustdocs, etc. is ok.

The bug was mainly caused by a poorly-named `version` variable in the function `src/baseline.rs::BaselineLoader::load_rustdoc` -- the `src/main.rs` was passing the "current" version and the `PathBaseline::load_rustdoc` was interpreting it as the "baseline" version. The `version` argument in this function is only needed for the `RegistryBaseline`, to choose the latest baseline version that is less equal to the current version.