### PR TITLE
Add vendored-openssl feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,5 @@ assert_cmd = "2.0"
 lazy_static = "1.4.0"
 
 [features]
+default = ["vendored-openssl"]
 vendored-openssl = ["crates-index/vendored-openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ ignore = "0.4.18"
 clap-verbosity-flag = "2.0.0"
 log = "0.4.17"
 git2 = { version = "0.16.0", default-features = false }
-crates-index = { version = "0.19.0", features = ["vendored-openssl"] }
+crates-index = { version = "0.19.0" }
 human-panic = "1.0.3"
 bugreport = "0.5.0"
 itertools = "0.10.5"
@@ -41,3 +41,6 @@ toml = "0.5.9"
 [dev-dependencies]
 assert_cmd = "2.0"
 lazy_static = "1.4.0"
+
+[features]
+vendored-openssl = ["crates-index/vendored-openssl"]


### PR DESCRIPTION
This PR adds a `vendored-openssl` default feature that enables `vendored-openssl` in `crates-index` dependency.

Because there were some issues in the CI https://github.com/obi1kenobi/cargo-semver-checks/pull/208, there was a decision to enable by default the `vendored-openssl` in `cargo-semver-checks`, but lately there have been some issues with it in some users https://github.com/obi1kenobi/cargo-semver-checks/issues/272. Now a temporary fix for those users would be to disable default features in `cargo-semver-checks` (thus disabling the `vendored-openssl` feature). Because this project is a binary, not a library, we've decided to make `vendored-openssl` a default feature so that users won't have to separately install `openssl` on their system.
