### PR TITLE
Changed some load_rustdoc arguments to a struct

### DIFF
--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -177,6 +177,7 @@ fn save_placeholder_rustdoc_manifest(
 }
 
 #[allow(dead_code)]
+#[derive(Debug)]
 pub(crate) enum CrateType<'a> {
     Current,
     Baseline {
@@ -187,6 +188,7 @@ pub(crate) enum CrateType<'a> {
     },
 }
 
+#[derive(Debug)]
 pub(crate) struct CrateDataForRustdoc<'a> {
     pub(crate) crate_type: CrateType<'a>,
     pub(crate) name: &'a str,

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -241,8 +241,6 @@ fn generate_rustdoc(
                         crate_data.crate_type.to_string()
                     ),
                 )?;
-                // TODO: replace "baseline" with a string passed as a function argument
-                // (the plan is to make this function work for both baseline and current).
                 return Ok(cached_rustdoc);
             }
 
@@ -261,8 +259,6 @@ fn generate_rustdoc(
         "Parsing",
         format_args!("{name} v{version} ({})", crate_data.crate_type.to_string()),
     )?;
-    // TODO: replace "baseline" with a string passed as a function argument
-    // (the plan is to make this function work for both baseline and current).
 
     let rustdoc_path = rustdoc.dump(
         placeholder_manifest_path.as_path(),

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -33,14 +33,8 @@ impl<'a> CrateSource<'a> {
     /// <https://doc.rust-lang.org/cargo/reference/features.html#the-features-section>
     fn regular_features(&self) -> Vec<String> {
         match self {
-            Self::Registry { crate_ } => crate_.features().keys().cloned().into_iter().collect(),
-            Self::ManifestPath { manifest } => manifest
-                .parsed
-                .features
-                .keys()
-                .cloned()
-                .into_iter()
-                .collect(),
+            Self::Registry { crate_ } => crate_.features().keys().cloned().collect(),
+            Self::ManifestPath { manifest } => manifest.parsed.features.keys().cloned().collect(),
         }
     }
 
@@ -182,11 +176,39 @@ fn save_placeholder_rustdoc_manifest(
     Ok(placeholder_manifest_path)
 }
 
+#[allow(dead_code)]
+pub(crate) enum CrateType<'a> {
+    Current,
+    Baseline {
+        /// When the baseline is being generated from registry
+        /// and no specific version was chosen, we want to select a version
+        /// that is the same or older than the version of the current crate.
+        highest_allowed_version: Option<&'a semver::Version>,
+    },
+}
+
+pub(crate) struct CrateDataForRustdoc<'a> {
+    pub(crate) crate_type: CrateType<'a>,
+    pub(crate) name: &'a str,
+    // TODO: pass an enum describing which features to enable
+}
+
+impl<'a> ToString for CrateType<'a> {
+    fn to_string(&self) -> String {
+        match self {
+            CrateType::Current => "current",
+            CrateType::Baseline { .. } => "baseline",
+        }
+        .to_string()
+    }
+}
+
 fn generate_rustdoc(
     config: &mut GlobalConfig,
     rustdoc: &RustDocCommand,
     target_root: PathBuf,
     crate_source: CrateSource,
+    crate_data: CrateDataForRustdoc,
 ) -> anyhow::Result<PathBuf> {
     let name = crate_source.name()?;
     let version = crate_source.version()?;
@@ -214,7 +236,10 @@ fn generate_rustdoc(
             if cached_rustdoc.exists() {
                 config.shell_status(
                     "Parsing",
-                    format_args!("{name} v{version} (baseline, cached)"),
+                    format_args!(
+                        "{name} v{version} ({}, cached)",
+                        crate_data.crate_type.to_string()
+                    ),
                 )?;
                 // TODO: replace "baseline" with a string passed as a function argument
                 // (the plan is to make this function work for both baseline and current).
@@ -232,7 +257,10 @@ fn generate_rustdoc(
         save_placeholder_rustdoc_manifest(build_dir.as_path(), placeholder_manifest)
             .context("failed to save placeholder rustdoc manifest")?;
 
-    config.shell_status("Parsing", format_args!("{name} v{version} (baseline)"))?;
+    config.shell_status(
+        "Parsing",
+        format_args!("{name} v{version} ({})", crate_data.crate_type.to_string()),
+    )?;
     // TODO: replace "baseline" with a string passed as a function argument
     // (the plan is to make this function work for both baseline and current).
 
@@ -270,8 +298,7 @@ pub(crate) trait BaselineLoader {
         &self,
         config: &mut GlobalConfig,
         rustdoc: &RustDocCommand,
-        name: &str,
-        version_current: Option<&semver::Version>,
+        crate_data: CrateDataForRustdoc,
     ) -> anyhow::Result<PathBuf>;
 }
 
@@ -290,8 +317,7 @@ impl BaselineLoader for RustdocBaseline {
         &self,
         _config: &mut GlobalConfig,
         _rustdoc: &RustDocCommand,
-        _name: &str,
-        _version_current: Option<&semver::Version>,
+        _crate_data: CrateDataForRustdoc,
     ) -> anyhow::Result<PathBuf> {
         Ok(self.path.clone())
     }
@@ -335,13 +361,12 @@ impl BaselineLoader for PathBaseline {
         &self,
         config: &mut GlobalConfig,
         rustdoc: &RustDocCommand,
-        name: &str,
-        _version_current: Option<&semver::Version>,
+        crate_data: CrateDataForRustdoc,
     ) -> anyhow::Result<PathBuf> {
-        let manifest: &Manifest = self.lookup.get(name).with_context(|| {
+        let manifest: &Manifest = self.lookup.get(crate_data.name).with_context(|| {
             format!(
                 "package `{}` not found in {}",
-                name,
+                crate_data.name,
                 self.project_root.display()
             )
         })?;
@@ -350,6 +375,7 @@ impl BaselineLoader for PathBaseline {
             rustdoc,
             self.target_root.clone(),
             CrateSource::ManifestPath { manifest },
+            crate_data,
         )
     }
 }
@@ -419,11 +445,9 @@ impl BaselineLoader for GitBaseline {
         &self,
         config: &mut GlobalConfig,
         rustdoc: &RustDocCommand,
-        name: &str,
-        version_current: Option<&semver::Version>,
+        crate_data: CrateDataForRustdoc,
     ) -> anyhow::Result<PathBuf> {
-        self.path
-            .load_rustdoc(config, rustdoc, name, version_current)
+        self.path.load_rustdoc(config, rustdoc, crate_data)
     }
 }
 
@@ -522,18 +546,25 @@ impl BaselineLoader for RegistryBaseline {
         &self,
         config: &mut GlobalConfig,
         rustdoc: &RustDocCommand,
-        name: &str,
-        version_current: Option<&semver::Version>,
+        crate_data: CrateDataForRustdoc,
     ) -> anyhow::Result<PathBuf> {
         let crate_ = self
             .index
-            .crate_(name)
-            .with_context(|| anyhow::format_err!("{} not found in registry", name))?;
+            .crate_(crate_data.name)
+            .with_context(|| anyhow::format_err!("{} not found in registry", crate_data.name))?;
 
         let base_version = if let Some(base) = self.version.as_ref() {
             base.to_string()
         } else {
-            choose_baseline_version(&crate_, version_current)?
+            choose_baseline_version(
+                &crate_,
+                match crate_data.crate_type {
+                    CrateType::Current => None,
+                    CrateType::Baseline {
+                        highest_allowed_version,
+                    } => highest_allowed_version,
+                },
+            )?
         };
 
         let crate_ = crate_
@@ -543,7 +574,7 @@ impl BaselineLoader for RegistryBaseline {
             .with_context(|| {
                 anyhow::format_err!(
                     "Version {} of crate {} not found in registry",
-                    name,
+                    crate_data.name,
                     base_version
                 )
             })?;
@@ -553,6 +584,7 @@ impl BaselineLoader for RegistryBaseline {
             rustdoc,
             self.target_root.clone(),
             CrateSource::Registry { crate_ },
+            crate_data,
         )
     }
 }


### PR DESCRIPTION
This PR is a continuation of #341 and #340.

It doesn't yet introduce functional changes -- the only change is that I've defined some new enums/structs and I'm passing them to `load_rustdoc` functions, instead of several arguments.

The reasoning is that some arguments were not obvious / should have been documented, but it's hard to do it near each `load_rustdoc` function. It's also convenient to group those struct fields together -- they are strictly related and independent of other `load_rustdoc` arguments. The new enum allows to execute the new rustdoc generation through the placeholder for the current crate (which will be done in a next PR). The struct also allows for an easier additive change in some next PR, which will add the possibility of choosing which features to enable.