### PR TITLE
Detect and don't report non-breaking renaming re-exports.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - lint
       - rust-tests
       - run-on-rust-libp2p
+      - run-on-libp2p-dcutr-relay
       - run-on-core-graphics
       - run-on-bevy-core
       - run-on-bevy-gltf
@@ -139,6 +140,51 @@ jobs:
       # Reference: https://github.com/obi1kenobi/cargo-semver-checks/issues/174
       - name: Run semver-checks (alternative command)
         run: cargo run semver-checks check-release --manifest-path="subject/core/Cargo.toml" --package="libp2p-core"
+
+  run-on-libp2p-dcutr-relay:
+    # Run cargo-semver-checks on a crate with no semver violations,
+    # to make sure there are no false-positives.
+    #
+    # cargo-semver-checks previously reported false-positives here
+    # due to renaming re-exports causing confusion about which types match each other:
+    # https://github.com/obi1kenobi/cargo-semver-checks/issues/202
+    # https://github.com/libp2p/rust-libp2p/pull/2647#issuecomment-1340254920
+    name: Run cargo-semver-checks on libp2p-dcutr 1.62.0 and libp2p-relay 0.14.0
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cargo-semver-checks
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Checkout rust-libp2p
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          repository: 'libp2p/rust-libp2p'
+          ref: 'be0b62a78fe9d72811b9eda742137cc8ddc4da35'
+          path: 'subject'
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      # rust-libp2p requires protobuf-compiler.
+      - name: Install protobuf-compiler
+        run: sudo apt install protobuf-compiler
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: libp2p-dcutr-relay
+
+      - name: Run semver-checks on libp2p-dcutr
+        run: cargo run semver-checks check-release --manifest-path="subject/protocols/dcutr/Cargo.toml"
+
+      - name: Run semver-checks on libp2p-relay
+        run: cargo run semver-checks check-release --manifest-path="subject/protocols/relay/Cargo.toml"
 
   run-on-core-graphics:
     # Run cargo-semver-checks on a crate with no semver violations,

--- a/src/lints/auto_trait_impl_removed.ron
+++ b/src/lints/auto_trait_impl_removed.ron
@@ -12,7 +12,6 @@ SemverQuery(
                 item {
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
 
                         importable_path {
                             path @output @tag
@@ -41,7 +40,7 @@ SemverQuery(
                 item {
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/constructible_struct_adds_field.ron
+++ b/src/lints/constructible_struct_adds_field.ron
@@ -18,7 +18,7 @@ SemverQuery(
                         # clearly stated that they don't consider the struct exhaustive anymore.
                         attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
 
-                        struct_name: name @output @tag
+                        struct_name: name @output
                         struct_type @output @tag
 
                         importable_path {
@@ -45,7 +45,6 @@ SemverQuery(
                     # 2. It needs to not have had any non-public fields.
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%struct_name"])
                         struct_type @filter(op: "=", value: ["%struct_type"])
 
                         # 1. It needs to not have been marked `#[non_exhaustive]`.

--- a/src/lints/constructible_struct_adds_private_field.ron
+++ b/src/lints/constructible_struct_adds_private_field.ron
@@ -18,7 +18,7 @@ SemverQuery(
                         # clearly stated that they don't consider the struct exhaustive anymore.
                         attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
 
-                        struct_name: name @output @tag
+                        struct_name: name @output
                         struct_type @output @tag
 
                         importable_path {
@@ -45,7 +45,6 @@ SemverQuery(
                     # 2. It needs to not have had any non-public fields.
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%struct_name"])
                         struct_type @filter(op: "=", value: ["%struct_type"])
 
                         # 1. It needs to not have been marked `#[non_exhaustive]`.

--- a/src/lints/constructible_struct_changed_type.ron
+++ b/src/lints/constructible_struct_changed_type.ron
@@ -25,7 +25,6 @@ More info: https://github.com/obi1kenobi/cargo-semver-checks/issues/297
                     ... on Struct {
                         struct_typename: __typename @tag @output
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
                         struct_type @output
 
                         # If the struct is non-exhaustive, it can't be constructed using a literal.
@@ -47,7 +46,7 @@ More info: https://github.com/obi1kenobi/cargo-semver-checks/issues/297
                         current_typename: __typename @filter(op: "!=", value: ["%struct_typename"])
                                                      @output
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/derive_trait_impl_removed.ron
+++ b/src/lints/derive_trait_impl_removed.ron
@@ -13,7 +13,6 @@ SemverQuery(
                 item {
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
 
                         importable_path {
                             path @output @tag
@@ -49,7 +48,7 @@ SemverQuery(
                 item {
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
 
                         importable_path @fold @transform(op: "count") @filter(op: ">", value: ["$zero"]) {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/enum_marked_non_exhaustive.ron
+++ b/src/lints/enum_marked_non_exhaustive.ron
@@ -18,7 +18,7 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
+                        name @output
 
                         attrs @filter(op: "contains", value: ["$non_exhaustive"])
 
@@ -37,7 +37,6 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
                         attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
 
                         importable_path {

--- a/src/lints/enum_missing.ron
+++ b/src/lints/enum_missing.ron
@@ -11,7 +11,7 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
+                        name @output
 
                         importable_path {
                             path @output @tag
@@ -28,7 +28,6 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/enum_must_use_added.ron
+++ b/src/lints/enum_must_use_added.ron
@@ -14,7 +14,7 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @tag @output
+                        name @output
 
                         importable_path {
                             path @tag @output
@@ -38,7 +38,6 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @filter(op: "=", value: ["%name"])
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/enum_repr_c_removed.ron
+++ b/src/lints/enum_repr_c_removed.ron
@@ -15,8 +15,7 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @tag @output
-                        
+
                         attribute {
                             old_attr: raw_attribute @output
                             content {
@@ -37,8 +36,8 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
-                        
+                        name @output
+
                         attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                             content {
                                 base @filter(op: "=", value: ["$repr"])

--- a/src/lints/enum_repr_int_changed.ron
+++ b/src/lints/enum_repr_int_changed.ron
@@ -15,7 +15,6 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @tag @output
 
                         attribute {
                             old_attr: raw_attribute @output
@@ -38,7 +37,7 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/enum_repr_int_removed.ron
+++ b/src/lints/enum_repr_int_removed.ron
@@ -15,7 +15,6 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @tag @output
 
                         attribute {
                             old_attr: raw_attribute @output
@@ -37,7 +36,7 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/enum_struct_variant_field_added.ron
+++ b/src/lints/enum_struct_variant_field_added.ron
@@ -11,7 +11,7 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        enum_name: name @output @tag
+                        enum_name: name @output
 
                         importable_path {
                             path @output @tag
@@ -44,7 +44,6 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%enum_name"])
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/enum_struct_variant_field_missing.ron
+++ b/src/lints/enum_struct_variant_field_missing.ron
@@ -11,7 +11,6 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        enum_name: name @output @tag
 
                         importable_path {
                             path @output @tag
@@ -37,7 +36,7 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%enum_name"])
+                        enum_name: name @output
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
@@ -46,7 +45,7 @@ SemverQuery(
                         variant {
                             ... on StructVariant {
                                 name @filter(op: "=", value: ["%variant_name"])
-                                
+
                                 field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                                     name @filter(op: "=", value: ["%field_name"])
                                 }

--- a/src/lints/enum_variant_added.ron
+++ b/src/lints/enum_variant_added.ron
@@ -10,7 +10,7 @@ SemverQuery(
             current {
                 item {
                     ... on Enum {
-                        enum_name: name @output @tag
+                        enum_name: name @output
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
                         attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
 
@@ -32,7 +32,6 @@ SemverQuery(
             baseline {
                 item {
                     ... on Enum {
-                        name @filter(op: "=", value: ["%enum_name"])
                         visibility_limit @filter(op: "=", value: ["$public"])
                         attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
 

--- a/src/lints/enum_variant_missing.ron
+++ b/src/lints/enum_variant_missing.ron
@@ -11,7 +11,6 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        enum_name: name @output @tag
 
                         importable_path {
                             path @output @tag
@@ -32,7 +31,7 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%enum_name"])
+                        enum_name: name @output
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/function_const_removed.ron
+++ b/src/lints/function_const_removed.ron
@@ -12,7 +12,6 @@ SemverQuery(
                     ... on Function {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
                         const @filter(op: "=", value: ["$true"])
-                        name @output @tag
 
                         importable_path {
                             path @output @tag
@@ -24,7 +23,7 @@ SemverQuery(
                 item {
                     ... on Function {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
                         const @filter(op: "!=", value: ["$true"])
 
                         importable_path {

--- a/src/lints/function_missing.ron
+++ b/src/lints/function_missing.ron
@@ -11,7 +11,7 @@ SemverQuery(
                 item {
                     ... on Function {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
+                        name @output
 
                         importable_path {
                             path @output @tag
@@ -28,7 +28,6 @@ SemverQuery(
                 item {
                     ... on Function {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/function_must_use_added.ron
+++ b/src/lints/function_must_use_added.ron
@@ -14,7 +14,7 @@ SemverQuery(
                 item {
                     ... on Function {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @tag @output
+                        name @output
 
                         importable_path {
                             path @tag @output
@@ -38,7 +38,6 @@ SemverQuery(
                 item {
                     ... on Function {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @filter(op: "=", value: ["%name"])
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/function_parameter_count_changed.ron
+++ b/src/lints/function_parameter_count_changed.ron
@@ -11,7 +11,6 @@ SemverQuery(
                 item {
                     ... on Function {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
 
                         importable_path {
                             path @output @tag
@@ -25,7 +24,7 @@ SemverQuery(
                 item {
                     ... on Function {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
 
                         current_parameter_: parameter @fold @transform(op: "count") @filter(op: "!=", value: ["%parameters"]) @output
 

--- a/src/lints/function_unsafe_added.ron
+++ b/src/lints/function_unsafe_added.ron
@@ -12,7 +12,6 @@ SemverQuery(
                     ... on Function {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
                         unsafe @filter(op: "!=", value: ["$true"])
-                        name @output @tag
 
                         importable_path {
                             path @output @tag
@@ -24,7 +23,7 @@ SemverQuery(
                 item {
                     ... on Function {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
                         unsafe @filter(op: "=", value: ["$true"])
 
                         importable_path {

--- a/src/lints/inherent_method_const_removed.ron
+++ b/src/lints/inherent_method_const_removed.ron
@@ -11,7 +11,6 @@ SemverQuery(
                 item {
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
 
                         importable_path {
                             path @output @tag
@@ -36,7 +35,7 @@ SemverQuery(
                 item {
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/inherent_method_missing.ron
+++ b/src/lints/inherent_method_missing.ron
@@ -11,7 +11,6 @@ SemverQuery(
                 item {
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
 
                         importable_path {
                             path @output @tag
@@ -35,7 +34,7 @@ SemverQuery(
                 item {
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/inherent_method_must_use_added.ron
+++ b/src/lints/inherent_method_must_use_added.ron
@@ -14,7 +14,7 @@ SemverQuery(
                 item {
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @tag @output
+                        name @output
                         owner_type: __typename @tag @output
 
                         importable_path {
@@ -46,7 +46,6 @@ SemverQuery(
                 item {
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
                         __typename @filter(op: "=", value: ["%owner_type"])
 
                         importable_path {

--- a/src/lints/inherent_method_unsafe_added.ron
+++ b/src/lints/inherent_method_unsafe_added.ron
@@ -11,7 +11,6 @@ SemverQuery(
                 item {
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
 
                         importable_path {
                             path @output @tag
@@ -36,7 +35,7 @@ SemverQuery(
                 item {
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/method_parameter_count_changed.ron
+++ b/src/lints/method_parameter_count_changed.ron
@@ -11,7 +11,6 @@ SemverQuery(
                 item {
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
 
                         importable_path {
                             path @output @tag
@@ -37,7 +36,7 @@ SemverQuery(
                 item {
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/sized_impl_removed.ron
+++ b/src/lints/sized_impl_removed.ron
@@ -12,7 +12,6 @@ SemverQuery(
                 item {
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
 
                         importable_path {
                             path @output @tag
@@ -41,7 +40,7 @@ SemverQuery(
                 item {
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/struct_marked_non_exhaustive.ron
+++ b/src/lints/struct_marked_non_exhaustive.ron
@@ -18,7 +18,7 @@ SemverQuery(
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
+                        name @output
                         struct_type @output
 
                         # The struct is now marked #[non_exhaustive] so it can't be constructed
@@ -40,7 +40,6 @@ SemverQuery(
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
                         attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
 
                         # Ensure the struct could previously be constructed outside of its crate

--- a/src/lints/struct_missing.ron
+++ b/src/lints/struct_missing.ron
@@ -11,7 +11,7 @@ SemverQuery(
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
+                        name @output
                         struct_type @output
 
                         importable_path {
@@ -32,7 +32,6 @@ SemverQuery(
                     # More info: https://github.com/obi1kenobi/cargo-semver-checks/issues/297
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/struct_must_use_added.ron
+++ b/src/lints/struct_must_use_added.ron
@@ -14,7 +14,7 @@ SemverQuery(
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @tag @output
+                        name @output
 
                         importable_path {
                             path @tag @output
@@ -38,7 +38,6 @@ SemverQuery(
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @filter(op: "=", value: ["%name"])
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/struct_pub_field_missing.ron
+++ b/src/lints/struct_pub_field_missing.ron
@@ -11,7 +11,6 @@ SemverQuery(
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        struct_name: name @output @tag
                         struct_type @output @tag
 
                         importable_path {
@@ -34,7 +33,7 @@ SemverQuery(
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%struct_name"])
+                        struct_name: name @output
                         struct_type @filter(op: "=", value: ["%struct_type"])
 
                         importable_path {

--- a/src/lints/struct_repr_c_removed.ron
+++ b/src/lints/struct_repr_c_removed.ron
@@ -15,8 +15,7 @@ SemverQuery(
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @tag @output
-                        
+
                         attribute {
                             old_attr: raw_attribute @output
                             content {
@@ -37,8 +36,8 @@ SemverQuery(
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
-                        
+                        name @output
+
                         attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                             content {
                                 base @filter(op: "=", value: ["$repr"])

--- a/src/lints/struct_repr_transparent_removed.ron
+++ b/src/lints/struct_repr_transparent_removed.ron
@@ -37,8 +37,7 @@ To avoid false-positives, this query is restricted to checking only structs that
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @tag @output
-                        
+
                         attribute {
                             old_attr: raw_attribute @output
                             content {
@@ -91,8 +90,8 @@ To avoid false-positives, this query is restricted to checking only structs that
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
-                        
+                        name @output
+
                         attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                             content {
                                 base @filter(op: "=", value: ["$repr"])

--- a/src/lints/struct_with_pub_fields_changed_type.ron
+++ b/src/lints/struct_with_pub_fields_changed_type.ron
@@ -21,7 +21,6 @@ More info: https://github.com/obi1kenobi/cargo-semver-checks/issues/297
                     ... on Struct {
                         struct_typename: __typename @tag @output
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
                         struct_type @output
 
                         # Ensure the struct has pub fields.
@@ -41,7 +40,7 @@ More info: https://github.com/obi1kenobi/cargo-semver-checks/issues/297
                         current_typename: __typename @filter(op: "!=", value: ["%struct_typename"])
                                                      @output
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/trait_missing.ron
+++ b/src/lints/trait_missing.ron
@@ -11,7 +11,7 @@ SemverQuery(
                 item {
                     ... on Trait {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
+                        name @output
 
                         importable_path {
                             path @output @tag
@@ -28,7 +28,6 @@ SemverQuery(
                 item {
                     ... on Trait {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/trait_must_use_added.ron
+++ b/src/lints/trait_must_use_added.ron
@@ -14,7 +14,7 @@ SemverQuery(
                 item {
                     ... on Trait {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @tag @output
+                        name @output
 
                         importable_path {
                             path @tag @output
@@ -38,7 +38,6 @@ SemverQuery(
                 item {
                     ... on Trait {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @filter(op: "=", value: ["%name"])
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/src/lints/trait_unsafe_added.ron
+++ b/src/lints/trait_unsafe_added.ron
@@ -12,7 +12,6 @@ SemverQuery(
                     ... on Trait {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
                         unsafe @filter(op: "!=", value: ["$true"])
-                        name @output @tag
 
                         importable_path {
                             path @output @tag
@@ -24,7 +23,7 @@ SemverQuery(
                 item {
                     ... on Trait {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
                         unsafe @filter(op: "=", value: ["$true"])
 
                         importable_path {

--- a/src/lints/trait_unsafe_removed.ron
+++ b/src/lints/trait_unsafe_removed.ron
@@ -12,7 +12,6 @@ SemverQuery(
                     ... on Trait {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
                         unsafe @filter(op: "=", value: ["$true"])
-                        name @output @tag
 
                         importable_path {
                             path @output @tag
@@ -24,7 +23,7 @@ SemverQuery(
                 item {
                     ... on Trait {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
                         unsafe @filter(op: "!=", value: ["$true"])
 
                         importable_path {

--- a/src/lints/tuple_struct_to_plain_struct.ron
+++ b/src/lints/tuple_struct_to_plain_struct.ron
@@ -15,7 +15,6 @@ Source: Rust for Rustaceans, Chapter 3, "Type Modifications", page 51
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @tag @output
                         attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
                         struct_type @filter(op: "=", value: ["$tuple"])
 
@@ -34,7 +33,7 @@ Source: Rust for Rustaceans, Chapter 3, "Type Modifications", page 51
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
                         attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
                         struct_type @filter(op: "=", value: ["$plain"])
 

--- a/src/lints/unit_struct_changed_kind.ron
+++ b/src/lints/unit_struct_changed_kind.ron
@@ -18,7 +18,6 @@ SemverQuery(
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
                         struct_type @filter(op: "=", value: ["$unit"])
                         attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
 
@@ -32,7 +31,7 @@ SemverQuery(
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
                         struct_type @filter(op: "=", value: ["$plain"])
 
                         importable_path {

--- a/src/lints/variant_marked_non_exhaustive.ron
+++ b/src/lints/variant_marked_non_exhaustive.ron
@@ -18,7 +18,6 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
-                        name @output @tag
 
                         importable_path {
                             path @output @tag
@@ -35,7 +34,7 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        name @filter(op: "=", value: ["%name"])
+                        name @output
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])

--- a/test_crates/move_item_and_reexport/new/Cargo.toml
+++ b/test_crates/move_item_and_reexport/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "move_item_and_reexport"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/move_item_and_reexport/new/src/lib.rs
+++ b/test_crates/move_item_and_reexport/new/src/lib.rs
@@ -1,0 +1,86 @@
+pub(crate) mod internal {
+    // The following items will be relocated to the `internal` module,
+    // but will get different flavors of re-exports to ensure the move is non-breaking.
+
+    pub enum RegularReexport {
+        Var,
+    }
+
+    pub(crate) mod glob_inner {
+        pub fn glob_reexport() {}
+    }
+
+    pub struct TypedefReexport;
+
+    pub struct TypedefWithGenericsReexport<'a, const N: usize, T> {
+        _marker: std::marker::PhantomData<&'a [T; N]>,
+    }
+
+    // The following types will also be renamed as part of being moved,
+    // but their re-exports will include renames to their previous names,
+    // meaning that the move and rename are non-breaking.
+
+    pub fn has_been_renamed_reexport() {}
+
+    pub struct HasBeenRenamedTypedefReexport;
+
+    pub struct HasBeenRenamedTypedefWithGenericsReexport<'a, const N: usize, T> {
+        _marker: std::marker::PhantomData<&'a [T; N]>,
+    }
+
+    // The following types will get moved, but their typedef re-exports
+    // will alter the generics in ways that mean the new typedef isn't equivalent.
+
+    pub struct NonEquivalentReorderedGenerics<'a, const N: usize, T> {
+        _marker: std::marker::PhantomData<&'a [T; N]>,
+    }
+
+    pub struct NonEquivalentRemovedLifetime<'a, const N: usize, T> {
+        _marker: std::marker::PhantomData<&'a [T; N]>,
+    }
+
+    pub struct NonEquivalentRemovedConst<'a, const N: usize, T> {
+        _marker: std::marker::PhantomData<&'a [T; N]>,
+    }
+
+    pub struct NonEquivalentRemovedType<'a, const N: usize, T> {
+        _marker: std::marker::PhantomData<&'a [T; N]>,
+    }
+}
+
+// The following items will be relocated to the `internal` module,
+// but will get different flavors of re-exports to ensure the move is non-breaking.
+
+pub use internal::RegularReexport;
+
+pub use internal::glob_inner::*;
+
+pub type TypedefReexport = internal::TypedefReexport;
+
+pub type TypedefWithGenericsReexport<'a, const N: usize, T> =
+    internal::TypedefWithGenericsReexport<'a, N, T>;
+
+// The following types will also be renamed as part of being moved,
+// but their re-exports will include renames to their previous names,
+// meaning that the move and rename are non-breaking.
+
+pub use internal::has_been_renamed_reexport as renamed_reexport;
+
+pub type RenamedTypedefReexport = internal::HasBeenRenamedTypedefReexport;
+
+pub type RenamedTypedefWithGenericsReexport<'a, const N: usize, T> =
+    internal::HasBeenRenamedTypedefWithGenericsReexport<'a, N, T>;
+
+// The following types will get moved, but their typedef re-exports
+// will alter the generics in ways that mean the new typedef isn't equivalent.
+
+pub type NonEquivalentReorderedGenerics<'a, T, const N: usize> =
+    internal::NonEquivalentReorderedGenerics<'a, N, T>;
+
+pub type NonEquivalentRemovedLifetime<const N: usize, T> =
+    internal::NonEquivalentRemovedLifetime<'static, N, T>;
+
+pub type NonEquivalentRemovedConst<'a, T> = internal::NonEquivalentRemovedConst<'a, 5, T>;
+
+pub type NonEquivalentRemovedType<'a, const N: usize> =
+    internal::NonEquivalentRemovedType<'a, N, i64>;

--- a/test_crates/move_item_and_reexport/old/Cargo.toml
+++ b/test_crates/move_item_and_reexport/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "move_item_and_reexport"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/move_item_and_reexport/old/src/lib.rs
+++ b/test_crates/move_item_and_reexport/old/src/lib.rs
@@ -1,0 +1,52 @@
+pub(crate) mod internal {
+    /// This type will be removed, which is non-breaking:
+    /// even though it's `pub`, it isn't actually externally visible
+    /// since it's in a `pub(crate)` module and not publicly re-exported.
+    pub struct NotPublicAndWillDisappear;
+}
+
+// The following items will be relocated to the `internal` module,
+// but will get different flavors of re-exports to ensure the move is non-breaking.
+
+pub enum RegularReexport {
+    Var,
+}
+
+pub fn glob_reexport() {}
+
+pub struct TypedefReexport;
+
+pub struct TypedefWithGenericsReexport<'a, const N: usize, T> {
+    _marker: std::marker::PhantomData<&'a [T; N]>,
+}
+
+// The following types will also be renamed as part of being moved,
+// but their re-exports will include renames to their previous names,
+// meaning that the move and rename are non-breaking.
+
+pub fn renamed_reexport() {}
+
+pub struct RenamedTypedefReexport;
+
+pub struct RenamedTypedefWithGenericsReexport<'a, const N: usize, T> {
+    _marker: std::marker::PhantomData<&'a [T; N]>,
+}
+
+// The following types will get moved, but their typedef re-exports
+// will alter the generics in ways that mean the new typedef isn't equivalent.
+
+pub struct NonEquivalentReorderedGenerics<'a, const N: usize, T> {
+    _marker: std::marker::PhantomData<&'a [T; N]>,
+}
+
+pub struct NonEquivalentRemovedLifetime<'a, const N: usize, T> {
+    _marker: std::marker::PhantomData<&'a [T; N]>,
+}
+
+pub struct NonEquivalentRemovedConst<'a, const N: usize, T> {
+    _marker: std::marker::PhantomData<&'a [T; N]>,
+}
+
+pub struct NonEquivalentRemovedType<'a, const N: usize, T> {
+    _marker: std::marker::PhantomData<&'a [T; N]>,
+}

--- a/test_outputs/struct_missing.output.ron
+++ b/test_outputs/struct_missing.output.ron
@@ -14,6 +14,52 @@
             "visibility_limit": String("public"),
         },
     ],
+    "./test_crates/move_item_and_reexport/": [
+        {
+            "name": String("NonEquivalentReorderedGenerics"),
+            "path": List([
+                String("move_item_and_reexport"),
+                String("NonEquivalentReorderedGenerics"),
+            ]),
+            "span_begin_line": Uint64(38),
+            "span_filename": String("src/lib.rs"),
+            "struct_type": String("plain"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("NonEquivalentRemovedLifetime"),
+            "path": List([
+                String("move_item_and_reexport"),
+                String("NonEquivalentRemovedLifetime"),
+            ]),
+            "span_begin_line": Uint64(42),
+            "span_filename": String("src/lib.rs"),
+            "struct_type": String("plain"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("NonEquivalentRemovedConst"),
+            "path": List([
+                String("move_item_and_reexport"),
+                String("NonEquivalentRemovedConst"),
+            ]),
+            "span_begin_line": Uint64(46),
+            "span_filename": String("src/lib.rs"),
+            "struct_type": String("plain"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("NonEquivalentRemovedType"),
+            "path": List([
+                String("move_item_and_reexport"),
+                String("NonEquivalentRemovedType"),
+            ]),
+            "span_begin_line": Uint64(50),
+            "span_filename": String("src/lib.rs"),
+            "struct_type": String("plain"),
+            "visibility_limit": String("public"),
+        },
+    ],
     "./test_crates/struct_missing/": [
         {
             "name": String("WillBeRemovedStruct"),


### PR DESCRIPTION
Only use importable paths to match items across versions.

Declared names (e.g. `Foo` in `pub struct Foo;`) are subject to change in renaming `pub use` and `pub type` statements (e.g. `pub use Foo as Bar`), so relying on them to match items across versions means we miss renames. The importable paths provided by `trustfall_rustdoc v0.8.2+` account for this, and list all valid paths under which the item can be imported. These paths are the only way we can match items across versions.

The above logic change needed to be applied to all currently-written lints, and will need to also apply to all future lints as well. Heads-up for @SmolSir @tonowak @staniewzki @mgr0dzicki.

The new logic is also somewhat more expensive, since it increases the search space and eliminates some of the pruning that filtering on the name could get us. This is unfortunate, but unavoidable at the moment — we don't want to sacrifice correctness for speed. I'll focus on perf improvements next and I'm confident we can win back all the lost performance and then some.

Fixes #288, #215, #202.
Fixes #42.