### PR TITLE
Exclude yanked releases when choosing baseline version

### DIFF
--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -364,6 +364,8 @@ mod tests {
     use super::choose_baseline_version;
 
     fn new_mock_version(version_name: &str, yanked: bool) -> Version {
+        // `crates_index::Version` cannot be created explicitly, as all its fields
+        // are private, so we use the fact that it can be deserialized.
         serde_json::from_value(serde_json::json!({
             "name": "test-crate",
             "vers": version_name,
@@ -376,6 +378,8 @@ mod tests {
     }
 
     fn new_crate(versions: &[Version]) -> Crate {
+        // `crates_index::Crate` cannot be created explicitly, as its field
+        // is private, so we use the fact that it can be deserialized.
         serde_json::from_value(serde_json::json!({ "versions": versions })).unwrap()
     }
 

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -403,7 +403,8 @@ mod tests {
                 .collect(),
         );
         let current_version = current_version_name.map(|version_name| {
-            semver::Version::parse(version_name).expect("Failed to parse hand-written string as a valid version name.")
+            semver::Version::parse(version_name)
+                .expect("Failed to parse hand-written string as a valid version name.")
         });
         let chosen_baseline = choose_baseline_version(&crate_, current_version.as_ref())
             .expect("choose_baseline_version should not return any error");

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -391,4 +391,43 @@ mod tests {
             "1.2.0".to_string()
         );
     }
+
+    #[test]
+    fn choose_baseline_version_not_latest() {
+        let crate_ = new_crate(&[
+            new_mock_version("1.2.0", false),
+            new_mock_version("1.2.1", false),
+        ]);
+        let current_version = semver::Version::new(1, 2, 0);
+        assert_eq!(
+            choose_baseline_version(&crate_, Some(&current_version)).unwrap(),
+            "1.2.0".to_string()
+        );
+    }
+
+    #[test]
+    fn choose_baseline_version_pre_release() {
+        let crate_ = new_crate(&[
+            new_mock_version("1.2.0", false),
+            new_mock_version("1.2.1-rc1", false),
+        ]);
+        let current_version = semver::Version::parse("1.2.1-rc2").unwrap();
+        assert_eq!(
+            choose_baseline_version(&crate_, Some(&current_version)).unwrap(),
+            "1.2.0".to_string()
+        );
+    }
+
+    #[test]
+    fn choose_baseline_version_no_current() {
+        let crate_ = new_crate(&[
+            new_mock_version("1.2.0", false),
+            new_mock_version("1.2.1-rc1", false),
+            new_mock_version("1.3.1", true),
+        ]);
+        assert_eq!(
+            choose_baseline_version(&crate_, None).unwrap(),
+            "1.2.0".to_string()
+        );
+    }
 }

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -403,11 +403,11 @@ mod tests {
                 .collect(),
         );
         let current_version = current_version_name.map(|version_name| {
-            semver::Version::parse(version_name).expect("current_version_name should be valid")
+            semver::Version::parse(version_name).expect("Failed to parse hand-written string as a valid version name.")
         });
-        let choosen_baseline = choose_baseline_version(&crate_, current_version.as_ref())
+        let chosen_baseline = choose_baseline_version(&crate_, current_version.as_ref())
             .expect("choose_baseline_version should not return any error");
-        assert_eq!(choosen_baseline, expected.to_owned());
+        assert_eq!(chosen_baseline, expected.to_owned());
     }
 
     #[test]

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -278,12 +278,14 @@ fn choose_baseline_version(
                 )
             })
     } else {
-        // If there is no normal version (not yanked and not a pre-release)
-        // choosing the latest one anyway is more reasonable than throwing an
-        // error, as there is still a chance that it is what the user expects.
         let instance = crate_
             .highest_normal_version()
-            .unwrap_or_else(|| crate_.highest_version())
+            .unwrap_or_else(|| {
+                // If there is no normal version (not yanked and not a pre-release)
+                // choosing the latest one anyway is more reasonable than throwing an
+                // error, as there is still a chance that it is what the user expects.
+                crate_.highest_version()
+            })
             .version();
         Ok(instance.to_owned())
     }

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -278,6 +278,9 @@ fn choose_baseline_version(
                 )
             })
     } else {
+        // If there is no normal version (not yanked and not a pre-release)
+        // choosing the latest one anyway is more reasonable than throwing an
+        // error, as there is still a chance that it is what the user expects.
         let instance = crate_
             .highest_normal_version()
             .unwrap_or_else(|| crate_.highest_version())
@@ -458,6 +461,15 @@ mod tests {
             vec![("1.2.1-rc1", false), ("1.2.1", true)],
             Some("1.2.1"),
             "1.2.1",
+        );
+    }
+
+    #[test]
+    fn baseline_choosing_logic_picks_yanked_if_there_is_no_normal2() {
+        assert_correctly_picks_baseline_version(
+            vec![("1.2.2", true), ("1.2.3", true)],
+            Some("1.2.1"),
+            "1.2.3",
         );
     }
 }

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -247,6 +247,9 @@ fn choose_baseline_version(
     crate_: &Crate,
     version_current: Option<&semver::Version>,
 ) -> anyhow::Result<String> {
+    // Try to avoid pre-releases
+    // - Breaking changes are allowed between them
+    // - Most likely the user cares about the last official release
     if let Some(current) = version_current {
         let mut instances = crate_
             .versions()
@@ -292,9 +295,7 @@ impl BaselineLoader for RegistryBaseline {
             .index
             .crate_(name)
             .with_context(|| anyhow::format_err!("{} not found in registry", name))?;
-        // Try to avoid pre-releases
-        // - Breaking changes are allowed between them
-        // - Most likely the user cares about the last official release
+
         let base_version = if let Some(base) = self.version.as_ref() {
             base.to_string()
         } else {

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -378,17 +378,17 @@ mod tests {
             "yanked": yanked,
             "cksum": "00".repeat(32),
         }))
-        .expect("Parsing JSON as crates_index::Version should not result in any errors.")
+        .expect("Failed to create crates_index::Version from a hand-written JSON.")
     }
 
     fn new_crate(versions: Vec<Version>) -> Crate {
         // `crates_index::Crate` cannot be created explicitly, as its field
         // is private, so we use the fact that it can be deserialized.
         serde_json::from_value(serde_json::json!({ "versions": versions }))
-            .expect("Parsing JSON as crates_index::Crate should not result in any errors.")
+            .expect("Failed to create crates_index::Crate from a hand-written JSON.")
     }
 
-    fn test_choose_baseline_version(
+    fn assert_correctly_picks_baseline_version(
         versions: Vec<(&str, bool)>,
         current_version_name: Option<&str>,
         expected: &str,
@@ -408,8 +408,8 @@ mod tests {
     }
 
     #[test]
-    fn choose_baseline_version_yanked() {
-        test_choose_baseline_version(
+    fn baseline_choosing_logic_skips_yanked() {
+        assert_correctly_picks_baseline_version(
             vec![("1.2.0", false), ("1.2.1", true)],
             Some("1.2.2"),
             "1.2.0",
@@ -417,8 +417,8 @@ mod tests {
     }
 
     #[test]
-    fn choose_baseline_version_not_latest() {
-        test_choose_baseline_version(
+    fn baseline_choosing_logic_skips_greater_than_current() {
+        assert_correctly_picks_baseline_version(
             vec![("1.2.0", false), ("1.2.1", false)],
             Some("1.2.0"),
             "1.2.0",
@@ -426,8 +426,8 @@ mod tests {
     }
 
     #[test]
-    fn choose_baseline_version_pre_release() {
-        test_choose_baseline_version(
+    fn baseline_choosing_logic_skips_pre_releases() {
+        assert_correctly_picks_baseline_version(
             vec![("1.2.0", false), ("1.2.1-rc1", false)],
             Some("1.2.1-rc2"),
             "1.2.0",
@@ -435,8 +435,8 @@ mod tests {
     }
 
     #[test]
-    fn choose_baseline_version_no_current() {
-        test_choose_baseline_version(
+    fn baseline_choosing_logic_without_current_picks_latest_normal() {
+        assert_correctly_picks_baseline_version(
             vec![("1.2.0", false), ("1.2.1-rc1", false), ("1.3.1", true)],
             None,
             "1.2.0",
@@ -444,8 +444,8 @@ mod tests {
     }
 
     #[test]
-    fn choose_baseline_version_no_normal_largest_yanked() {
-        test_choose_baseline_version(
+    fn baseline_choosing_logic_picks_pre_release_if_there_is_no_normal() {
+        assert_correctly_picks_baseline_version(
             vec![("1.2.0", true), ("1.2.1-rc1", false)],
             Some("1.2.1"),
             "1.2.1-rc1",
@@ -453,8 +453,8 @@ mod tests {
     }
 
     #[test]
-    fn choose_baseline_version_no_normal_largest_pre_release() {
-        test_choose_baseline_version(
+    fn baseline_choosing_logic_picks_yanked_if_there_is_no_normal() {
+        assert_correctly_picks_baseline_version(
             vec![("1.2.1-rc1", false), ("1.2.1", true)],
             Some("1.2.1"),
             "1.2.1",

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -381,14 +381,14 @@ mod tests {
             "yanked": yanked,
             "cksum": "00".repeat(32),
         }))
-        .expect("Failed to create crates_index::Version from a hand-written JSON.")
+        .expect("hand-written JSON used to create mock crates_index::Version should be valid")
     }
 
     fn new_crate(versions: Vec<Version>) -> Crate {
         // `crates_index::Crate` cannot be created explicitly, as its field
         // is private, so we use the fact that it can be deserialized.
         serde_json::from_value(serde_json::json!({ "versions": versions }))
-            .expect("Failed to create crates_index::Crate from a hand-written JSON.")
+            .expect("hand-written JSON used to create mock crates_index::Crate should be valid")
     }
 
     fn assert_correctly_picks_baseline_version(
@@ -404,10 +404,10 @@ mod tests {
         );
         let current_version = current_version_name.map(|version_name| {
             semver::Version::parse(version_name)
-                .expect("Failed to parse hand-written string as a valid version name.")
+                .expect("current_version_name used in assertion should encode a valid version")
         });
         let chosen_baseline = choose_baseline_version(&crate_, current_version.as_ref())
-            .expect("choose_baseline_version should not return any error");
+            .expect("choose_baseline_version should not return any error in the test case");
         assert_eq!(chosen_baseline, expected.to_owned());
     }
 

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -463,13 +463,4 @@ mod tests {
             "1.2.1",
         );
     }
-
-    #[test]
-    fn baseline_choosing_logic_picks_yanked_if_there_is_no_normal2() {
-        assert_correctly_picks_baseline_version(
-            vec![("1.2.2", true), ("1.2.3", true)],
-            Some("1.2.1"),
-            "1.2.3",
-        );
-    }
 }


### PR DESCRIPTION
Closes #254

Extracts the selection of baseline version to a separate function, adds tests for it.