### PR TITLE
Update issue template to reference `CARGO_` env vars.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,7 +29,7 @@ body:
   - type: textarea
     attributes:
       label: "Build Configuration"
-      description: "Any local [Rust build configuration](https://doc.rust-lang.org/cargo/reference/config.html) in config.toml files? Paste the file content here, if you have one."
+      description: "Any local [Rust build configuration](https://doc.rust-lang.org/cargo/reference/config.html) in config.toml files, or in env vars prefixed with `CARGO_`? Paste them here, if you have any."
   - type: textarea
     attributes:
       label: "Additional Context"


### PR DESCRIPTION
In #309, the build configuration was in an env var, not in a `cargo.toml`. Advise bug reporters about this possibility.