### PR TITLE
New lint: Trait method `#[must_use]` added

### DIFF
--- a/test_crates/trait_method_must_use_added/new/Cargo.toml
+++ b/test_crates/trait_method_must_use_added/new/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "trait_method_must_use_added"
 version = "0.1.0"
 edition = "2021"

--- a/test_crates/trait_method_must_use_added/new/Cargo.toml
+++ b/test_crates/trait_method_must_use_added/new/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "trait_method_must_use_added"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_method_must_use_added/new/src/lib.rs
+++ b/test_crates/trait_method_must_use_added/new/src/lib.rs
@@ -68,6 +68,70 @@ pub trait TraitWithProvidedMustUseMethods {
 }
 
 
+pub trait TraitWithDeclaredToProvidedMustUseMethods {
+
+    // These methods did not have the #[must_use] attribute in the old version.
+    // Addition of the attribute should be reported.
+
+    #[must_use]
+    fn DeclaredMethodToProvidedMustUseMethod(&self) {}
+
+    #[must_use = "Foo"]
+    fn DeclaredMethodToProvidedMustUseMessageMethod(&self) {}
+
+
+    // These methods had the #[must_use] attribute in the old version. Changes of
+    // the attribute, including deletion, should not be reported.
+
+    fn DeclaredMustUseMethodToProvidedMethod(&self) {}
+
+    #[must_use = "Foo"]
+    fn DeclaredMustUseMethodToProvidedMustUseMessageMethod(&self) {}
+
+
+    // These methods had the #[must_use] attribute in the old version.
+    // They also included the user-defined warning message. Changes of
+    // the attribute, including deletion, should not be reported.
+
+    fn DeclaredMustUseMessageMethodToProvidedMethod(&self) {}
+
+    #[must_use]
+    fn DeclaredMustUseMessageMethodToProvidedMustUseMethod(&self) {}
+
+    #[must_use = "Baz"]
+    fn DeclaredMustUseMessageMethodToProvidedMustUseMessageMethod(&self) {}
+}
+
+
+// This trait's methods were provided in the old version of the crate, but
+// their bodies have been removed turning them into declared methods.
+// They should NOT be reported by this rule to avoid duplicate lints.
+// They should be reported as changes of the trait's provided methods into
+// declared methods.
+
+pub trait TraitWithProvidedToDeclaredMustUseMethods {
+
+    #[must_use]
+    fn ProvidedMethodToDeclaredMustUseMethod(&self);
+
+    #[must_use = "Foo"]
+    fn ProvidedMethodToDeclaredMustUseMessageMethod(&self);
+
+    fn ProvidedMustUseMethodToDeclaredMethod(&self);
+
+    #[must_use = "Foo"]
+    fn ProvidedMustUseMethodToDeclaredMustUseMessageMethod(&self);
+
+    fn ProvidedMustUseMessageMethodToDeclaredMethod(&self);
+
+    #[must_use]
+    fn ProvidedMustUseMessageMethodToDeclaredMustUseMethod(&self);
+
+    #[must_use = "Baz"]
+    fn ProvidedMustUseMessageMethodToDeclaredMustUseMessageMethod(&self);
+}
+
+
 // This trait is private and adding #[must_use] to its methods
 // should NOT be reported.
 
@@ -78,6 +142,12 @@ trait PrivateTraitWithMustUseMethods {
 
     #[must_use]
     fn PrivateProvidedMethodToPrivateProvidedMustUseMethod(&self) {}
+
+    #[must_use]
+    fn PrivateDeclaredMethodToPrivateProvidedMustUseMethod(&self) {}
+
+    #[must_use]
+    fn PrivateProvidedMethodToPrivateDeclaredMustUseMethod(&self);
 }
 
 

--- a/test_crates/trait_method_must_use_added/new/src/lib.rs
+++ b/test_crates/trait_method_must_use_added/new/src/lib.rs
@@ -1,0 +1,96 @@
+pub trait TraitWithDeclaredMustUseMethods {
+
+    // These methods did not have the #[must_use] attribute in the old version.
+    // Addition of the attribute should be reported.
+
+    #[must_use]
+    fn DeclaredMethodToDeclaredMustUseMethod(&self);
+
+    #[must_use = "Foo"]
+    fn DeclaredMethodToDeclaredMustUseMessageMethod(&self);
+
+
+    // These methods had the #[must_use] attribute in the old version. Changes of
+    // the attribute, including deletion, should not be reported.
+
+    fn DeclaredMustUseMethodToDeclaredMethod(&self);
+
+    #[must_use = "Foo"]
+    fn DeclaredMustUseMethodToDeclaredMustUseMessageMethod(&self);
+
+
+    // These methods had the #[must_use] attribute in the old version.
+    // They also included the user-defined warning message. Changes of
+    // the attribute, including deletion, should not be reported.
+
+    fn DeclaredMustUseMessageMethodToDeclaredMethod(&self);
+
+    #[must_use]
+    fn DeclaredMustUseMessageMethodToDeclaredMustUseMethod(&self);
+
+    #[must_use = "Baz"]
+    fn DeclaredMustUseMessageMethodToDeclaredMustUseMessageMethod(&self);
+}
+
+
+pub trait TraitWithProvidedMustUseMethods {
+
+    // These methods did not have the #[must_use] attribute in the old version.
+    // Addition of the attribute should be reported.
+
+    #[must_use]
+    fn ProvidedMethodToProvidedMustUseMethod(&self) {}
+
+    #[must_use = "Foo"]
+    fn ProvidedMethodToProvidedMustUseMessageMethod(&self) {}
+
+
+    // These methods had the #[must_use] attribute in the old version. Changes of
+    // the attribute, including deletion, should not be reported.
+
+    fn ProvidedMustUseMethodToProvidedMethod(&self) {}
+
+    #[must_use = "Foo"]
+    fn ProvidedMustUseMethodToProvidedMustUseMessageMethod(&self) {}
+
+
+    // These methods had the #[must_use] attribute in the old version.
+    // They also included the user-defined warning message. Changes of
+    // the attribute, including deletion, should not be reported.
+
+    fn ProvidedMustUseMessageMethodToProvidedMethod(&self) {}
+
+    #[must_use]
+    fn ProvidedMustUseMessageMethodToProvidedMustUseMethod(&self) {}
+
+    #[must_use = "Baz"]
+    fn ProvidedMustUseMessageMethodToProvidedMustUseMessageMethod(&self) {}
+}
+
+
+// This trait is private and adding #[must_use] to its methods
+// should NOT be reported.
+
+trait PrivateTraitWithMustUseMethods {
+
+    #[must_use]
+    fn PrivateDeclaredMethodToPrivateDeclaredMustUseMethod(&self);
+
+    #[must_use]
+    fn PrivateProvidedMethodToPrivateProvidedMustUseMethod(&self) {}
+}
+
+
+// This trait and its methods were added in the new version of the crate,
+// together with the methods' attributes.
+// It should NOT be reported by this rule to avoid duplicate lints.
+// It should be reported as a new pub type that is part of the crate's API.
+
+pub trait NewTraitWithMustUseMethods {
+
+    #[must_use]
+    fn NewTraitWithDeclaredMustUseMethod(&self);
+
+    #[must_use]
+    fn NewTraitWithProvidedMustUseMethod(&self) {}
+}

--- a/test_crates/trait_method_must_use_added/old/Cargo.toml
+++ b/test_crates/trait_method_must_use_added/old/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "trait_method_must_use_added"
 version = "0.1.0"
 edition = "2021"

--- a/test_crates/trait_method_must_use_added/old/Cargo.toml
+++ b/test_crates/trait_method_must_use_added/old/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "trait_method_must_use_added"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_method_must_use_added/old/src/lib.rs
+++ b/test_crates/trait_method_must_use_added/old/src/lib.rs
@@ -68,6 +68,70 @@ pub trait TraitWithProvidedMustUseMethods {
 }
 
 
+pub trait TraitWithDeclaredToProvidedMustUseMethods {
+
+    // These methods did not have the #[must_use] attribute in the old version.
+    // Addition of the attribute should be reported.
+
+    fn DeclaredMethodToProvidedMustUseMethod(&self);
+
+    fn DeclaredMethodToProvidedMustUseMessageMethod(&self);
+
+
+    // These methods had the #[must_use] attribute in the old version. Changes
+    // of the attribute, including deletion, should not be reported.
+
+    #[must_use]
+    fn DeclaredMustUseMethodToProvidedMethod(&self);
+
+    #[must_use]
+    fn DeclaredMustUseMethodToProvidedMustUseMessageMethod(&self);
+
+
+    // These methods had the #[must_use] attribute in the old version.
+    // They also included the user-defined warning message. Changes of
+    // the attribute, including deletion, should not be reported.
+
+    #[must_use = "Foo"]
+    fn DeclaredMustUseMessageMethodToProvidedMethod(&self);
+
+    #[must_use = "Foo"]
+    fn DeclaredMustUseMessageMethodToProvidedMustUseMethod(&self);
+
+    #[must_use = "Foo"]
+    fn DeclaredMustUseMessageMethodToProvidedMustUseMessageMethod(&self);
+}
+
+
+// This trait's methods were provided in the old version of the crate, but
+// their bodies have been removed turning them into declared methods.
+// They should NOT be reported by this rule to avoid duplicate lints.
+// They should be reported as changes of the trait's provided methods into
+// declared methods.
+
+pub trait TraitWithProvidedToDeclaredMustUseMethods {
+
+    fn ProvidedMethodToDeclaredMustUseMethod(&self) {}
+
+    fn ProvidedMethodToDeclaredMustUseMessageMethod(&self) {}
+
+    #[must_use]
+    fn ProvidedMustUseMethodToDeclaredMethod(&self) {}
+
+    #[must_use]
+    fn ProvidedMustUseMethodToDeclaredMustUseMessageMethod(&self) {}
+
+    #[must_use = "Foo"]
+    fn ProvidedMustUseMessageMethodToDeclaredMethod(&self) {}
+
+    #[must_use = "Foo"]
+    fn ProvidedMustUseMessageMethodToDeclaredMustUseMethod(&self) {}
+
+    #[must_use = "Foo"]
+    fn ProvidedMustUseMessageMethodToDeclaredMustUseMessageMethod(&self) {}
+}
+
+
 // This trait is private and adding #[must_use] to its methods
 // should NOT be reported.
 
@@ -76,4 +140,8 @@ trait PrivateTraitWithMustUseMethods {
     fn PrivateDeclaredMethodToPrivateDeclaredMustUseMethod(&self);
 
     fn PrivateProvidedMethodToPrivateProvidedMustUseMethod(&self) {}
+
+    fn PrivateDeclaredMethodToPrivateProvidedMustUseMethod(&self);
+
+    fn PrivateProvidedMethodToPrivateDeclaredMustUseMethod(&self) {}
 }

--- a/test_crates/trait_method_must_use_added/old/src/lib.rs
+++ b/test_crates/trait_method_must_use_added/old/src/lib.rs
@@ -1,0 +1,79 @@
+pub trait TraitWithDeclaredMustUseMethods {
+
+    // These methods did not have the #[must_use] attribute in the old version.
+    // Addition of the attribute should be reported.
+
+    fn DeclaredMethodToDeclaredMustUseMethod(&self);
+
+    fn DeclaredMethodToDeclaredMustUseMessageMethod(&self);
+
+
+    // These methods had the #[must_use] attribute in the old version. Changes
+    // of the attribute, including deletion, should not be reported.
+
+    #[must_use]
+    fn DeclaredMustUseMethodToDeclaredMethod(&self);
+
+    #[must_use]
+    fn DeclaredMustUseMethodToDeclaredMustUseMessageMethod(&self);
+
+
+    // These methods had the #[must_use] attribute in the old version.
+    // They also included the user-defined warning message. Changes of
+    // the attribute, including deletion, should not be reported.
+
+    #[must_use = "Foo"]
+    fn DeclaredMustUseMessageMethodToDeclaredMethod(&self);
+
+    #[must_use = "Foo"]
+    fn DeclaredMustUseMessageMethodToDeclaredMustUseMethod(&self);
+
+    #[must_use = "Foo"]
+    fn DeclaredMustUseMessageMethodToDeclaredMustUseMessageMethod(&self);
+}
+
+
+pub trait TraitWithProvidedMustUseMethods {
+
+    // These methods did not have the #[must_use] attribute in the old version.
+    // Addition of the attribute should be reported.
+
+    fn ProvidedMethodToProvidedMustUseMethod(&self) {}
+
+    fn ProvidedMethodToProvidedMustUseMessageMethod(&self) {}
+
+
+    // These methods had the #[must_use] attribute in the old version. Changes
+    // of the attribute, including deletion, should not be reported.
+
+    #[must_use]
+    fn ProvidedMustUseMethodToProvidedMethod(&self) {}
+
+    #[must_use]
+    fn ProvidedMustUseMethodToProvidedMustUseMessageMethod(&self) {}
+
+
+    // These methods had the #[must_use] attribute in the old version.
+    // They also included the user-defined warning message. Changes of
+    // the attribute, including deletion, should not be reported.
+
+    #[must_use = "Foo"]
+    fn ProvidedMustUseMessageMethodToProvidedMethod(&self) {}
+
+    #[must_use = "Foo"]
+    fn ProvidedMustUseMessageMethodToProvidedMustUseMethod(&self) {}
+
+    #[must_use = "Foo"]
+    fn ProvidedMustUseMessageMethodToProvidedMustUseMessageMethod(&self) {}
+}
+
+
+// This trait is private and adding #[must_use] to its methods
+// should NOT be reported.
+
+trait PrivateTraitWithMustUseMethods {
+
+    fn PrivateDeclaredMethodToPrivateDeclaredMustUseMethod(&self);
+
+    fn PrivateProvidedMethodToPrivateProvidedMustUseMethod(&self) {}
+}


### PR DESCRIPTION
This is a part of solving https://github.com/obi1kenobi/cargo-semver-checks/issues/159, as well as splitting https://github.com/obi1kenobi/cargo-semver-checks/pull/268 into more manageable, smaller PRs.

Implements the check against adding `#[must_use]` attribute to a public Trait's method.