### PR TITLE
Do not crash on typedefs that omit generics with default values.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - rust-tests
       - run-on-rust-libp2p
       - run-on-libp2p-dcutr-relay
+      - run-on-libp2p-gossipsub-request-response
       - run-on-core-graphics
       - run-on-bevy-core
       - run-on-bevy-gltf
@@ -185,6 +186,48 @@ jobs:
 
       - name: Run semver-checks on libp2p-relay
         run: cargo run semver-checks check-release --manifest-path="subject/protocols/relay/Cargo.toml"
+
+  run-on-libp2p-gossipsub-request-response:
+    # Run cargo-semver-checks on two crates that used to trip an assert and cause a crash,
+    # due to re-exports that omit generic parameters because the underlying generic type supplies
+    # default values for those generics.
+    # https://github.com/libp2p/rust-libp2p/pull/3401#issuecomment-1409381365
+    name: Run cargo-semver-checks on libp2p-gossipsub 0.44.0 and libp2p-request-response 0.23.0
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cargo-semver-checks
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Checkout rust-libp2p
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          repository: 'libp2p/rust-libp2p'
+          ref: '8b8dc26e0601433f5675430b29b50687a37d4cd8'
+          path: 'subject'
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      # rust-libp2p requires protobuf-compiler.
+      - name: Install protobuf-compiler
+        run: sudo apt install protobuf-compiler
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: libp2p-gossipsub-request-response
+
+      - name: Run semver-checks on libp2p-gossipsub
+        run: cargo run semver-checks check-release --manifest-path="subject/protocols/gossipsub/Cargo.toml"
+
+      - name: Run semver-checks on libp2p-request-response
+        run: cargo run semver-checks check-release --manifest-path="subject/protocols/request-response/Cargo.toml"
 
   run-on-core-graphics:
     # Run cargo-semver-checks on a crate with no semver violations,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.3"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d93d855ce6a0aa87b8473ef9169482f40abaa2e9e0993024c35c902cbd5920"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
+checksum = "322296e2f2e5af4270b54df9e85a02ff037e271af20ba3e7fe1575515dc840b8"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -447,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
+checksum = "017a1385b05d631e7875b1f151c9f012d37b53491e2a87f65bff5c262b2111d8"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -462,15 +462,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
+checksum = "c26bbb078acf09bc1ecda02d4223f03bdd28bd4874edcb0379138efc499ce971"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
+checksum = "357f40d1f06a24b60ae1fe122542c1fb05d28d32acb2aed064e84bc2ad1e252e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -501,9 +501,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "errno"
@@ -1329,9 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c68e921cef53841b8925c2abadd27c9b891d9613bdc43d6b823062866df38e8"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
 dependencies = [
  "serde",
 ]
@@ -1516,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729bfd096e40da9c001f778f5cdecbd2957929a24e10e5883d9392220a751581"
+checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
 dependencies = [
  "indexmap",
  "nom8",
@@ -1529,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "21.5.0"
+version = "21.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da6228cdbb2a3bb154aa987e851ab7bafa18c130d5ce83fb6dc74dbb5d3413e"
+checksum = "29adb177243f06c90853473ed5fdfd8f9250d3e1ead50dffe7fcc2e64440e39a"
 dependencies = [
  "rustdoc-types 0.17.0",
  "trustfall_core",
@@ -1539,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "22.5.0"
+version = "22.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723b2c74116fa55ea088e99fc07314f6db367da02aaa98f97234dd330554b7a1"
+checksum = "801552bacc0325b589e9ba7f1a684677125dec3580193022603868d65de06128"
 dependencies = [
  "rustdoc-types 0.18.0",
  "trustfall_core",
@@ -1549,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "23.2.0"
+version = "23.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19adac744c50202744a870cf5b108c077178fe7f4370971b866f4229e9bf4c10"
+checksum = "6f52f10d42a8e0ec203855ad2306f38a12dd5be253dab21945a9763ce967c744"
 dependencies = [
  "rustdoc-types 0.19.0",
  "trustfall_core",
@@ -1559,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "24.1.0"
+version = "24.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09834eed7a5d5783e022f74451a271c63aa24fb5292a2c346801d048466b3cd0"
+checksum = "bd2b792e093fdce04d43269f7456ff9cd14923ee10de723979ed9174e82ba3f8"
 dependencies = [
  "rustdoc-types 0.20.0",
  "trustfall_core",
@@ -1611,10 +1611,10 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
- "trustfall-rustdoc-adapter 21.5.0",
- "trustfall-rustdoc-adapter 22.5.0",
- "trustfall-rustdoc-adapter 23.2.0",
- "trustfall-rustdoc-adapter 24.1.0",
+ "trustfall-rustdoc-adapter 21.5.1",
+ "trustfall-rustdoc-adapter 22.5.1",
+ "trustfall-rustdoc-adapter 23.2.1",
+ "trustfall-rustdoc-adapter 24.1.1",
  "trustfall_core",
 ]
 


### PR DESCRIPTION
Reproduce the failure in https://github.com/libp2p/rust-libp2p/pull/3401 in our own CI test suite.
