### PR TITLE
Add test for precompiled binary failing on Windows to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - run-on-clap
       - run-on-sqllogictest
       - run-on-ref-slice-fork
+      - run-on-ref-slice-fork-windows
     steps:
       - run: exit 0
 
@@ -612,6 +613,73 @@ jobs:
         run: |
           rm output
           rm -f unexpectedly_did_not_fail
+
+  run-on-ref-slice-fork-windows:
+    # Same as above, but run on a Windows machine and from a compiled binary after
+    # removing .cargo/registry/index. This broke in a workflow of the GitHub Action
+    # using a precompiled binary after a fresh Rust installation, when the
+    # registry index does not exist yet.
+    name: Run cargo-semver-checks on ref-slice fork (Windows)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout cargo-semver-checks
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: true
+
+      - name: Checkout ref-slice fork semver break
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          repository: 'mgr0dzicki/cargo-semver-action-ref-slice'
+          ref: 'major_change'
+          path: 'subject'
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ref-slice-fork-windows
+
+      - name: Build cargo-semver-checks
+        run: cargo build
+
+      - name: Remove the cargo registry index
+        run: Remove-Item -Recurse -Force C:\Users\runneradmin\.cargo\registry\index
+
+      - name: Run cargo-semver-checks
+        continue-on-error: true
+        id: semver_checks
+        run: ./target/debug/cargo-semver-checks.exe semver-checks check-release --manifest-path="subject/Cargo.toml" 2>&1 | tee output
+
+      - name: Check whether it failed
+        if: steps.semver_checks.outcome != 'failure'
+        run: |
+          echo "Error! check-release should have failed because of the breaking change, but it has not."
+          exit 1
+
+      - name: Baseline is correct
+        run: |
+          $EXPECTED = "     Parsing ref_slice v1.2.2 (current)`r`n     Parsing ref_slice v1.2.1 (baseline)`r`n    Checking ref_slice v1.2.1 -> v1.2.2 (patch change)"
+          # Strip ANSI escapes for colors and bold text before comparing.
+          $RESULT = (cat output | grep 'ref_slice v1.' | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g") | Out-String
+          compare $RESULT $EXPECTED
+
+      - name: Semver break found
+        run: |
+          $EXPECTED = "--- failure function_missing: pub fn removed or renamed ---"
+          $RESULT = (cat output | grep failure)
+          compare $RESULT $EXPECTED
+          # Ensure the following fragment (not full line!) is in the output file:
+          grep '  function ref_slice::ref_slice, previously in file' output
+
+      - name: Cleanup
+        run: rm output
 
   init-release:
     name: Run the release workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -899,7 +899,7 @@ jobs:
           cd semver
           rm output
           rm -f unexpectedly_did_not_fail
-      
+
       - name: Save rustdoc
         uses: actions/cache/save@v3
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,40 @@ jobs:
           path: bins/
           key: bins-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
+  build-binary-windows:
+    name: Build binary (Windows)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          path: 'semver'
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: 'semver'
+
+      - name: build and cache
+        run: |
+          cd semver
+          cargo build
+          mkdir ../bins
+          mv target/debug/cargo-semver-checks.exe ../bins/cargo-semver-checks.exe
+
+      - name: cache binary
+        uses: actions/cache/save@v3
+        with:
+          path: bins/
+          key: bins-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+
   run-on-rust-libp2p:
     # Run cargo-semver-checks on a crate with no semver violations,
     # to make sure there are no false-positives.
@@ -1127,17 +1161,20 @@ jobs:
           path: subject/target/semver-checks/cache
 
   run-on-ref-slice-fork-windows:
-    # Same as above, but run on a Windows machine and from a compiled binary after
-    # removing .cargo/registry/index. This broke in a workflow of the GitHub Action
-    # using a precompiled binary after a fresh Rust installation, when the
-    # registry index does not exist yet.
+    # Same as above, but run on a Windows machine.
+    # This broke in a workflow of the GitHub Action using a precompiled binary
+    # after a fresh Rust installation, when the registry index does not exist yet
+    # (see https://github.com/frewsxcv/rust-crates-index/issues/97).
     name: Run cargo-semver-checks on ref-slice fork (Windows)
     runs-on: windows-latest
+    needs:
+      - build-binary-windows
     steps:
       - name: Checkout cargo-semver-checks
         uses: actions/checkout@v3
         with:
           persist-credentials: true
+          path: semver
 
       - name: Checkout ref-slice fork semver break
         uses: actions/checkout@v3
@@ -1154,26 +1191,36 @@ jobs:
           profile: minimal
           override: true
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Restore binary
+        id: cache-binary
+        uses: actions/cache/restore@v3
         with:
-          key: ref-slice-fork-windows
+          path: bins/
+          key: bins-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          fail-on-cache-miss: true
 
-      - name: Build cargo-semver-checks
-        run: cargo build
+      - run: |
+          rustc --version | tee .rustc-version
 
-        # The index directory is created during the above built, but does not exist
-        # just after installing Rust. In especially it might not exist when one is
-        # using the precompiled cargo-semver-checks binary, which resulted in the
-        # following issue: https://github.com/frewsxcv/rust-crates-index/issues/97.
-        # We therefore remove the index directory in order to make sure that the
-        # compiled binary will work in spite of that.
-      - name: Remove the cargo registry index
-        run: Remove-Item -Recurse -Force C:\Users\runneradmin\.cargo\registry\index
+      - name: Restore rustdoc
+        id: cache
+        uses: actions/cache/restore@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('.rustc-version', 'semver/**/Cargo.lock') }}-${{ github.job }}-rustdoc
+          path: subject/target/semver-checks/cache
+
+      - name: Restore cargo index and rustdoc target dir
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            subject/target/semver-checks/local-ref_slice-1_2_2/
 
       - name: Run cargo-semver-checks
         continue-on-error: true
         id: semver_checks
-        run: ./target/debug/cargo-semver-checks.exe semver-checks check-release --manifest-path="subject/Cargo.toml" 2>&1 | tee output
+        run: |
+          cd semver
+          ../bins/cargo-semver-checks.exe semver-checks check-release --manifest-path="../subject/Cargo.toml" 2>&1 | tee output
 
       - name: Check whether it failed
         if: steps.semver_checks.outcome != 'failure'
@@ -1183,13 +1230,15 @@ jobs:
 
       - name: Baseline is correct
         run: |
-          $EXPECTED = "     Parsing ref_slice v1.2.2 (current)`r`n     Parsing ref_slice v1.2.1 (baseline)`r`n    Checking ref_slice v1.2.1 -> v1.2.2 (patch change)"
+          cd semver
+          $EXPECTED = "    Checking ref_slice v1.2.1 -> v1.2.2 (patch change)"
           # Strip ANSI escapes for colors and bold text before comparing.
           $RESULT = (cat output | grep 'ref_slice v1.' | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g") | Out-String
           compare $RESULT $EXPECTED
 
       - name: Semver break found
         run: |
+          cd semver
           $EXPECTED = "--- failure function_missing: pub fn removed or renamed ---"
           $RESULT = (cat output | grep failure)
           compare $RESULT $EXPECTED
@@ -1197,7 +1246,16 @@ jobs:
           grep '  function ref_slice::ref_slice, previously in file' output
 
       - name: Cleanup
-        run: rm output
+        run: |
+          cd semver
+          rm output
+
+      - name: Save rustdoc
+        uses: actions/cache/save@v3
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('.rustc-version', 'semver/**/Cargo.lock') }}-${{ github.job }}-rustdoc
+          path: subject/target/semver-checks/cache
 
   init-release:
     name: Run the release workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -942,6 +942,12 @@ jobs:
       - name: Build cargo-semver-checks
         run: cargo build
 
+        # The index directory is created during the above built, but does not exist
+        # just after installing Rust. In especially it might not exist when one is
+        # using the precompiled cargo-semver-checks binary, which resulted in the
+        # following issue: https://github.com/frewsxcv/rust-crates-index/issues/97.
+        # We therefore remove the index directory in order to make sure that the
+        # compiled binary will work in spite of that.
       - name: Remove the cargo registry index
         run: Remove-Item -Recurse -Force C:\Users\runneradmin\.cargo\registry\index
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,13 +190,13 @@ jobs:
         run: |
           cd semver
           cargo build
-          mkdir ../bins
-          mv target/debug/cargo-semver-checks.exe ../bins/cargo-semver-checks.exe
+          mkdir ..\bins
+          mv target\debug\cargo-semver-checks.exe ..\bins\cargo-semver-checks.exe
 
       - name: cache binary
         uses: actions/cache/save@v3
         with:
-          path: bins/
+          path: bins\
           key: bins-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
   run-on-rust-libp2p:
@@ -1165,7 +1165,7 @@ jobs:
     # This broke in a workflow of the GitHub Action using a precompiled binary
     # after a fresh Rust installation, when the registry index does not exist yet
     # (see https://github.com/frewsxcv/rust-crates-index/issues/97).
-    name: Run cargo-semver-checks on ref-slice fork (Windows)
+    name: 'Semver: ref-slice fork (Windows)'
     runs-on: windows-latest
     needs:
       - build-binary-windows
@@ -1195,7 +1195,7 @@ jobs:
         id: cache-binary
         uses: actions/cache/restore@v3
         with:
-          path: bins/
+          path: bins\
           key: bins-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
           fail-on-cache-miss: true
 
@@ -1206,21 +1206,21 @@ jobs:
         id: cache
         uses: actions/cache/restore@v3
         with:
-          key: ${{ runner.os }}-${{ hashFiles('.rustc-version', 'semver/**/Cargo.lock') }}-${{ github.job }}-rustdoc
-          path: subject/target/semver-checks/cache
+          key: ${{ runner.os }}-${{ hashFiles('.rustc-version', 'semver\**\Cargo.lock') }}-${{ github.job }}-rustdoc
+          path: subject\target\semver-checks\cache
 
       - name: Restore cargo index and rustdoc target dir
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
-            subject/target/semver-checks/local-ref_slice-1_2_2/
+            subject\target\semver-checks\local-ref_slice-1_2_2\
 
       - name: Run cargo-semver-checks
         continue-on-error: true
         id: semver_checks
         run: |
           cd semver
-          ../bins/cargo-semver-checks.exe semver-checks check-release --manifest-path="../subject/Cargo.toml" 2>&1 | tee output
+          ..\bins\cargo-semver-checks.exe semver-checks check-release --manifest-path="..\subject\Cargo.toml" 2>&1 | tee output
 
       - name: Check whether it failed
         if: steps.semver_checks.outcome != 'failure'
@@ -1254,8 +1254,8 @@ jobs:
         uses: actions/cache/save@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
-          key: ${{ runner.os }}-${{ hashFiles('.rustc-version', 'semver/**/Cargo.lock') }}-${{ github.job }}-rustdoc
-          path: subject/target/semver-checks/cache
+          key: ${{ runner.os }}-${{ hashFiles('.rustc-version', 'semver\**\Cargo.lock') }}-${{ github.job }}-rustdoc
+          path: subject\target\semver-checks\cache
 
   init-release:
     name: Run the release workflow

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "crates-index"
-version = "0.19.3"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950189cd3f794bdfe3d29deb4df4948e2bcd68210d1d3d8e292d4b436de9d178"
+checksum = "4141149a7de0e3619fd1e77b7d1a750f03d109cb8a543ef67d0b6748ff1da666"
 dependencies = [
  "git2",
  "hex",
@@ -395,7 +395,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smol_str",
- "toml 0.6.0",
+ "toml 0.7.2",
 ]
 
 [[package]]
@@ -1562,35 +1562,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb9d890e4dc9298b70f740f615f2e05b9db37dce531f6b24fb77ac993f9f217"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime 0.5.1",
- "toml_edit 0.18.1",
-]
-
-[[package]]
-name = "toml"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7afcae9e3f0fe2c370fd4657108972cbb2fa9db1b9f84849cefd80741b01cb6"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime 0.6.1",
- "toml_edit 0.19.3",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
-dependencies = [
- "serde",
+ "toml_datetime",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1604,19 +1583,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
-dependencies = [
- "indexmap",
- "nom8",
- "serde",
- "serde_spanned",
- "toml_datetime 0.5.1",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6a7712b49e1775fb9a7b998de6635b299237f48b404dde71704f2e0e7f37e5"
@@ -1625,7 +1591,7 @@ dependencies = [
  "nom8",
  "serde",
  "serde_spanned",
- "toml_datetime 0.6.1",
+ "toml_datetime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ ignore = "0.4.18"
 clap-verbosity-flag = "2.0.0"
 log = "0.4.17"
 git2 = { version = "0.16.0", default-features = false }
-crates-index = { version = "0.19.2" }
+crates-index = { version = "0.19.6" }
 human-panic = "1.0.3"
 bugreport = "0.5.0"
 itertools = "0.10.5"


### PR DESCRIPTION
This exposes the issue encountered while testing the new GitHub Action on Windows machine (see current workaround https://github.com/obi1kenobi/cargo-semver-checks-action/pull/21/commits/2d4767cfb82b228e158e7b30b3516859b26f44b4).