### PR TITLE
bump cargo-toml to 0.15.2 and remove workarounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189929343288eb08d1f418bfbc022a5bddc6889e4a8f8dfaf06035fd3adf6fed"
+checksum = "7f83bc2e401ed041b7057345ebc488c005efa0341d5541ce7004d30458d0090b"
 dependencies = [
  "serde",
  "toml 0.7.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ crates-index = { version = "0.19.2" }
 human-panic = "1.0.3"
 bugreport = "0.5.0"
 itertools = "0.10.5"
-cargo_toml = "0.15"
+cargo_toml = "0.15.2"
 toml = "0.5.9"
 
 [dev-dependencies]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -13,7 +13,7 @@ impl Manifest {
         // the existence of lib targets and ensure proper handling of workspace inheritance.
 
         let parsed = cargo_toml::Manifest::from_path(&path)
-            .map_err(|e| anyhow::format_err!("Failed when reading {}: {}", path.display(), e))?;
+            .with_context(|| format!("Failed when reading {}", path.display()))?;
 
         Ok(Self { path, parsed })
     }
@@ -36,11 +36,10 @@ pub(crate) fn get_package_version(manifest: &Manifest) -> anyhow::Result<&str> {
             manifest.path.display()
         )
     })?;
-    let version = package.version.get().map_err(|e| {
-        anyhow::format_err!(
-            "Failed to retrieve package version from {}: {}",
+    let version = package.version.get().with_context(|| {
+        format!(
+            "Failed to retrieve package version from {}",
             manifest.path.display(),
-            e
         )
     })?;
     Ok(version)


### PR DESCRIPTION
Thanks to @kornelski for a quick review for my PR to cargo_toml and we can remove the workaround now!