### PR TITLE
Fix workspace handling CLI bugs. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -605,9 +605,8 @@ jobs:
           EXPECTED="$(echo -e "--- failure function_missing: pub fn removed or renamed ---")"
           RESULT="$(cat output | grep failure)"
           diff <(echo "$RESULT") <(echo "$EXPECTED")
-          EXPECTED="$(echo -e "  function ref_slice::ref_slice, previously in file")"
-          RESULT="$(cat output | grep 'previously in file')"
-          diff <(echo "$RESULT") <(echo "$EXPECTED")
+          # Ensure the following fragment (not full line!) is in the output file:
+          grep '  function ref_slice::ref_slice, previously in file' output
 
       - name: Cleanup
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - run-on-bevy-gltf
       - run-on-clap
       - run-on-sqllogictest
+      - run-on-tokio
     steps:
       - run: exit 0
 
@@ -413,6 +414,42 @@ jobs:
 
       - name: Run via package Cargo.toml
         run: cargo run semver-checks check-release --manifest-path subject/sqllogictest/Cargo.toml
+
+  run-on-tokio:
+    # cargo-semver-checks crashed here due to improper CLI argument handling:
+    # https://github.com/obi1kenobi/cargo-semver-checks/issues/380
+    name: Run cargo-semver-checks on tokio ~v1.25.0
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cargo-semver-checks
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Checkout tokio
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          repository: 'tokio-rs/tokio'
+          ref: 'd7b7c6131774ab631be6529fef3680abfeeb4781'
+          path: 'subject'
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: tokio
+
+      - name: Run semver-checks on tokio crate manifest only
+        run: cargo run semver-checks check-release --manifest-path="subject/tokio/Cargo.toml" --release-type minor --exclude benches --exclude examples --exclude stress-test --exclude tests-build --exclude tests-integration
+
+      - name: Run semver-checks on workspace manifest
+        run: cargo run semver-checks check-release --manifest-path="subject/Cargo.toml" --release-type minor --exclude benches --exclude examples --exclude stress-test --exclude tests-build --exclude tests-integration
 
   run-on-clap:
     # clap v3.2.0 added a semver violation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -586,7 +586,8 @@ jobs:
       - name: Run semver-checks
         continue-on-error: true
         run: |
-          cargo run semver-checks check-release --manifest-path="subject/Cargo.toml" > output
+          set -euo pipefail
+          cargo run semver-checks check-release --manifest-path="subject/Cargo.toml" 2>&1 | tee output
           touch unexpectedly_did_not_fail
 
       - name: Check whether it failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,7 +597,8 @@ jobs:
       - name: Baseline is correct
         run: |
           EXPECTED="$(echo -e "     Parsing ref_slice v1.2.2 (current)\n     Parsing ref_slice v1.2.1 (baseline)\n    Checking ref_slice v1.2.1 -> v1.2.2 (patch change)")"
-          RESULT="$(cat output | grep 'ref_slice v1.')"
+          # Strip ANSI escapes for colors and bold text before comparing.
+          RESULT="$(cat output | grep 'ref_slice v1.' | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g")"
           diff <(echo "$RESULT") <(echo "$EXPECTED")
 
       - name: Semver break found

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -604,7 +604,7 @@ jobs:
       - name: Semver break found
         run: |
           EXPECTED="$(echo -e "--- failure function_missing: pub fn removed or renamed ---")"
-          RESULT="$(cat output | grep failure')"
+          RESULT="$(cat output | grep failure)"
           diff <(echo "$RESULT") <(echo "$EXPECTED")
           EXPECTED="$(echo -e "  function ref_slice::ref_slice, previously in file")"
           RESULT="$(cat output | grep 'previously in file')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,8 +446,11 @@ jobs:
         with:
           key: tokio
 
-      # This test caught a bug where the default baseline was set to the current path,
-      # instead of the default registry version.
+      # This test caught two bugs:
+      # - The default baseline was set to the current path instead of the default registry version.
+      # - Specifying `--exclude` together with a crate manifest that is within a workspace
+      #   (but doesn't *itself* define the workspace) would cause the entire workspace to
+      #   get tested, even though only a single crate's manifest was specified.
       - name: Run semver-checks on tokio crate manifest only
         run: cargo run semver-checks check-release --manifest-path="subject/tokio/Cargo.toml" --release-type minor --exclude benches --exclude examples --exclude stress-test --exclude tests-build --exclude tests-integration
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
       - run-on-bevy-gltf
       - run-on-clap
       - run-on-sqllogictest
-      - run-on-tokio
       - run-on-ref-slice-fork
     steps:
       - run: exit 0
@@ -451,8 +450,8 @@ jobs:
       # - Specifying `--exclude` together with a crate manifest that is within a workspace
       #   (but doesn't *itself* define the workspace) would cause the entire workspace to
       #   get tested, even though only a single crate's manifest was specified.
-      - name: Run semver-checks on tokio crate manifest only
-        run: cargo run semver-checks check-release --manifest-path="subject/tokio/Cargo.toml" --release-type minor --exclude benches --exclude examples --exclude stress-test --exclude tests-build --exclude tests-integration
+      - name: Run semver-checks on tokio-stream crate manifest only
+        run: cargo run semver-checks check-release --manifest-path="subject/tokio-stream/Cargo.toml" --release-type minor --exclude benches --exclude examples --exclude stress-test --exclude tests-build --exclude tests-integration
 
       # This test caught a bug where `--exclude` was silently ignored
       # if `--workspace` wasn't set at the same time.
@@ -675,6 +674,7 @@ jobs:
     needs:
       - ci-everything
       - should-publish
+      - run-on-tokio  # this check is too expensive on every PR, so we do it pre-publish instead
     if: needs.should-publish.outputs.is_new_version == 'yes'
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - run-on-clap
       - run-on-sqllogictest
       - run-on-tokio
+      - run-on-ref-slice-fork
     steps:
       - run: exit 0
 
@@ -541,6 +542,73 @@ jobs:
           EXPECTED="$(echo -e "--- failure auto_trait_impl_removed: auto trait no longer implemented ---\n--- failure trait_missing: pub trait removed or renamed ---")"
           RESULT="$(cat output | grep failure)"
           diff <(echo "$RESULT") <(echo "$EXPECTED")
+
+  run-on-ref-slice-fork:
+    # Simulate testing an as-yet-unreleased crate version without an explicit baseline,
+    # i.e. with the expectation that the largest crates.io version is used as a baseline.
+    # This broke when a PR accidentally changed the default baseline behavior.
+    # https://github.com/obi1kenobi/cargo-semver-checks/issues/382
+    #
+    # To perform this test, we forked a stable crate and made a semver-major change in
+    # an unreleased patch version (v1.2.2). In this test, we make sure that:
+    # - v1.2.1 is chosen as the baseline, as the largest crates.io version,
+    # - cargo-semver-checks detects the semver break we've manufactured.
+    name: Run cargo-semver-checks on ref-slice fork
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cargo-semver-checks
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: true
+
+      - name: Checkout ref-slice fork semver break
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          repository: 'mgr0dzicki/cargo-semver-action-ref-slice'
+          ref: 'major_change'
+          path: 'subject'
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ref-slice-fork
+
+      - name: Run semver-checks
+        continue-on-error: true
+        run: |
+          cargo run semver-checks check-release --manifest-path="subject/Cargo.toml" > output
+          touch unexpectedly_did_not_fail
+
+      - name: Check whether it failed
+        run: |
+          if [ -f unexpectedly_did_not_fail ]; then exit 1; else exit 0; fi
+
+      - name: Baseline is correct
+        run: |
+          EXPECTED="$(echo -e "     Parsing ref_slice v1.2.2 (current)\n     Parsing ref_slice v1.2.1 (baseline)\n    Checking ref_slice v1.2.1 -> v1.2.2 (patch change)")"
+          RESULT="$(cat output | grep 'ref_slice v1.')"
+          diff <(echo "$RESULT") <(echo "$EXPECTED")
+
+      - name: Semver break found
+        run: |
+          EXPECTED="$(echo -e "--- failure function_missing: pub fn removed or renamed ---")"
+          RESULT="$(cat output | grep failure')"
+          diff <(echo "$RESULT") <(echo "$EXPECTED")
+          EXPECTED="$(echo -e "  function ref_slice::ref_slice, previously in file")"
+          RESULT="$(cat output | grep 'previously in file')"
+          diff <(echo "$RESULT") <(echo "$EXPECTED")
+
+      - name: Cleanup
+        run: |
+          rm output
+          rm -f unexpectedly_did_not_fail
 
   init-release:
     name: Run the release workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,8 +455,8 @@ jobs:
       - name: Run semver-checks on workspace manifest with explicit exclusions
         run: cargo run semver-checks check-release --manifest-path="subject/Cargo.toml" --release-type minor --exclude examples --exclude stress-test --exclude tests-build --exclude tests-integration
 
-      # This test caught a bug where `publish = false` items were still semver-checked
-      # unless either `--workspace` was present or was implied e.g. via `--exclude`.
+      # This test caught a bug where `publish = false` items in a workspace were semver-checked
+      # unless either explicit `--workspace` was present or was implied e.g. via `--exclude`.
       - name: Run semver-checks on workspace manifest with implicit exclusions
         run: cargo run semver-checks check-release --manifest-path="subject/Cargo.toml" --release-type minor
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,11 +445,20 @@ jobs:
         with:
           key: tokio
 
+      # This test caught a bug where the default baseline was set to the current path,
+      # instead of the default registry version.
       - name: Run semver-checks on tokio crate manifest only
         run: cargo run semver-checks check-release --manifest-path="subject/tokio/Cargo.toml" --release-type minor --exclude benches --exclude examples --exclude stress-test --exclude tests-build --exclude tests-integration
 
-      - name: Run semver-checks on workspace manifest
-        run: cargo run semver-checks check-release --manifest-path="subject/Cargo.toml" --release-type minor --exclude benches --exclude examples --exclude stress-test --exclude tests-build --exclude tests-integration
+      # This test caught a bug where `--exclude` was silently ignored
+      # if `--workspace` wasn't set at the same time.
+      - name: Run semver-checks on workspace manifest with explicit exclusions
+        run: cargo run semver-checks check-release --manifest-path="subject/Cargo.toml" --release-type minor --exclude examples --exclude stress-test --exclude tests-build --exclude tests-integration
+
+      # This test caught a bug where `publish = false` items were still semver-checked
+      # unless either `--workspace` was present or was implied e.g. via `--exclude`.
+      - name: Run semver-checks on workspace manifest with implicit exclusions
+        run: cargo run semver-checks check-release --manifest-path="subject/Cargo.toml" --release-type minor
 
   run-on-clap:
     # clap v3.2.0 added a semver violation

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ localdata/
 .vscode/
 
 # Unnecessary test data
-test_crates/*/*/Cargo.lock
+test_crates/**/Cargo.lock

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,7 +367,14 @@ impl Check {
                         let crate_name = &selected.name;
                         let version = &selected.version;
 
-                        let is_implied = selected.publish == Some(vec![]);
+                        // If the manifest we're using points to a workspace, then
+                        // ignore `publish = false` crates unless they are specifically selected.
+                        // If the manifest points to a specific crate, then check the crate
+                        // even if `publish = false` is set.
+                        let is_implied =
+                            matches!(self.scope.mode, ScopeMode::DenyList(..))
+                            && metadata.workspace_members.len() > 1
+                            && selected.publish == Some(vec![]);
                         if is_implied {
                             config.verbose(|config| {
                                 config.shell_status(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,11 +383,6 @@ impl Check {
                             })?;
                             Ok(true)
                         } else {
-                            config.shell_status(
-                                "Parsing",
-                                format_args!("{crate_name} v{version} (current)"),
-                            )?;
-
                             let (current_crate, baseline_crate) = generate_versioned_crates(
                                 &mut config,
                                 &rustdoc_cmd,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,13 +367,7 @@ impl Check {
                         let crate_name = &selected.name;
                         let version = &selected.version;
 
-                        let is_implied = matches!(
-                            self.scope.mode,
-                            ScopeMode::DenyList(PackageSelection {
-                                selection: ScopeSelection::Workspace,
-                                ..
-                            })
-                        ) && selected.publish == Some(vec![]);
+                        let is_implied = selected.publish == Some(vec![]);
                         if is_implied {
                             config.verbose(|config| {
                                 config.shell_status(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,8 +371,7 @@ impl Check {
                         // ignore `publish = false` crates unless they are specifically selected.
                         // If the manifest points to a specific crate, then check the crate
                         // even if `publish = false` is set.
-                        let is_implied =
-                            matches!(self.scope.mode, ScopeMode::DenyList(..))
+                        let is_implied = matches!(self.scope.mode, ScopeMode::DenyList(..))
                             && metadata.workspace_members.len() > 1
                             && selected.publish == Some(vec![]);
                         if is_implied {

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,7 +215,7 @@ impl From<CheckRelease> for cargo_semver_checks::Check {
             (Rustdoc::from_root(&project_root), Some(project_root))
         };
         let mut check = Self::new(current);
-        if value.workspace.all || value.workspace.workspace {
+        if value.workspace.all || value.workspace.workspace || !value.workspace.exclude.is_empty() {
             let mut selection = PackageSelection::new(ScopeSelection::Workspace);
             selection.with_excluded_packages(value.workspace.exclude);
             check.with_package_selection(selection);


### PR DESCRIPTION
Fixes #380.
Fixes #378.
Fixes #382.

- Fix baseline path handling and duplicated `Parsing` output.
- `--exclude` implies `--workspace`.
- Fix `publish = false` item handling: when given a workspace manifest, they should still be skipped even without `--workspace`.
