### PR TITLE
Add "skip minor lints" flag

### DIFF
--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -83,6 +83,7 @@ pub(super) fn run_check_release(
     crate_name: &str,
     current_crate: VersionedCrate,
     baseline_crate: VersionedCrate,
+    skip_minor_lints: bool,
 ) -> anyhow::Result<bool> {
     let current_version = current_crate.crate_version();
     let baseline_version = baseline_crate.crate_version();
@@ -113,6 +114,10 @@ pub(super) fn run_check_release(
     let queries_to_run: Vec<_> = queries
         .iter()
         .filter(|(_, query)| !version_change.supports_requirement(query.required_update))
+        .filter(|(_, query)| match query.required_update {
+            RequiredSemverUpdate::Major => true,
+            RequiredSemverUpdate::Minor => !skip_minor_lints,
+        })
         .collect();
     let skipped_queries = queries.len().saturating_sub(queries_to_run.len());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,13 @@ fn main() -> anyhow::Result<()> {
                     baseline_highest_allowed_version,
                 )?;
 
-                let success = run_check_release(&mut config, name, current_crate, baseline_crate)?;
+                let success = run_check_release(
+                    &mut config,
+                    name,
+                    current_crate,
+                    baseline_crate,
+                    args.skip_minor_lints,
+                )?;
                 vec![Ok(success)]
             } else {
                 let metadata = args.manifest.metadata().exec()?;
@@ -184,6 +190,7 @@ fn main() -> anyhow::Result<()> {
                                 crate_name,
                                 current_crate,
                                 baseline_crate,
+                                args.skip_minor_lints,
                             )?)
                         }
                     })
@@ -284,6 +291,10 @@ struct CheckRelease {
 
     #[command(flatten, next_help_heading = "Current")]
     pub workspace: clap_cargo::Workspace,
+
+    /// Only check whether a major version increment is required.
+    #[arg(long)]
+    skip_minor_lints: bool,
 
     /// The current rustdoc json output to test for semver violations.
     #[arg(


### PR DESCRIPTION
Related to #359, but doesn't directly close it. But might make it obsolete.