### PR TITLE
Changed all baseline rustdoc generations to use placeholder manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,11 +377,11 @@ jobs:
         continue-on-error: true
         run: |
           cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-root="subject-baseline/Cargo.toml" > output
-          echo "$?" > return_code
+          touch failed_successfully
 
-      - name: Check return code
+      - name: Check whether it failed
         run: |
-          if [[ "$(cat return_code)" == "0" ]]; then exit 1; else exit 0; fi
+          if [ -f failed_successfully ]; then exit 1; else exit 0; fi
 
       - name: Check output
         run: |
@@ -391,17 +391,18 @@ jobs:
 
       - name: Cleanup
         run: |
-          rm output return_code
+          rm output
+          rm -f failed_successfully
 
       - name: Run semver-checks with --baseline-rev
         continue-on-error: true
         run: |
           cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-rev=3.1.18 > output
-          echo "$?" > return_code
+          touch failed_successfully
 
-      - name: Check return code
+      - name: Check whether it failed
         run: |
-          if [[ "$(cat return_code)" == "0" ]]; then exit 1; else exit 0; fi
+          if [ -f failed_successfully ]; then exit 1; else exit 0; fi
 
       - name: Check output
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,7 +397,7 @@ jobs:
       - name: Fetch v3.1.18 in subject-current
         run: |
           cd subject-current
-          git fetch origin e36cf1a67ee6a447d3615a70b065d2b4f5e60
+          git fetch origin 524e36cf1a67ee6a447d3615a70b065d2b4f5e60
           cd ..
 
       - name: Run semver-checks with --baseline-rev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,10 +394,15 @@ jobs:
           rm output
           rm -f failed_successfully
 
+      - name: Fetch v3.1.18 in subject-current
+        run: |
+          cd subject-current
+          git fetch origin e36cf1a67ee6a447d3615a70b065d2b4f5e60
+          cd ..
+
       - name: Run semver-checks with --baseline-rev
         continue-on-error: true
         run: |
-          git fetch origin e36cf1a67ee6a447d3615a70b065d2b4f5e60
           cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-rev=524e36cf1a67ee6a447d3615a70b065d2b4f5e60 > output
           touch failed_successfully
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,11 +377,11 @@ jobs:
         continue-on-error: true
         run: |
           cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-root="subject-baseline/Cargo.toml" > output
-          touch failed_successfully
+          touch unexpectedly_did_not_fail
 
       - name: Check whether it failed
         run: |
-          if [ -f failed_successfully ]; then exit 1; else exit 0; fi
+          if [ -f unexpectedly_did_not_fail ]; then exit 1; else exit 0; fi
 
       - name: Check output
         run: |
@@ -392,7 +392,7 @@ jobs:
       - name: Cleanup
         run: |
           rm output
-          rm -f failed_successfully
+          rm -f unexpectedly_did_not_fail
 
       - name: Fetch v3.1.18 in subject-current
         run: |
@@ -404,11 +404,11 @@ jobs:
         continue-on-error: true
         run: |
           cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-rev=524e36cf1a67ee6a447d3615a70b065d2b4f5e60 > output
-          touch failed_successfully
+          touch unexpectedly_did_not_fail
 
       - name: Check whether it failed
         run: |
-          if [ -f failed_successfully ]; then exit 1; else exit 0; fi
+          if [ -f unexpectedly_did_not_fail ]; then exit 1; else exit 0; fi
 
       - name: Check output
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,7 +397,7 @@ jobs:
       - name: Run semver-checks with --baseline-rev
         continue-on-error: true
         run: |
-          cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-rev=v3.1.18 > output
+          cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-rev=524e36cf1a67ee6a447d3615a70b065d2b4f5e60 > output
           touch failed_successfully
 
       - name: Check whether it failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,6 +397,7 @@ jobs:
       - name: Run semver-checks with --baseline-rev
         continue-on-error: true
         run: |
+          git fetch origin e36cf1a67ee6a447d3615a70b065d2b4f5e60
           cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-rev=524e36cf1a67ee6a447d3615a70b065d2b4f5e60 > output
           touch failed_successfully
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,10 +373,30 @@ jobs:
         with:
           key: clap
 
-      - name: Run semver-checks
+      - name: Run semver-checks with --baseline-root
         continue-on-error: true
         run: |
           cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-root="subject-baseline/Cargo.toml" > output
+          echo "$?" > return_code
+
+      - name: Check return code
+        run: |
+          if [[ "$(cat return_code)" == "0" ]]; then exit 1; else exit 0; fi
+
+      - name: Check output
+        run: |
+          EXPECTED="$(echo -e "--- failure auto_trait_impl_removed: auto trait no longer implemented ---\n--- failure trait_missing: pub trait removed or renamed ---")"
+          RESULT="$(cat output | grep failure)"
+          diff <(echo "$RESULT") <(echo "$EXPECTED")
+
+      - name: Cleanup
+        run: |
+          rm output return_code
+
+      - name: Run semver-checks with --baseline-rev
+        continue-on-error: true
+        run: |
+          cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-rev=3.1.18 > output
           echo "$?" > return_code
 
       - name: Check return code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,7 +397,7 @@ jobs:
       - name: Run semver-checks with --baseline-rev
         continue-on-error: true
         run: |
-          cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-rev=3.1.18 > output
+          cargo run semver-checks check-release --manifest-path="subject-current/Cargo.toml" --baseline-rev=v3.1.18 > output
           touch failed_successfully
 
       - name: Check whether it failed

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -129,7 +129,11 @@ fn create_placeholder_rustdoc_manifest(
                 },
                 CrateSource::ManifestPath { manifest } => DependencyDetail {
                     path: Some({
-                        assert!(manifest.path.ends_with("Cargo.toml"));
+                        assert!(
+                            manifest.path.ends_with("Cargo.toml"),
+                            "path {} isn't pointing to a manifest",
+                            manifest.path.display()
+                        );
                         let dir_path = manifest
                             .path
                             .parent()

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -304,11 +304,11 @@ pub(crate) struct PathBaseline {
 }
 
 impl PathBaseline {
+    /// # Arguments
+    /// * `project_root` - Path to a directory with the manifest or with subdirectories with the manifests.
+    /// * `target_root` - Path to a directory where the placeholder manifest / rustdoc can be created.
     pub(crate) fn new(
-        // Path to a directory with the manifest or with subdirectories with the manifests.
         project_root: &std::path::Path,
-
-        // Path to a directory where the placeholder manifest / rustdoc can be created.
         target_root: &std::path::Path,
     ) -> anyhow::Result<Self> {
         let mut lookup = std::collections::HashMap::new();

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -187,6 +187,9 @@ fn generate_rustdoc(
         "{}-{}-{}",
         match crate_source {
             CrateSource::Registry { .. } => "registry",
+            // Identifiers of manifest-based crates cannot be used for caching,
+            // since they probably correspond to a specific (and unknown) gitrev and git state
+            // so cached entries cannot be checked to see if they are a match or not.
             CrateSource::ManifestPath { .. } => "local",
         },
         slugify(&name),

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -305,10 +305,10 @@ pub(crate) struct PathBaseline {
 
 impl PathBaseline {
     pub(crate) fn new(
-        // Path to a directory with the manifest or with subdirectories with the manifests.
+        /// Path to a directory with the manifest or with subdirectories with the manifests.
         project_root: &std::path::Path,
 
-        // Path to a directory where the placeholder manifest / rustdoc can be created.
+        /// Path to a directory where the placeholder manifest / rustdoc can be created.
         target_root: &std::path::Path,
     ) -> anyhow::Result<Self> {
         let mut lookup = std::collections::HashMap::new();

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -30,7 +30,7 @@ impl<'a> CrateSource<'a> {
     }
 
     /// Returns features listed in `[features]` section in the manifest
-    /// https://doc.rust-lang.org/cargo/reference/features.html#the-features-section
+    /// <https://doc.rust-lang.org/cargo/reference/features.html#the-features-section>
     fn regular_features(&self) -> Vec<String> {
         match self {
             Self::Registry { crate_ } => crate_.features().keys().cloned().into_iter().collect(),
@@ -45,7 +45,7 @@ impl<'a> CrateSource<'a> {
     }
 
     /// Returns features implicitly defined by optional dependencies
-    /// https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies
+    /// <https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies>
     fn implicit_features(&self) -> std::collections::BTreeSet<String> {
         let mut implicit_features: std::collections::BTreeSet<_> = match self {
             Self::Registry { crate_ } => crate_

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -15,16 +15,16 @@ enum CrateSource<'a> {
 }
 
 impl<'a> CrateSource<'a> {
-    fn name(&self) -> anyhow::Result<String> {
+    fn name(&self) -> anyhow::Result<&str> {
         Ok(match self {
-            Self::Registry { crate_ } => crate_.name().to_string(),
+            Self::Registry { crate_ } => crate_.name(),
             Self::ManifestPath { manifest } => crate::manifest::get_package_name(manifest)?,
         })
     }
 
-    fn version(&self) -> anyhow::Result<String> {
+    fn version(&self) -> anyhow::Result<&str> {
         Ok(match self {
-            Self::Registry { crate_ } => crate_.version().to_string(),
+            Self::Registry { crate_ } => crate_.version(),
             Self::ManifestPath { manifest } => crate::manifest::get_package_version(manifest)?,
         })
     }
@@ -153,7 +153,7 @@ fn create_placeholder_rustdoc_manifest(
             };
             let mut deps = DepsSet::new();
             deps.insert(
-                crate_source.name()?,
+                crate_source.name()?.to_string(),
                 Dependency::Detailed(project_with_features),
             );
             deps
@@ -200,8 +200,8 @@ fn generate_rustdoc(
             // so cached entries cannot be checked to see if they are a match or not.
             CrateSource::ManifestPath { .. } => "local",
         },
-        slugify(&name),
-        slugify(&version)
+        slugify(name),
+        slugify(version)
     );
     let build_dir = target_root.join(&crate_identifier);
     let (cache_dir, cached_rustdoc) = match crate_source {
@@ -317,7 +317,7 @@ impl PathBaseline {
             if entry.file_name() == "Cargo.toml" {
                 if let Ok(manifest) = crate::manifest::Manifest::parse(entry.into_path()) {
                     if let Ok(name) = crate::manifest::get_package_name(&manifest) {
-                        lookup.insert(name, manifest);
+                        lookup.insert(name.to_string(), manifest);
                     }
                 }
             }

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -29,6 +29,8 @@ impl<'a> CrateSource<'a> {
         })
     }
 
+    /// Returns features listed in `[features]` section in the manifest
+    /// https://doc.rust-lang.org/cargo/reference/features.html#the-features-section
     fn regular_features(&self) -> Vec<String> {
         match self {
             Self::Registry { crate_ } => crate_.features().keys().cloned().into_iter().collect(),
@@ -42,6 +44,8 @@ impl<'a> CrateSource<'a> {
         }
     }
 
+    /// Returns features implicitly defined by optional dependencies
+    /// https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies
     fn implicit_features(&self) -> std::collections::BTreeSet<String> {
         let mut implicit_features: std::collections::BTreeSet<_> = match self {
             Self::Registry { crate_ } => crate_

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -4,29 +4,69 @@ use anyhow::Context as _;
 use crates_index::Crate;
 
 use crate::dump::RustDocCommand;
+use crate::manifest::Manifest;
 use crate::util::slugify;
 use crate::GlobalConfig;
 
-mod crate_features {
-    /// Sometimes crates ship types with fields or variants that are included
-    /// only when certain features are enabled.
-    ///
-    /// By default, we want to generate rustdoc with `--all-features`,
-    /// but that option isn't available outside of the current crate,
-    /// so we have to implement it ourselves.
+#[derive(Debug, Clone)]
+enum CrateSource<'a> {
+    Registry { crate_: &'a crates_index::Version },
+    ManifestPath { manifest: &'a Manifest },
+}
 
-    pub(crate) fn get_all_crate_features_from_registry(
-        crate_: &crates_index::Version,
-    ) -> Vec<String> {
-        // Implicit features from optional dependencies have to be added separately
-        // from regular features: https://github.com/obi1kenobi/cargo-semver-checks/issues/265
-        let mut implicit_features: std::collections::BTreeSet<_> = crate_
-            .dependencies()
-            .iter()
-            .filter_map(|dep| dep.is_optional().then_some(dep.name()))
-            .map(|x| x.to_string())
-            .collect();
-        for feature_defn in crate_.features().values().flatten() {
+impl<'a> CrateSource<'a> {
+    fn name(&self) -> anyhow::Result<String> {
+        Ok(match self {
+            Self::Registry { crate_ } => crate_.name().to_string(),
+            Self::ManifestPath { manifest } => crate::manifest::get_package_name(manifest)?,
+        })
+    }
+
+    fn version(&self) -> anyhow::Result<String> {
+        Ok(match self {
+            Self::Registry { crate_ } => crate_.version().to_string(),
+            Self::ManifestPath { manifest } => crate::manifest::get_package_version(manifest)?,
+        })
+    }
+
+    fn regular_features(&self) -> Vec<String> {
+        match self {
+            Self::Registry { crate_ } => crate_.features().keys().cloned().into_iter().collect(),
+            Self::ManifestPath { manifest } => manifest
+                .parsed
+                .features
+                .keys()
+                .cloned()
+                .into_iter()
+                .collect(),
+        }
+    }
+
+    fn implicit_features(&self) -> std::collections::BTreeSet<String> {
+        let mut implicit_features: std::collections::BTreeSet<_> = match self {
+            Self::Registry { crate_ } => crate_
+                .dependencies()
+                .iter()
+                .filter_map(|dep| dep.is_optional().then_some(dep.name()))
+                .map(|x| x.to_string())
+                .collect(),
+            Self::ManifestPath { manifest } => manifest
+                .parsed
+                .dependencies
+                .iter()
+                .filter_map(|(name, dep)| dep.optional().then_some(name))
+                .map(|x| x.to_string())
+                .collect(),
+        };
+
+        let feature_defns: Vec<&String> = match self {
+            Self::Registry { crate_ } => crate_.features().values().flatten().collect(),
+            Self::ManifestPath { manifest } => {
+                manifest.parsed.features.values().flatten().collect()
+            }
+        };
+
+        for feature_defn in feature_defns {
             // "If you specify the optional dependency with the dep: prefix anywhere
             //  in the [features] table, that disables the implicit feature."
             // https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies
@@ -34,39 +74,21 @@ mod crate_features {
                 implicit_features.remove(optional_dep);
             }
         }
-        let regular_features: std::collections::BTreeSet<_> =
-            crate_.features().keys().cloned().collect();
-        let mut all_crate_features = implicit_features;
-        all_crate_features.extend(regular_features);
+        implicit_features
+    }
+
+    /// Sometimes crates ship types with fields or variants that are included
+    /// only when certain features are enabled.
+    ///
+    /// By default, we want to generate rustdoc with `--all-features`,
+    /// but that option isn't available outside of the current crate,
+    /// so we have to implement it ourselves.
+    fn all_features(&self) -> Vec<String> {
+        // Implicit features from optional dependencies have to be added separately
+        // from regular features: https://github.com/obi1kenobi/cargo-semver-checks/issues/265
+        let mut all_crate_features = self.implicit_features();
+        all_crate_features.extend(self.regular_features());
         all_crate_features.into_iter().collect()
-    }
-
-    #[allow(unused_variables)]
-    pub(crate) fn get_all_crate_features_from_manifest(path: &std::path::Path) -> Vec<String> {
-        unimplemented!()
-    }
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Clone)]
-enum CrateSource<'a> {
-    Registry { crate_: &'a crates_index::Version },
-    ManifestPath { path: &'a Path, name: String },
-}
-
-impl<'a> CrateSource<'a> {
-    fn name(&self) -> &str {
-        match self {
-            Self::Registry { crate_ } => crate_.name(),
-            Self::ManifestPath { .. } => unimplemented!(),
-        }
-    }
-
-    fn version(&self) -> &str {
-        match self {
-            Self::Registry { crate_ } => crate_.version(),
-            Self::ManifestPath { .. } => unimplemented!(),
-        }
     }
 }
 
@@ -98,26 +120,32 @@ fn create_placeholder_rustdoc_manifest(
                     // give us the latest semver-compatible version which is not we want.
                     // Fixes: https://github.com/obi1kenobi/cargo-semver-checks/issues/261
                     version: Some(format!("={}", crate_.version())),
-                    features: crate_features::get_all_crate_features_from_registry(crate_),
+                    features: crate_source.all_features(),
                     ..DependencyDetail::default()
                 },
-                CrateSource::ManifestPath { path, .. } => DependencyDetail {
-                    path: Some(
+                CrateSource::ManifestPath { manifest } => DependencyDetail {
+                    path: Some({
+                        assert!(manifest.path.ends_with("Cargo.toml"));
+                        let dir_path = manifest
+                            .path
+                            .parent()
+                            .context("manifest path doesn't have a parent")?;
                         // The manifest will be saved in some other directory,
                         // so for convenience, we're using absolute paths.
-                        path.canonicalize()
+                        dir_path
+                            .canonicalize()
                             .context("failed to canonicalize manifest path")?
                             .to_str()
                             .context("manifest path is not valid UTF-8")?
-                            .to_string(),
-                    ),
-                    features: crate_features::get_all_crate_features_from_manifest(path),
+                            .to_string()
+                    }),
+                    features: crate_source.all_features(),
                     ..DependencyDetail::default()
                 },
             };
             let mut deps = DepsSet::new();
             deps.insert(
-                crate_source.name().to_string(),
+                crate_source.name()?,
                 Dependency::Detailed(project_with_features),
             );
             deps
@@ -152,12 +180,21 @@ fn generate_rustdoc(
     target_root: PathBuf,
     crate_source: CrateSource,
 ) -> anyhow::Result<PathBuf> {
-    let name = crate_source.name();
-    let version = crate_source.version();
+    let name = crate_source.name()?;
+    let version = crate_source.version()?;
 
-    let (build_dir, cache_dir, cached_rustdoc) = match crate_source {
+    let crate_identifier = format!(
+        "{}-{}-{}",
+        match crate_source {
+            CrateSource::Registry { .. } => "registry",
+            CrateSource::ManifestPath { .. } => "local",
+        },
+        slugify(&name),
+        slugify(&version)
+    );
+    let build_dir = target_root.join(&crate_identifier);
+    let (cache_dir, cached_rustdoc) = match crate_source {
         CrateSource::Registry { .. } => {
-            let crate_identifier = format!("registry-{}-{}", slugify(name), slugify(version));
             let cache_dir = target_root.join("cache");
             let cached_rustdoc = cache_dir.join(format!("{crate_identifier}.json"));
 
@@ -173,12 +210,9 @@ fn generate_rustdoc(
                 return Ok(cached_rustdoc);
             }
 
-            let build_dir = target_root.join(crate_identifier);
-            (build_dir, cache_dir, cached_rustdoc)
+            (Some(cache_dir), Some(cached_rustdoc))
         }
-        CrateSource::ManifestPath { .. } => {
-            unimplemented!()
-        }
+        CrateSource::ManifestPath { .. } => (None, None),
     };
 
     let placeholder_manifest = create_placeholder_rustdoc_manifest(&crate_source)
@@ -200,6 +234,8 @@ fn generate_rustdoc(
     match crate_source {
         CrateSource::Registry { .. } => {
             // Clean up after ourselves.
+            let cache_dir = cache_dir.unwrap();
+            let cached_rustdoc = cached_rustdoc.unwrap();
             std::fs::create_dir_all(cache_dir)?;
             std::fs::copy(rustdoc_path, &cached_rustdoc)?;
             std::fs::remove_dir_all(build_dir)?;
@@ -247,27 +283,29 @@ impl BaselineLoader for RustdocBaseline {
 }
 
 pub(crate) struct PathBaseline {
+    target_root: PathBuf,
     root: PathBuf,
-    lookup: std::collections::HashMap<String, (String, PathBuf)>,
+    lookup: std::collections::HashMap<String, Manifest>,
 }
 
 impl PathBaseline {
-    pub(crate) fn new(root: &std::path::Path) -> anyhow::Result<Self> {
+    pub(crate) fn new(
+        target_root: &std::path::Path,
+        root: &std::path::Path,
+    ) -> anyhow::Result<Self> {
         let mut lookup = std::collections::HashMap::new();
         for result in ignore::Walk::new(root) {
             let entry = result?;
             if entry.file_name() == "Cargo.toml" {
-                if let Ok(manifest) = crate::manifest::Manifest::parse(entry.path()) {
-                    if let (Ok(name), Ok(version)) = (
-                        crate::manifest::get_package_name(&manifest),
-                        crate::manifest::get_package_version(&manifest),
-                    ) {
-                        lookup.insert(name, (version, entry.into_path()));
+                if let Ok(manifest) = crate::manifest::Manifest::parse(entry.into_path()) {
+                    if let Ok(name) = crate::manifest::get_package_name(&manifest) {
+                        lookup.insert(name, manifest);
                     }
                 }
             }
         }
         Ok(Self {
+            target_root: target_root.to_owned(),
             root: root.to_owned(),
             lookup,
         })
@@ -282,14 +320,16 @@ impl BaselineLoader for PathBaseline {
         name: &str,
         _version_current: Option<&semver::Version>,
     ) -> anyhow::Result<PathBuf> {
-        let (version, manifest_path) = self
+        let manifest: &Manifest = self
             .lookup
             .get(name)
             .with_context(|| format!("package `{}` not found in {}", name, self.root.display()))?;
-        let version = format!(" v{version}");
-        config.shell_status("Parsing", format_args!("{name}{version} (baseline)"))?;
-        let rustdoc_path = rustdoc.dump(manifest_path.as_path(), None, true)?;
-        Ok(rustdoc_path)
+        generate_rustdoc(
+            config,
+            rustdoc,
+            self.target_root.clone(),
+            CrateSource::ManifestPath { manifest },
+        )
     }
 }
 
@@ -308,13 +348,13 @@ impl GitBaseline {
         let repo = git2::Repository::discover(source)?;
 
         let rev = repo.revparse_single(rev)?;
-        let target = target.join(rev.id().to_string());
+        let rev_dir = target.join(rev.id().to_string());
 
-        std::fs::create_dir_all(&target)?;
+        std::fs::create_dir_all(&rev_dir)?;
         let tree = rev.peel_to_tree()?;
-        extract_tree(&repo, tree, &target)?;
+        extract_tree(&repo, tree, &rev_dir)?;
 
-        let path = PathBaseline::new(&target)?;
+        let path = PathBaseline::new(target, &rev_dir)?;
         Ok(Self { path })
     }
 }

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -305,10 +305,10 @@ pub(crate) struct PathBaseline {
 
 impl PathBaseline {
     pub(crate) fn new(
-        /// Path to a directory with the manifest or with subdirectories with the manifests.
+        // Path to a directory with the manifest or with subdirectories with the manifests.
         project_root: &std::path::Path,
 
-        /// Path to a directory where the placeholder manifest / rustdoc can be created.
+        // Path to a directory where the placeholder manifest / rustdoc can be created.
         target_root: &std::path::Path,
     ) -> anyhow::Result<Self> {
         let mut lookup = std::collections::HashMap::new();

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -237,8 +237,12 @@ fn generate_rustdoc(
     match crate_source {
         CrateSource::Registry { .. } => {
             // Clean up after ourselves.
-            let cache_dir = cache_dir.unwrap();
-            let cached_rustdoc = cached_rustdoc.unwrap();
+            let cache_dir = cache_dir.expect(
+                "when crate_source is Registry a cache_dir was created, so it should be Some",
+            );
+            let cached_rustdoc = cached_rustdoc.expect(
+                "when crate_source is Registry a cached_rustdoc was created, so it should be Some",
+            );
             std::fs::create_dir_all(cache_dir)?;
             std::fs::copy(rustdoc_path, &cached_rustdoc)?;
             std::fs::remove_dir_all(build_dir)?;

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -135,11 +135,7 @@ impl RustDocCommand {
             let json_path = target_dir.join(format!("doc/{first_bin_target_name}.json"));
             if !json_path.exists() {
                 let crate_name = if let Some(pkg_spec) = pkg_spec {
-                    pkg_spec
-                        .split_once('@')
-                        .map(|s| s.0)
-                        .unwrap_or(pkg_spec)
-                        .to_owned()
+                    pkg_spec.split_once('@').map(|s| s.0).unwrap_or(pkg_spec)
                 } else {
                     crate::manifest::get_package_name(&manifest)?
                 };

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -123,7 +123,7 @@ impl RustDocCommand {
                 );
             }
         } else {
-            let manifest = crate::manifest::Manifest::parse(manifest_path)?;
+            let manifest = crate::manifest::Manifest::parse(manifest_path.to_path_buf())?;
 
             let lib_target_name = crate::manifest::get_lib_target_name(&manifest)?;
             let json_path = target_dir.join(format!("doc/{lib_target_name}.json"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,9 @@ fn main() -> anyhow::Result<()> {
                 if let Some(path) = args.baseline_rustdoc.as_deref() {
                     Box::new(baseline::RustdocBaseline::new(path.to_owned()))
                 } else if let Some(root) = args.baseline_root.as_deref() {
-                    Box::new(baseline::PathBaseline::new(root)?)
+                    let metadata = args.manifest.metadata().no_deps().exec()?;
+                    let target = metadata.target_directory.as_std_path().join(util::SCOPE);
+                    Box::new(baseline::PathBaseline::new(&target, root)?)
                 } else if let Some(rev) = args.baseline_rev.as_deref() {
                     let metadata = args.manifest.metadata().no_deps().exec()?;
                     let source = metadata.workspace_root.as_std_path();

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ fn main() -> anyhow::Result<()> {
                 } else if let Some(root) = args.baseline_root.as_deref() {
                     let metadata = args.manifest.metadata().no_deps().exec()?;
                     let target = metadata.target_directory.as_std_path().join(util::SCOPE);
-                    Box::new(baseline::PathBaseline::new(&target, root)?)
+                    Box::new(baseline::PathBaseline::new(root, &target)?)
                 } else if let Some(rev) = args.baseline_rev.as_deref() {
                     let metadata = args.manifest.metadata().no_deps().exec()?;
                     let source = metadata.workspace_root.as_std_path();

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,12 +1,12 @@
 #[derive(Debug, Clone)]
-pub(crate) struct Manifest<'a> {
-    path: &'a std::path::Path,
-    parsed: cargo_toml::Manifest,
+pub(crate) struct Manifest {
+    pub(crate) path: std::path::PathBuf,
+    pub(crate) parsed: cargo_toml::Manifest,
 }
 
-impl<'a> Manifest<'a> {
-    pub(crate) fn parse(path: &'a std::path::Path) -> anyhow::Result<Self> {
-        let manifest_text = std::fs::read_to_string(path)
+impl Manifest {
+    pub(crate) fn parse(path: std::path::PathBuf) -> anyhow::Result<Self> {
+        let manifest_text = std::fs::read_to_string(&path)
             .map_err(|e| anyhow::format_err!("Failed when reading {}: {}", path.display(), e))?;
         let parsed = toml::from_str(manifest_text.as_str())
             .map_err(|e| anyhow::format_err!("Failed to parse {}: {}", path.display(), e))?;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -15,17 +15,17 @@ impl Manifest {
     }
 }
 
-pub(crate) fn get_package_name(manifest: &Manifest) -> anyhow::Result<String> {
+pub(crate) fn get_package_name(manifest: &Manifest) -> anyhow::Result<&str> {
     let package = manifest.parsed.package.as_ref().ok_or_else(|| {
         anyhow::format_err!(
             "Failed to parse {}: no `package` table",
             manifest.path.display()
         )
     })?;
-    Ok(package.name.clone())
+    Ok(&package.name)
 }
 
-pub(crate) fn get_package_version(manifest: &Manifest) -> anyhow::Result<String> {
+pub(crate) fn get_package_version(manifest: &Manifest) -> anyhow::Result<&str> {
     let package = manifest.parsed.package.as_ref().ok_or_else(|| {
         anyhow::format_err!(
             "Failed to parse {}: no `package` table",
@@ -39,7 +39,7 @@ pub(crate) fn get_package_version(manifest: &Manifest) -> anyhow::Result<String>
             e
         )
     })?;
-    Ok(version.clone())
+    Ok(version)
 }
 
 pub(crate) fn get_lib_target_name(manifest: &Manifest) -> anyhow::Result<String> {


### PR DESCRIPTION
This PR is a continuation of #340.

This PR changes the way baseline rustdoc of `PathBaseline` is being generated -- similarly to  `RegistryBaseline`, a placeholder project is created (with a dependency to the true project) on which the rustdoc is generated.

I was worried about two possible places which could have bugs, but after writing this PR, it turned out to not be a problem:
- the dependency is given an absolute path, instead of a relative path, so the target directory in which the placeholder project is placed doesn't matter,
- getting all features from a manifest (instead of the registry) turned out to be *extremely* similar to getting all features from registry. I've split the feature functions into multiple smaller functions, which shows similarities for easier comparison and lesser chance of making a bug.