### PR TITLE
Fix syntax highlighting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Lint your crate API changes for semver violations.
 
 ## Quick Start
 
-```console
+```sh
 $ cargo install cargo-semver-checks --locked
 
 # Check whether it's safe to release the new version:


### PR DESCRIPTION
`console` is not a recognized syntax highlighting tag by most markdown viewers