### PR TITLE
New lint: Trait `#[must_use]` added

### DIFF
--- a/src/lints/trait_must_use_added.ron
+++ b/src/lints/trait_must_use_added.ron
@@ -1,0 +1,64 @@
+SemverQuery(
+    id: "trait_must_use_added",
+    human_readable_name: "trait #[must_use] added",
+    description: "A trait has been marked with #[must_use].",
+    required_update: Minor,
+
+    // TODO: Change the reference link to point to the cargo semver reference
+    //       once it has a section on attribute #[must_use].
+    reference_link: Some("https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        name @tag @output
+
+                        importable_path {
+                            path @tag @output
+                        }
+
+                        attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            content {
+                                base @filter(op: "=", value: ["$must_use"])
+                            }
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @filter(op: "=", value: ["%name"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                        }
+
+                        attribute {
+                            new_attr: raw_attribute @output
+                            content {
+                                base @filter(op: "=", value: ["$must_use"])
+                            }
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "must_use": "must_use",
+        "zero": 0,
+    },
+    error_message: "A trait has been marked with #[must_use]. This can cause downstream crates that called a function returning an impl or dyn value of this trait to get a compiler lint.",
+    per_result_error_template: Some("trait {{join \"::\" path}} in {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/lints/trait_must_use_added.ron
+++ b/src/lints/trait_must_use_added.ron
@@ -59,6 +59,6 @@ SemverQuery(
         "must_use": "must_use",
         "zero": 0,
     },
-    error_message: "A trait has been marked with #[must_use]. This can cause downstream crates that called a function returning an impl or dyn value of this trait to get a compiler lint.",
+    error_message: "A trait is now #[must_use]. Downstream crates that called a function returning an impl trait or dyn trait of this trait will get a compiler lint.",
     per_result_error_template: Some("trait {{join \"::\" path}} in {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/query.rs
+++ b/src/query.rs
@@ -431,6 +431,7 @@ add_lints!(
     struct_repr_c_removed,
     struct_repr_transparent_removed,
     trait_missing,
+    trait_must_use_added,
     trait_unsafe_added,
     trait_unsafe_removed,
     tuple_struct_to_plain_struct,

--- a/test_crates/trait_must_use_added/new/Cargo.toml
+++ b/test_crates/trait_must_use_added/new/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "trait_must_use_added"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_must_use_added/new/src/lib.rs
+++ b/test_crates/trait_must_use_added/new/src/lib.rs
@@ -36,9 +36,9 @@ pub trait MustUseMessageTraitToMustUseMessageTrait {}
 trait MustUsePrivateTrait {}
 
 
-// This trait was added in the new version of the crate with it's attribute.
-// It should NOT be reported by this rule because adding a new trait is not
-// a breaking change.
+// This trait was added in the new version of the crate with its attribute.
+// It should NOT be reported by this rule to avoid duplicate lints.
+// It should be reported as a new pub type that is part of the crate's API.
 
 #[must_use]
 pub trait MustUseNewTrait {}

--- a/test_crates/trait_must_use_added/new/src/lib.rs
+++ b/test_crates/trait_must_use_added/new/src/lib.rs
@@ -1,0 +1,44 @@
+// These traits did not have the #[must_use] attribute in the old version.
+// Addition of the attribute should be reported by this rule.
+
+#[must_use]
+pub trait TraitToMustUseTrait {}
+
+#[must_use = "Foo"]
+pub trait TraitToMustUseMessageTrait {}
+
+
+// These traits had the #[must_use] attribute in the old version. Changes of
+// the attribute, including deletion, should NOT be reported by this rule.
+
+pub trait MustUseTraitToTrait {}
+
+#[must_use = "Foo"]
+pub trait MustUseTraitToMustUseMessageTrait {}
+
+
+// These traits had the #[must_use] attribute in the old version.
+// They also included the user-defined warning message. Changes of
+// the attribute, including deletion, should NOT be reported by this rule.
+
+pub trait MustUseMessageTraitToTrait {}
+
+#[must_use]
+pub trait MustUseMessageTraitToMustUseTrait {}
+
+#[must_use = "Baz"]
+pub trait MustUseMessageTraitToMustUseMessageTrait {}
+
+
+// This trait is private and should NOT be reported by this rule.
+
+#[must_use]
+trait MustUsePrivateTrait {}
+
+
+// This trait was added in the new version of the crate with it's attribute.
+// It should NOT be reported by this rule because adding a new trait is not
+// a breaking change.
+
+#[must_use]
+pub trait MustUseNewTrait {}

--- a/test_crates/trait_must_use_added/old/Cargo.toml
+++ b/test_crates/trait_must_use_added/old/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "trait_must_use_added"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_must_use_added/old/src/lib.rs
+++ b/test_crates/trait_must_use_added/old/src/lib.rs
@@ -1,0 +1,35 @@
+// These traits did not have the #[must_use] attribute in the old version.
+// Addition of the attribute should be reported by this rule.
+
+pub trait TraitToMustUseTrait {}
+
+pub trait TraitToMustUseMessageTrait {}
+
+
+// These traits had the #[must_use] attribute in the old version. Changes of
+// the attribute, including deletion, should NOT be reported by this rule.
+
+#[must_use]
+pub trait MustUseTraitToTrait {}
+
+#[must_use]
+pub trait MustUseTraitToMustUseMessageTrait {}
+
+
+// These traits had the #[must_use] attribute in the old version.
+// They also included the user-defined warning message. Changes of
+// the attribute, including deletion, should NOT be reported by this rule.
+
+#[must_use = "Foo"]
+pub trait MustUseMessageTraitToTrait {}
+
+#[must_use = "Foo"]
+pub trait MustUseMessageTraitToMustUseTrait {}
+
+#[must_use = "Foo"]
+pub trait MustUseMessageTraitToMustUseMessageTrait {}
+
+
+// This trait is private and should NOT be reported by this rule.
+
+trait MustUsePrivateTrait {}

--- a/test_outputs/trait_must_use_added.output.ron
+++ b/test_outputs/trait_must_use_added.output.ron
@@ -1,0 +1,26 @@
+{
+    "./test_crates/trait_must_use_added/": [
+        {
+            "name": String("TraitToMustUseTrait"),
+            "new_attr": String("#[must_use]"),
+            "path": List([
+                String("trait_must_use_added"),
+                String("TraitToMustUseTrait"),
+            ]),
+            "span_begin_line": Uint64(5),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("TraitToMustUseMessageTrait"),
+            "new_attr": String("#[must_use = \"Foo\"]"),
+            "path": List([
+                String("trait_must_use_added"),
+                String("TraitToMustUseMessageTrait"),
+            ]),
+            "span_begin_line": Uint64(8),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+    ],
+}


### PR DESCRIPTION
This is a part of solving #159, as well as splitting #268 into more manageable, smaller PRs.

Implements the check against adding `#[must_use]` attribute to a public Trait.