### PR TITLE
New lint: Function `#[must_use]` added

### DIFF
--- a/src/lints/function_must_use_added.ron
+++ b/src/lints/function_must_use_added.ron
@@ -1,0 +1,64 @@
+SemverQuery(
+    id: "function_must_use_added",
+    human_readable_name: "function #[must_use] added",
+    description: "A function has been marked with #[must_use].",
+    required_update: Minor,
+
+    // TODO: Change the reference link to point to the cargo semver reference
+    //       once it has a section on attribute #[must_use].
+    reference_link: Some("https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Function {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        name @tag @output
+
+                        importable_path {
+                            path @tag @output
+                        }
+
+                        attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            content {
+                                base @filter(op: "=", value: ["$must_use"])
+                            }
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Function {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @filter(op: "=", value: ["%name"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                        }
+
+                        attribute {
+                            new_attr: raw_attribute @output
+                            content {
+                                base @filter(op: "=", value: ["$must_use"])
+                            }
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "must_use": "must_use",
+        "zero": 0,
+    },
+    error_message: "A function has been marked with #[must_use]. This can cause downstream crates that did not use the value returned by this function to get a compiler lint.",
+    per_result_error_template: Some("function {{join \"::\" path}} in {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/lints/function_must_use_added.ron
+++ b/src/lints/function_must_use_added.ron
@@ -59,6 +59,6 @@ SemverQuery(
         "must_use": "must_use",
         "zero": 0,
     },
-    error_message: "A function has been marked with #[must_use]. This can cause downstream crates that did not use the value returned by this function to get a compiler lint.",
+    error_message: "A function is now #[must_use]. Downstream crates that did not use its return value will get a compiler lint.",
     per_result_error_template: Some("function {{join \"::\" path}} in {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/query.rs
+++ b/src/query.rs
@@ -418,6 +418,7 @@ add_lints!(
     enum_variant_missing,
     function_const_removed,
     function_missing,
+    function_must_use_added,
     function_parameter_count_changed,
     function_unsafe_added,
     inherent_method_const_removed,

--- a/test_crates/function_must_use_added/new/Cargo.toml
+++ b/test_crates/function_must_use_added/new/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "function_must_use_added"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/function_must_use_added/new/src/lib.rs
+++ b/test_crates/function_must_use_added/new/src/lib.rs
@@ -36,9 +36,9 @@ pub fn MustUseMessageFunctionToMustUseMessageFunction() {}
 fn MustUsePrivateFunction() {}
 
 
-// This function was added in the new version of the crate with it's attribute.
-// It should NOT be reported by this rule because adding a new function is not
-// a breaking change.
+// This function was added in the new version of the crate with its attribute.
+// It should NOT be reported by this rule to avoid duplicate lints.
+// It should be reported as a new pub item that is part of the crate's API.
 
 #[must_use]
 pub fn MustUseNewFunction() {}

--- a/test_crates/function_must_use_added/new/src/lib.rs
+++ b/test_crates/function_must_use_added/new/src/lib.rs
@@ -1,0 +1,44 @@
+// These functions did not have the #[must_use] attribute in the old version.
+// Addition of the attribute should be reported by this rule.
+
+#[must_use]
+pub fn FunctionToMustUseFunction() {}
+
+#[must_use = "Foo"]
+pub fn FunctionToMustUseMessageFunction() {}
+
+
+// These functions had the #[must_use] attribute in the old version. Changes of
+// the attribute, including deletion, should NOT be reported by this rule.
+
+pub fn MustUseFunctionToFunction() {}
+
+#[must_use = "Foo"]
+pub fn MustUseFunctionToMustUseMessageFunction() {}
+
+
+// These functions had the #[must_use] attribute in the old version.
+// They also included the user-defined warning message. Changes of
+// the attribute, including deletion, should NOT be reported by this rule.
+
+pub fn MustUseMessageFunctionToFunction() {}
+
+#[must_use]
+pub fn MustUseMessageFunctionToMustUseFunction() {}
+
+#[must_use = "Baz"]
+pub fn MustUseMessageFunctionToMustUseMessageFunction() {}
+
+
+// This function is private and should NOT be reported by this rule.
+
+#[must_use]
+fn MustUsePrivateFunction() {}
+
+
+// This function was added in the new version of the crate with it's attribute.
+// It should NOT be reported by this rule because adding a new function is not
+// a breaking change.
+
+#[must_use]
+pub fn MustUseNewFunction() {}

--- a/test_crates/function_must_use_added/old/Cargo.toml
+++ b/test_crates/function_must_use_added/old/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "function_must_use_added"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/function_must_use_added/old/src/lib.rs
+++ b/test_crates/function_must_use_added/old/src/lib.rs
@@ -1,0 +1,35 @@
+// These functions did not have the #[must_use] attribute in the old version.
+// Addition of the attribute should be reported by this rule.
+
+pub fn FunctionToMustUseFunction() {}
+
+pub fn FunctionToMustUseMessageFunction() {}
+
+
+// These functions had the #[must_use] attribute in the old version. Changes of
+// the attribute, including deletion, should NOT be reported by this rule.
+
+#[must_use]
+pub fn MustUseFunctionToFunction() {}
+
+#[must_use]
+pub fn MustUseFunctionToMustUseMessageFunction() {}
+
+
+// These functions had the #[must_use] attribute in the old version.
+// They also included the user-defined warning message. Changes of
+// the attribute, including deletion, should NOT be reported by this rule.
+
+#[must_use = "Foo"]
+pub fn MustUseMessageFunctionToFunction() {}
+
+#[must_use = "Foo"]
+pub fn MustUseMessageFunctionToMustUseFunction() {}
+
+#[must_use = "Foo"]
+pub fn MustUseMessageFunctionToMustUseMessageFunction() {}
+
+
+// This function is private and should NOT be reported by this rule.
+
+fn MustUsePrivateFunction() {}

--- a/test_outputs/function_must_use_added.output.ron
+++ b/test_outputs/function_must_use_added.output.ron
@@ -1,0 +1,26 @@
+{
+    "./test_crates/function_must_use_added/": [
+        {
+            "name": String("FunctionToMustUseFunction"),
+            "new_attr": String("#[must_use]"),
+            "path": List([
+                String("function_must_use_added"),
+                String("FunctionToMustUseFunction"),
+            ]),
+            "span_begin_line": Uint64(5),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("FunctionToMustUseMessageFunction"),
+            "new_attr": String("#[must_use = \"Foo\"]"),
+            "path": List([
+                String("function_must_use_added"),
+                String("FunctionToMustUseMessageFunction"),
+            ]),
+            "span_begin_line": Uint64(8),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+    ],
+}


### PR DESCRIPTION
This is a part of solving #159, as well as splitting #268 into more manageable, smaller PRs.

Implements the check against adding `#[must_use]` attribute to a public function.