### PR TITLE
New lint: Struct `#[must_use]` added

### DIFF
--- a/src/lints/struct_must_use_added.ron
+++ b/src/lints/struct_must_use_added.ron
@@ -1,0 +1,64 @@
+SemverQuery(
+    id: "struct_must_use_added",
+    human_readable_name: "struct #[must_use] added",
+    description: "A struct has been marked with #[must_use].",
+    required_update: Minor,
+
+    // TODO: Change the reference link to point to the cargo semver reference
+    //       once it has a section on attribute #[must_use].
+    reference_link: Some("https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Struct {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        name @tag @output
+
+                        importable_path {
+                            path @tag @output
+                        }
+
+                        attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            content {
+                                base @filter(op: "=", value: ["$must_use"])
+                            }
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Struct {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @filter(op: "=", value: ["%name"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                        }
+
+                        attribute {
+                            new_attr: raw_attribute @output
+                            content {
+                                base @filter(op: "=", value: ["$must_use"])
+                            }
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "must_use": "must_use",
+        "zero": 0,
+    },
+    error_message: "A struct has been marked with #[must_use]. This can cause downstream crates that did not use this struct's value to get a compiler lint.",
+    per_result_error_template: Some("struct {{name}} in {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/lints/struct_must_use_added.ron
+++ b/src/lints/struct_must_use_added.ron
@@ -59,6 +59,6 @@ SemverQuery(
         "must_use": "must_use",
         "zero": 0,
     },
-    error_message: "A struct has been marked with #[must_use]. This can cause downstream crates that did not use this struct's value to get a compiler lint.",
+    error_message: "A struct is now #[must_use]. Downstream crates that did not use its value will get a compiler lint.",
     per_result_error_template: Some("struct {{name}} in {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/query.rs
+++ b/src/query.rs
@@ -427,6 +427,7 @@ add_lints!(
     sized_impl_removed,
     struct_marked_non_exhaustive,
     struct_missing,
+    struct_must_use_added,
     struct_pub_field_missing,
     struct_repr_c_removed,
     struct_repr_transparent_removed,

--- a/test_crates/struct_must_use_added/new/Cargo.toml
+++ b/test_crates/struct_must_use_added/new/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "struct_must_use_added"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/struct_must_use_added/new/src/lib.rs
+++ b/test_crates/struct_must_use_added/new/src/lib.rs
@@ -1,0 +1,62 @@
+// These structs did not have the #[must_use] attribute in the old version.
+// Addition of the attribute should be reported by this rule.
+
+#[must_use]
+pub struct StructToMustUseStruct {
+    bar: u64,
+}
+
+#[must_use = "Foo"]
+pub struct StructToMustUseMessageStruct {
+    bar: u64,
+}
+
+
+// These structs had the #[must_use] attribute in the old version. Changes of
+// the attribute, including deletion, should NOT be reported by this rule.
+
+pub struct MustUseStructToStruct {
+    bar: u64,
+}
+
+#[must_use = "Foo"]
+pub struct MustUseStructToMustUseMessageStruct {
+    bar: u64,
+}
+
+
+// These structs had the #[must_use] attribute in the old version.
+// They also included the user-defined warning message. Changes of
+// the attribute, including deletion, should NOT be reported by this rule.
+
+pub struct MustUseMessageStructToStruct {
+    bar: u64,
+}
+
+#[must_use]
+pub struct MustUseMessageStructToMustUseStruct {
+    bar: u64,
+}
+
+#[must_use = "Baz"]
+pub struct MustUseMessageStructToMustUseMessageStruct {
+    bar: u64,
+}
+
+
+// This struct is private and should NOT be reported by this rule.
+
+#[must_use]
+struct MustUsePrivateStruct {
+    bar: u64,
+}
+
+
+// This struct was added in the new version of the crate with it's attribute.
+// It should NOT be reported by this rule because adding a new struct is not
+// a breaking change.
+
+#[must_use]
+pub struct MustUseNewStruct {
+    bar: u64,
+}

--- a/test_crates/struct_must_use_added/new/src/lib.rs
+++ b/test_crates/struct_must_use_added/new/src/lib.rs
@@ -52,9 +52,9 @@ struct MustUsePrivateStruct {
 }
 
 
-// This struct was added in the new version of the crate with it's attribute.
-// It should NOT be reported by this rule because adding a new struct is not
-// a breaking change.
+// This struct was added in the new version of the crate with its attribute.
+// It should NOT be reported by this rule to avoid duplicate lints.
+// It should be reported as a new pub type that is part of the crate's API.
 
 #[must_use]
 pub struct MustUseNewStruct {

--- a/test_crates/struct_must_use_added/old/Cargo.toml
+++ b/test_crates/struct_must_use_added/old/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "struct_must_use_added"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/struct_must_use_added/old/src/lib.rs
+++ b/test_crates/struct_must_use_added/old/src/lib.rs
@@ -1,0 +1,51 @@
+// These structs did not have the #[must_use] attribute in the old version.
+// Addition of the attribute should be reported by this rule.
+
+pub struct StructToMustUseStruct {
+    bar: u64,
+}
+
+pub struct StructToMustUseMessageStruct {
+    bar: u64,
+}
+
+
+// These structs had the #[must_use] attribute in the old version. Changes of
+// the attribute, including deletion, should NOT be reported by this rule.
+
+#[must_use]
+pub struct MustUseStructToStruct {
+    bar: u64,
+}
+
+#[must_use]
+pub struct MustUseStructToMustUseMessageStruct {
+    bar: u64,
+}
+
+
+// These structs had the #[must_use] attribute in the old version.
+// They also included the user-defined warning message. Changes of
+// the attribute, including deletion, should NOT be reported by this rule.
+
+#[must_use = "Foo"]
+pub struct MustUseMessageStructToStruct {
+    bar: u64,
+}
+
+#[must_use = "Foo"]
+pub struct MustUseMessageStructToMustUseStruct {
+    bar: u64,
+}
+
+#[must_use = "Foo"]
+pub struct MustUseMessageStructToMustUseMessageStruct {
+    bar: u64,
+}
+
+
+// This struct is private and should NOT be reported by this rule.
+
+struct MustUsePrivateStruct {
+    bar: u64,
+}

--- a/test_outputs/struct_must_use_added.output.ron
+++ b/test_outputs/struct_must_use_added.output.ron
@@ -1,0 +1,26 @@
+{
+    "./test_crates/struct_must_use_added/": [
+        {
+            "name": String("StructToMustUseStruct"),
+            "new_attr": String("#[must_use]"),
+            "path": List([
+                String("struct_must_use_added"),
+                String("StructToMustUseStruct"),
+            ]),
+            "span_begin_line": Uint64(5),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("StructToMustUseMessageStruct"),
+            "new_attr": String("#[must_use = \"Foo\"]"),
+            "path": List([
+                String("struct_must_use_added"),
+                String("StructToMustUseMessageStruct"),
+            ]),
+            "span_begin_line": Uint64(10),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+    ],
+}


### PR DESCRIPTION
This is a part of solving #159, as well as splitting #268 into more manageable, smaller PRs.

Implements the check against adding `#[must_use]` attribute to a public Struct.