### PR TITLE
Lint: constructible struct with no fields became an enum or union.

### DIFF
--- a/src/lints/constructible_struct_changed_type.ron
+++ b/src/lints/constructible_struct_changed_type.ron
@@ -1,0 +1,72 @@
+SemverQuery(
+    id: "constructible_struct_changed_type",
+    human_readable_name: "struct constructible with literal became an enum or union",
+    description: "A struct was converted into an enum or union, breaking struct literals.",
+    required_update: Major,
+    reference_link: Some("https://github.com/obi1kenobi/cargo-semver-checks/issues/297#issuecomment-1399099659"),
+    reference: Some(
+        r#"\
+Exhaustive structs with no fields are constructible with a struct literal. Changing such a struct \
+to make it an enum or union is a breaking change, since the new enum / union cannot be constructed \
+with the same struct literal syntax.
+
+While struct literals can be used to create any exhaustive struct whose fields are all public, \
+structs with *any* (not *only*) public fields are handled in a different lint. \
+This lint covers the remaining edge case: exhaustive structs with no fields whatsoever.
+
+More info: https://github.com/obi1kenobi/cargo-semver-checks/issues/297
+"#
+    ),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Struct {
+                        struct_typename: __typename @tag @output
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        name @output @tag
+                        struct_type @output
+
+                        # If the struct is non-exhaustive, it can't be constructed using a literal.
+                        attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
+
+                        # The struct must not have any fields.
+                        # If it does, it's the domain of another lint.
+                        field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"])
+
+                        importable_path {
+                            path @output @tag
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on ImplOwner {
+                        current_typename: __typename @filter(op: "!=", value: ["%struct_typename"])
+                                                     @output
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @filter(op: "=", value: ["%name"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "non_exhaustive": "#[non_exhaustive]",
+        "zero": 0,
+    },
+    error_message: "A struct became an enum or union, and is no longer publicly constructible with a struct literal.",
+    per_result_error_template: Some("struct {{join \"::\" path}} became {{lowercase current_typename}} in file {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -439,6 +439,7 @@ add_lints!(
     auto_trait_impl_removed,
     constructible_struct_adds_field,
     constructible_struct_adds_private_field,
+    constructible_struct_changed_type,
     derive_trait_impl_removed,
     enum_marked_non_exhaustive,
     enum_missing,

--- a/src/templating.rs
+++ b/src/templating.rs
@@ -1,6 +1,15 @@
 use handlebars::{handlebars_helper, Handlebars};
 use serde_json::Value;
 
+// a helper to lowercase a string
+handlebars_helper!(lowercase: |arg: Value| {
+    if let Value::String(arg) = arg {
+        arg.to_ascii_lowercase()
+    } else {
+        unreachable!("non-string value provided: {arg:?}")
+    }
+});
+
 // a helper to join all values
 handlebars_helper!(join: |sep: str, args: Value| {
     if let Value::Array(arr) = args {
@@ -53,6 +62,7 @@ handlebars_helper!(multiple_spans: |files: Value, begin_line_numbers: Value| {
 pub(crate) fn make_handlebars_registry() -> Handlebars<'static> {
     let mut registry = Handlebars::new();
     registry.set_strict_mode(true);
+    registry.register_helper("lowercase", Box::new(lowercase));
     registry.register_helper("join", Box::new(join));
     registry.register_helper("unpack_if_singleton", Box::new(unpack_if_singleton));
     registry.register_helper("multiple_spans", Box::new(multiple_spans));

--- a/test_crates/inherent_method_must_use_added/old/src/item_type_changed_inherent_method_must_use_added.rs
+++ b/test_crates/inherent_method_must_use_added/old/src/item_type_changed_inherent_method_must_use_added.rs
@@ -59,7 +59,9 @@ impl EnumToUnionWithMustUseMethods {
 }
 
 
-pub struct StructToEnumWithMustUseMethods {}
+pub struct StructToEnumWithMustUseMethods {
+    internal: bool,
+}
 
 impl StructToEnumWithMustUseMethods {
 
@@ -84,7 +86,9 @@ impl StructToEnumWithMustUseMethods {
 }
 
 
-pub struct StructToUnionWithMustUseMethods {}
+pub struct StructToUnionWithMustUseMethods {
+    internal: bool,
+}
 
 impl StructToUnionWithMustUseMethods {
 

--- a/test_crates/struct_becomes_enum/new/src/lib.rs
+++ b/test_crates/struct_becomes_enum/new/src/lib.rs
@@ -39,7 +39,8 @@ pub enum ConstructibleFieldlessStruct {}
 // They have no pub fields that might become inaccessible,
 // so they can become enums with a non-breaking change.
 //
-// They are even allowed to become non-exhaustive without that being a breaking change, either.
+// They are even allowed to (but not required to) become non-exhaustive without
+// that being a breaking change, either.
 
 pub enum TupleToEnum {
     Var(i64)

--- a/test_outputs/constructible_struct_changed_type.output.ron
+++ b/test_outputs/constructible_struct_changed_type.output.ron
@@ -1,0 +1,43 @@
+{
+    "./test_crates/struct_becomes_enum/": [
+        {
+            "current_typename": String("Enum"),
+            "name": String("ConstructibleFieldlessUnit"),
+            "path": List([
+                String("struct_becomes_enum"),
+                String("ConstructibleFieldlessUnit"),
+            ]),
+            "span_begin_line": Uint64(29),
+            "span_filename": String("src/lib.rs"),
+            "struct_type": String("unit"),
+            "struct_typename": String("Struct"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "current_typename": String("Enum"),
+            "name": String("ConstructibleFieldlessTuple"),
+            "path": List([
+                String("struct_becomes_enum"),
+                String("ConstructibleFieldlessTuple"),
+            ]),
+            "span_begin_line": Uint64(31),
+            "span_filename": String("src/lib.rs"),
+            "struct_type": String("tuple"),
+            "struct_typename": String("Struct"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "current_typename": String("Enum"),
+            "name": String("ConstructibleFieldlessStruct"),
+            "path": List([
+                String("struct_becomes_enum"),
+                String("ConstructibleFieldlessStruct"),
+            ]),
+            "span_begin_line": Uint64(35),
+            "span_filename": String("src/lib.rs"),
+            "struct_type": String("plain"),
+            "struct_typename": String("Struct"),
+            "visibility_limit": String("public"),
+        },
+    ],
+}

--- a/test_outputs/struct_missing.output.ron
+++ b/test_outputs/struct_missing.output.ron
@@ -8,7 +8,7 @@
                 String("item_type_changed_inherent_method_must_use_added"),
                 String("StructToUnionWithMustUseMethods"),
             ]),
-            "span_begin_line": Uint64(87),
+            "span_begin_line": Uint64(89),
             "span_filename": String("src/item_type_changed_inherent_method_must_use_added.rs"),
             "struct_type": String("plain"),
             "visibility_limit": String("public"),


### PR DESCRIPTION
Another part toward fixing #297.

This struct was constructible with a literal, and that will break as part of the conversion to enum or union.