### PR TITLE
Better error reporting when manifests fail to parse.

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -11,36 +11,26 @@ impl Manifest {
         // Parsing via `cargo_toml::Manifest::from_path()` is preferable to parsing from a string,
         // because inspection of surrounding files is sometimes necessary to determine
         // the existence of lib targets and ensure proper handling of workspace inheritance.
-
         let parsed = cargo_toml::Manifest::from_path(&path)
-            .with_context(|| format!("Failed when reading {}", path.display()))?;
+            .with_context(|| format!("failed when reading {}", path.display()))?;
 
         Ok(Self { path, parsed })
     }
 }
 
 pub(crate) fn get_package_name(manifest: &Manifest) -> anyhow::Result<&str> {
-    let package = manifest.parsed.package.as_ref().ok_or_else(|| {
-        anyhow::format_err!(
-            "Failed to parse {}: no `package` table",
-            manifest.path.display()
-        )
+    let package = manifest.parsed.package.as_ref().with_context(|| {
+        format!("failed to parse {}: no `package` table", manifest.path.display())
     })?;
     Ok(&package.name)
 }
 
 pub(crate) fn get_package_version(manifest: &Manifest) -> anyhow::Result<&str> {
-    let package = manifest.parsed.package.as_ref().ok_or_else(|| {
-        anyhow::format_err!(
-            "Failed to parse {}: no `package` table",
-            manifest.path.display()
-        )
+    let package = manifest.parsed.package.as_ref().with_context(|| {
+        format!("failed to parse {}: no `package` table", manifest.path.display())
     })?;
     let version = package.version.get().with_context(|| {
-        format!(
-            "Failed to retrieve package version from {}",
-            manifest.path.display(),
-        )
+        format!("failed to retrieve package version from {}", manifest.path.display())
     })?;
     Ok(version)
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -20,17 +20,26 @@ impl Manifest {
 
 pub(crate) fn get_package_name(manifest: &Manifest) -> anyhow::Result<&str> {
     let package = manifest.parsed.package.as_ref().with_context(|| {
-        format!("failed to parse {}: no `package` table", manifest.path.display())
+        format!(
+            "failed to parse {}: no `package` table",
+            manifest.path.display()
+        )
     })?;
     Ok(&package.name)
 }
 
 pub(crate) fn get_package_version(manifest: &Manifest) -> anyhow::Result<&str> {
     let package = manifest.parsed.package.as_ref().with_context(|| {
-        format!("failed to parse {}: no `package` table", manifest.path.display())
+        format!(
+            "failed to parse {}: no `package` table",
+            manifest.path.display()
+        )
     })?;
     let version = package.version.get().with_context(|| {
-        format!("failed to retrieve package version from {}", manifest.path.display())
+        format!(
+            "failed to retrieve package version from {}",
+            manifest.path.display()
+        )
     })?;
     Ok(version)
 }

--- a/src/rustdoc_gen.rs
+++ b/src/rustdoc_gen.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use crates_index::Crate;
+use itertools::Itertools;
 
 use crate::manifest::Manifest;
 use crate::rustdoc_cmd::RustdocCommand;
@@ -325,7 +326,8 @@ impl RustdocGenerator for RustdocFromFile {
 #[derive(Debug)]
 pub(crate) struct RustdocFromProjectRoot {
     project_root: PathBuf,
-    lookup: std::collections::HashMap<String, Manifest>,
+    manifests: std::collections::HashMap<String, Manifest>,
+    manifest_errors: std::collections::HashMap<PathBuf, anyhow::Error>,
     target_root: PathBuf,
 }
 
@@ -337,20 +339,33 @@ impl RustdocFromProjectRoot {
         project_root: &std::path::Path,
         target_root: &std::path::Path,
     ) -> anyhow::Result<Self> {
-        let mut lookup = std::collections::HashMap::new();
+        let mut manifests = std::collections::HashMap::new();
+        let mut manifest_errors = std::collections::HashMap::new();
         for result in ignore::Walk::new(project_root) {
             let entry = result?;
             if entry.file_name() == "Cargo.toml" {
-                if let Ok(manifest) = crate::manifest::Manifest::parse(entry.into_path()) {
-                    if let Ok(name) = crate::manifest::get_package_name(&manifest) {
-                        lookup.insert(name.to_string(), manifest);
+                let path = entry.into_path();
+                match crate::manifest::Manifest::parse(path.clone()) {
+                    Ok(manifest) => {
+                        match crate::manifest::get_package_name(&manifest) {
+                            Ok(name) => {
+                                manifests.insert(name.to_string(), manifest);
+                            }
+                            Err(e) => {
+                                manifest_errors.insert(path, e);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        manifest_errors.insert(path, e);
                     }
                 }
             }
         }
         Ok(Self {
             project_root: project_root.to_owned(),
-            lookup,
+            manifests,
+            manifest_errors,
             target_root: target_root.to_owned(),
         })
     }
@@ -363,11 +378,16 @@ impl RustdocGenerator for RustdocFromProjectRoot {
         rustdoc_cmd: &RustdocCommand,
         crate_data: CrateDataForRustdoc,
     ) -> anyhow::Result<PathBuf> {
-        let manifest: &Manifest = self.lookup.get(crate_data.name).with_context(|| {
+        let manifest: &Manifest = self.manifests.get(crate_data.name).with_context(|| {
+            let errors = self.manifest_errors.values().map(|error| {
+                format!("  {error:#},")
+            }).join("\n");
+            format!("possibly due to errors: [\n{errors}\n]")
+        }).with_context(|| {
             format!(
                 "package `{}` not found in {}",
                 crate_data.name,
-                self.project_root.display()
+                self.project_root.display(),
             )
         })?;
         generate_rustdoc(


### PR DESCRIPTION
Improved error message for cases like #376. I'm under no illusions that this new UX is perfect, but it's certainly better than before and we can keep making it better still.

Before:
```
$ cargo semver-checks check-release --manifest-path common/config/Cargo.toml 
     Parsing bootloader-boot-config v0.11.0 (current)
Error: package `bootloader-boot-config` not found in common/config
```

After:
```
$ cargo semver-checks check-release --manifest-path common/config/Cargo.toml 
     Parsing bootloader-boot-config v0.11.0 (current)
Error: package `bootloader-boot-config` not found in common/config

Caused by:
    possibly due to errors: [
      failed when reading common/config/Cargo.toml: not all fields of `bootloader-boot-config` have been present in workspace.package,
    ]
```