### PR TITLE
Fix rustdoc .json files overwriting each other

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: bevy-core
+          key: bevy--core
 
       - name: Run semver-checks
         run: cargo run semver-checks check-release --manifest-path="subject/crates/bevy_core/Cargo.toml"
@@ -243,6 +243,40 @@ jobs:
 
       - name: Run semver-checks
         run: cargo run semver-checks check-release --manifest-path="subject/crates/bevy_gltf/Cargo.toml" --baseline-version 0.9.0
+
+  run-on-clap:
+    # clap v3.2.0 added a semver violation
+    # check if cargo-semver-checks detects the issue
+    # https://github.com/clap-rs/clap/issues/3876
+    name: Run cargo-semver-checks on clap v3.2.0
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cargo-semver-checks
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Checkout clap
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          repository: 'clap-rs/clap'
+          ref: 'v3.2.0'
+          path: 'subject'
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: clap
+
+      - name: Run semver-checks
+        run: cargo run semver-checks check-release --manifest-path="subject/Cargo.toml"
 
   init-release:
     name: Run the release workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
 
   run-on-clap:
     # clap v3.2.0 added a semver violation
-    # check if cargo-semver-checks detects the issue
+    # check whether cargo-semver-checks detects the issue
     # https://github.com/clap-rs/clap/issues/3876
     name: Run cargo-semver-checks on clap v3.2.0
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,9 @@ jobs:
           key: clap
 
       - name: Run semver-checks
-        run: not cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-root="subject-baseline/Cargo.toml" > output
+        run: |
+          cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-root="subject-baseline/Cargo.toml" > output
+          if [[ $? == 0 ]]; then exit 1; else exit 0; fi
 
       - name: Check output
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       - run-on-core-graphics
       - run-on-bevy-core
       - run-on-bevy-gltf
+      - run-on-clap
     steps:
       - run: exit 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,12 +292,12 @@ jobs:
 
       - name: Check return code
         run: |
-          if [[ $(cat return_code) == 0 ]]; then exit 1; else exit 0; fi
+          if [[ "$(cat return_code)" == "0" ]]; then exit 1; else exit 0; fi
 
       - name: Check output
         run: |
-          EXPECTED=$(echo -e "--- failure auto_trait_impl_removed: auto trait no longer implemented ---\n--- failure trait_missing: pub trait removed or renamed ---")
-          RESULT=$(cat output | grep failure)
+          EXPECTED="$(echo -e "--- failure auto_trait_impl_removed: auto trait no longer implemented ---\n--- failure trait_missing: pub trait removed or renamed ---")"
+          RESULT="$(cat output | grep failure)"
           diff <(echo "$RESULT") <(echo "$EXPECTED")
 
   init-release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,9 +284,14 @@ jobs:
           key: clap
 
       - name: Run semver-checks
+        continue-on-error: true
         run: |
           cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-root="subject-baseline/Cargo.toml" > output
-          if [[ $? == 0 ]]; then exit 1; else exit 0; fi
+          echo "$?" > return_code
+
+      - name: Check return code
+        run: |
+          if [[ $(cat return_code) == 0 ]]; then exit 1; else exit 0; fi
 
       - name: Check output
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,13 +256,21 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Checkout clap
+      - name: Checkout clap v3.2.0
         uses: actions/checkout@v3
         with:
           persist-credentials: false
           repository: 'clap-rs/clap'
           ref: 'v3.2.0'
-          path: 'subject'
+          path: 'subject-current'
+
+      - name: Checkout clap v3.1.18
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          repository: 'clap-rs/clap'
+          ref: 'v3.1.18'
+          path: 'subject-baseline'
 
       - name: Install rust
         uses: actions-rs/toolchain@v1
@@ -276,7 +284,14 @@ jobs:
           key: clap
 
       - name: Run semver-checks
-        run: cargo run semver-checks check-release --manifest-path="subject/Cargo.toml"
+        run: ! cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-root="subject-baseline/Cargo.toml" > output
+
+      - name: Check output
+        run: |
+          EXPECTED=$(echo -e "--- failure auto_trait_impl_removed: auto trait no longer implemented ---\n--- failure trait_missing: pub trait removed or renamed ---")
+          RESULT=$(cat output | grep failure)
+          diff <(echo "$RESULT") <(echo "$EXPECTED")
+          [[ $RESULT == $EXPECTED ]]
 
   init-release:
     name: Run the release workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: bevy--core
+          key: bevy-core
 
       - name: Run semver-checks
         run: cargo run semver-checks check-release --manifest-path="subject/crates/bevy_core/Cargo.toml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
           key: clap
 
       - name: Run semver-checks
-        run: ! cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-root="subject-baseline/Cargo.toml" > output
+        run: not cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-root="subject-baseline/Cargo.toml" > output
 
       - name: Check output
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,6 @@ jobs:
           EXPECTED=$(echo -e "--- failure auto_trait_impl_removed: auto trait no longer implemented ---\n--- failure trait_missing: pub trait removed or renamed ---")
           RESULT=$(cat output | grep failure)
           diff <(echo "$RESULT") <(echo "$EXPECTED")
-          [[ $RESULT == $EXPECTED ]]
 
   init-release:
     name: Run the release workflow

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,9 +176,11 @@ fn main() -> anyhow::Result<()> {
                     let rustdoc_path = rustdoc_cmd.dump(manifest_path, None, true)?;
                     let current_crate = load_rustdoc(&rustdoc_path)?;
 
-                    // Can overwrite rustdoc of current crate.
+                    // The process of generating baseline rustdoc can overwrite 
+                    // the already-generated rustdoc of the current crate.
                     // For example, this happens when target-dir is specified in `.cargo/config.toml`.
-                    // That's the reason why we're immediately loading the rustdocs to memory.
+                    // That's the reason why we're immediately loading the rustdocs into memory.
+                    // See: https://github.com/obi1kenobi/cargo-semver-checks/issues/269
                     let baseline_path = loader.load_rustdoc(
                         &mut config,
                         &rustdoc_cmd,

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,13 +129,14 @@ fn main() -> anyhow::Result<()> {
                 args.current_rustdoc.as_deref()
             {
                 let name = "<unknown>";
+                let version = None;
                 let (current_crate, baseline_crate) = generate_versioned_crates(
                     &mut config,
                     CurrentCratePath::CurrentRustdocPath(current_rustdoc_path),
-                    &loader,
+                    &*loader,
                     &rustdoc_cmd,
                     name,
-                    None,
+                    version,
                 )?;
 
                 let success = run_check_release(&mut config, name, current_crate, baseline_crate)?;
@@ -168,7 +169,7 @@ fn main() -> anyhow::Result<()> {
                             let (current_crate, baseline_crate) = generate_versioned_crates(
                                 &mut config,
                                 CurrentCratePath::ManifestPath(manifest_path),
-                                &loader,
+                                &*loader,
                                 &rustdoc_cmd,
                                 crate_name,
                                 Some(version),
@@ -210,7 +211,7 @@ enum CurrentCratePath<'a> {
 fn generate_versioned_crates(
     config: &mut GlobalConfig,
     current_crate_path: CurrentCratePath,
-    loader: &Box<dyn baseline::BaselineLoader>,
+    loader: &dyn baseline::BaselineLoader,
     rustdoc_cmd: &RustDocCommand,
     crate_name: &str,
     version: Option<&Version>,
@@ -228,7 +229,7 @@ fn generate_versioned_crates(
     // For example, this happens when target-dir is specified in `.cargo/config.toml`.
     // That's the reason why we're immediately loading the rustdocs into memory.
     // See: https://github.com/obi1kenobi/cargo-semver-checks/issues/269
-    let baseline_path = loader.load_rustdoc(config, &rustdoc_cmd, crate_name, version)?;
+    let baseline_path = loader.load_rustdoc(config, rustdoc_cmd, crate_name, version)?;
     let baseline_crate = load_rustdoc(&baseline_path)?;
 
     Ok((current_crate, baseline_crate))

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,10 +202,9 @@ fn main() -> anyhow::Result<()> {
 }
 
 // Argument to the generate_versioned_crates function.
-// It can be either a path to an existing rustdoc, or a manifest path of a crate.
 enum CurrentCratePath<'a> {
-    CurrentRustdocPath(&'a Path),
-    ManifestPath(&'a Path),
+    CurrentRustdocPath(&'a Path), // If rustdoc is passed, it is just loaded into the memory.
+    ManifestPath(&'a Path),       // Otherwise, the function generates the rustdoc.
 }
 
 fn generate_versioned_crates(

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,8 +123,17 @@ fn main() -> anyhow::Result<()> {
                 .silence(!config.is_verbose());
 
             let mut success = true;
-            let mut run_check_release = |config: &mut GlobalConfig, crate_name: &str, current_crate: VersionedCrate, baseline_crate: VersionedCrate| -> anyhow::Result<()> {
-                if !check_release::run_check_release(config, crate_name, current_crate, baseline_crate)? {
+            let mut run_check_release = |config: &mut GlobalConfig,
+                                         crate_name: &str,
+                                         current_crate: VersionedCrate,
+                                         baseline_crate: VersionedCrate|
+             -> anyhow::Result<()> {
+                if !check_release::run_check_release(
+                    config,
+                    crate_name,
+                    current_crate,
+                    baseline_crate,
+                )? {
                     success = false;
                 }
                 Ok(())


### PR DESCRIPTION
Fixes https://github.com/obi1kenobi/cargo-semver-checks/issues/269 and #309.

When `target-dir` is specified in `.cargo/config.toml`, the path for generated rustdoc .json file is the same for the baseline and current crate version. When generating the .json files both in advance, and them processing them later, this is obviously a problem, as one of them gets overwritten.

I don't know if the solution I have came up with is the best one, as we might load too much data into memory when processing multiple crates at once. On the other hand, this way we are sure, overwritting is not an issue.