### PR TITLE
Only parse test rustdocs once, for ~2x test time speedup.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
  "human-panic",
  "ignore",
  "itertools",
+ "lazy_static",
  "log",
  "ron 0.7.1",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ toml = "0.5.9"
 
 [dev-dependencies]
 assert_cmd = "2.0"
+lazy_static = "1.4.0"

--- a/src/query.rs
+++ b/src/query.rs
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn pub_use_handling() {
-        let (_baseline_crate, current_crate) = &TEST_CRATE_RUSTDOCS["template"];
+        let (_baseline_crate, current_crate) = &TEST_CRATE_RUSTDOCS["pub_use_handling"];
         let current = VersionedIndexedCrate::new(current_crate);
 
         let query = r#"

--- a/src/query.rs
+++ b/src/query.rs
@@ -176,7 +176,7 @@ mod tests {
 
     #[test]
     fn all_queries_parse_correctly() {
-        let current_crate = &TEST_CRATE_RUSTDOCS["template"].1;
+        let (_baseline_crate, current_crate) = &TEST_CRATE_RUSTDOCS["template"];
         let indexed_crate = VersionedIndexedCrate::new(current_crate);
         let adapter =
             VersionedRustdocAdapter::new(&indexed_crate, None).expect("failed to create adapter");
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn pub_use_handling() {
-        let current_crate = &TEST_CRATE_RUSTDOCS["pub_use_handling"].1;
+        let (_baseline_crate, current_crate) = &TEST_CRATE_RUSTDOCS["template"];
         let current = VersionedIndexedCrate::new(current_crate);
 
         let query = r#"


### PR DESCRIPTION
The original code used to parse each test crate's rustdoc JSON once per test case, which was wasteful. Each lint's test runs the lint on every test crate, so all test crates are always loaded even when running only a single test. The new test code loads test crates only once total, and runs approximately ~2x faster as a result.
