### PR TITLE
Use exact version when generating a registry baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - rust-tests
       - run-on-rust-libp2p
       - run-on-core-graphics
+      - run-on-bevy-core
     steps:
       - run: exit 0
 
@@ -111,7 +112,7 @@ jobs:
           persist-credentials: false
           repository: 'libp2p/rust-libp2p'
           ref: '3371d7ceab242440216ae9ab99829631fa418f3b'
-          path: 'crate'
+          path: 'subject'
 
       - name: Install rust
         uses: actions-rs/toolchain@v1
@@ -125,15 +126,17 @@ jobs:
         run: sudo apt install protobuf-compiler
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: rust-libp2p
 
       - name: Run semver-checks
-        run: cargo run semver-checks check-release --manifest-path="crate/core/Cargo.toml"
+        run: cargo run semver-checks check-release --manifest-path="subject/core/Cargo.toml"
 
       # Test passing package name explicitly.
       # It was previously possible to make the command above work while the one here failed.
       # Reference: https://github.com/obi1kenobi/cargo-semver-checks/issues/174
       - name: Run semver-checks (alternative command)
-        run: cargo run semver-checks check-release --manifest-path="crate/core/Cargo.toml" --package="libp2p-core"
+        run: cargo run semver-checks check-release --manifest-path="subject/core/Cargo.toml" --package="libp2p-core"
 
   run-on-core-graphics:
     # Run cargo-semver-checks on a crate with no semver violations,
@@ -156,7 +159,7 @@ jobs:
           persist-credentials: false
           repository: 'servo/core-foundation-rs'
           ref: '786895643140fa0ee4f913d7b4aeb0c4626b2085'
-          path: 'crate'
+          path: 'subject'
 
       - name: Install rust
         uses: actions-rs/toolchain@v1
@@ -166,9 +169,45 @@ jobs:
           override: true
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: core-graphics
 
       - name: Run semver-checks
-        run: cargo run semver-checks check-release --manifest-path="crate/core-graphics/Cargo.toml"
+        run: cargo run semver-checks check-release --manifest-path="subject/core-graphics/Cargo.toml"
+
+  run-on-bevy-core:
+    # cargo-semver-checks previously crashed here due to
+    # a bug in the generated Cargo.toml when generating a registry baseline:
+    # https://github.com/obi1kenobi/cargo-semver-checks/issues/261
+    name: Run cargo-semver-checks on bevy-core
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cargo-semver-checks
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Checkout bevy
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          repository: 'bevyengine/bevy'
+          ref: '3dd8b42f7287340913055db34db5606c1720b9d5'
+          path: 'subject'
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: bevy-core
+
+      - name: Run semver-checks
+        run: cargo run semver-checks check-release --manifest-path="subject/crates/bevy_core/Cargo.toml"
 
   init-release:
     name: Run the release workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
         with:
           persist-credentials: false
           repository: 'bevyengine/bevy'
-          ref: '3dd8b42f7287340913055db34db5606c1720b9d5'
+          ref: 'v0.9.0'
           path: 'subject'
 
       - name: Install rust

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -222,7 +222,10 @@ fn create_rustdoc_manifest_for_crate_version(
         },
         dependencies: {
             let project_with_features = DependencyDetail {
-                version: Some(crate_baseline.version().to_string()),
+                // we need the *exact* version as a dependency, or else cargo will
+                // give us the latest semver-compatible version which is not we want;
+                // fixes: https://github.com/obi1kenobi/cargo-semver-checks/issues/261
+                version: Some(format!("={}", crate_baseline.version())),
                 // adding features fixes:
                 // https://github.com/obi1kenobi/cargo-semver-check/issues/147
                 features: crate_baseline

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -87,7 +87,7 @@ impl RustDocCommand {
         if !output.status.success() {
             if self.silence {
                 anyhow::bail!(
-                    "Failed when running cargo-doc on {}: {}",
+                    "Failed when running cargo-doc on {}:\n{}",
                     manifest_path.display(),
                     String::from_utf8_lossy(&output.stderr)
                 )


### PR DESCRIPTION
Use the exact version of the baseline in the generated `Cargo.toml`. Otherwise, cargo will use the latest semver-compatible release, which may have the wrong number and therefore fail when attempting to generate rustdoc JSON as in #261.

Also improves the formatting of the encountered error message.

Resolves #261.