### PR TITLE
Optimize the `#[must_use]` lint queries by improving filtering.

### DIFF
--- a/src/lints/enum_must_use_added.ron
+++ b/src/lints/enum_must_use_added.ron
@@ -10,32 +10,14 @@ SemverQuery(
     query: r#"
     {
         CrateDiff {
-            baseline {
-                item {
-                    ... on Enum {
-                        visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @tag @output
-
-                        importable_path {
-                            path @tag @output
-                        }
-
-                        attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
-                            content {
-                                base @filter(op: "=", value: ["$must_use"])
-                            }
-                        }
-                    }
-                }
-            }
             current {
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @tag @output
 
                         importable_path {
-                            path @filter(op: "=", value: ["%path"])
+                            path @tag @output
                         }
 
                         attribute {
@@ -48,6 +30,24 @@ SemverQuery(
                         span_: span @optional {
                             filename @output
                             begin_line @output
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on Enum {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        name @filter(op: "=", value: ["%name"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                        }
+
+                        attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            content {
+                                base @filter(op: "=", value: ["$must_use"])
+                            }
                         }
                     }
                 }

--- a/src/lints/function_must_use_added.ron
+++ b/src/lints/function_must_use_added.ron
@@ -10,32 +10,14 @@ SemverQuery(
     query: r#"
     {
         CrateDiff {
-            baseline {
-                item {
-                    ... on Function {
-                        visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @tag @output
-
-                        importable_path {
-                            path @tag @output
-                        }
-
-                        attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
-                            content {
-                                base @filter(op: "=", value: ["$must_use"])
-                            }
-                        }
-                    }
-                }
-            }
             current {
                 item {
                     ... on Function {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @tag @output
 
                         importable_path {
-                            path @filter(op: "=", value: ["%path"])
+                            path @tag @output
                         }
 
                         attribute {
@@ -48,6 +30,24 @@ SemverQuery(
                         span_: span @optional {
                             filename @output
                             begin_line @output
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on Function {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        name @filter(op: "=", value: ["%name"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                        }
+
+                        attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            content {
+                                base @filter(op: "=", value: ["$must_use"])
+                            }
                         }
                     }
                 }

--- a/src/lints/struct_must_use_added.ron
+++ b/src/lints/struct_must_use_added.ron
@@ -10,32 +10,14 @@ SemverQuery(
     query: r#"
     {
         CrateDiff {
-            baseline {
-                item {
-                    ... on Struct {
-                        visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @tag @output
-
-                        importable_path {
-                            path @tag @output
-                        }
-
-                        attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
-                            content {
-                                base @filter(op: "=", value: ["$must_use"])
-                            }
-                        }
-                    }
-                }
-            }
             current {
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @tag @output
 
                         importable_path {
-                            path @filter(op: "=", value: ["%path"])
+                            path @tag @output
                         }
 
                         attribute {
@@ -48,6 +30,24 @@ SemverQuery(
                         span_: span @optional {
                             filename @output
                             begin_line @output
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on Struct {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        name @filter(op: "=", value: ["%name"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                        }
+
+                        attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            content {
+                                base @filter(op: "=", value: ["$must_use"])
+                            }
                         }
                     }
                 }

--- a/src/lints/trait_must_use_added.ron
+++ b/src/lints/trait_must_use_added.ron
@@ -10,32 +10,14 @@ SemverQuery(
     query: r#"
     {
         CrateDiff {
-            baseline {
-                item {
-                    ... on Trait {
-                        visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @tag @output
-
-                        importable_path {
-                            path @tag @output
-                        }
-
-                        attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
-                            content {
-                                base @filter(op: "=", value: ["$must_use"])
-                            }
-                        }
-                    }
-                }
-            }
             current {
                 item {
                     ... on Trait {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @tag @output
 
                         importable_path {
-                            path @filter(op: "=", value: ["%path"])
+                            path @tag @output
                         }
 
                         attribute {
@@ -48,6 +30,24 @@ SemverQuery(
                         span_: span @optional {
                             filename @output
                             begin_line @output
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        name @filter(op: "=", value: ["%name"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                        }
+
+                        attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            content {
+                                base @filter(op: "=", value: ["$must_use"])
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Most items are not `#[must_use]`. By moving the more-selective branch of the query (the `current` one that looks for `#[must_use]`), the query will evaluate fewer items because it will discard more of them earlier in the process.

The speedup is approximately a factor of 1600-2000x when measured on a particularly large crate: `aws-sdk-ec2`
https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/ec2 

Running just the 4 affected lints on that crate:
- Before: 401-413s total scan time
- After: 0.21-0.25s total scan time

The numbers only include lint execution time, excluding things such as the time needed to build the rustdoc JSON.

This is an optimization that requires knowing the underlying shape of the dataset being queried, so it's not something that Trustfall could have applied automatically without access to statistics.