### PR TITLE
Pin baseline version for failing CI check.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,7 @@ jobs:
     # due to re-exports that omit generic parameters because the underlying generic type supplies
     # default values for those generics.
     # https://github.com/libp2p/rust-libp2p/pull/3401#issuecomment-1409381365
-    name: 'Semver: libp2p-gossipsub ~0.44.0 + libp2p-request-response 0.23.0'
+    name: 'Semver: libp2p-gossipsub ~0.44.0 + libp2p-request-response ~0.24.0'
     runs-on: ubuntu-latest
     needs:
       - build-binary
@@ -396,7 +396,7 @@ jobs:
       - name: Run semver-checks on libp2p-request-response
         run: |
           cd semver
-          ../bins/cargo-semver-checks semver-checks check-release --manifest-path="../subject/protocols/request-response/Cargo.toml" --verbose
+          ../bins/cargo-semver-checks semver-checks check-release --manifest-path="../subject/protocols/request-response/Cargo.toml" --baseline-version 0.23.0 --verbose
 
       - name: Save rustdoc
         uses: actions/cache/save@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,7 @@ jobs:
     # due to re-exports that omit generic parameters because the underlying generic type supplies
     # default values for those generics.
     # https://github.com/libp2p/rust-libp2p/pull/3401#issuecomment-1409381365
-    name: 'Semver: libp2p-gossipsub 0.44.0 + libp2p-request-response 0.23.0'
+    name: 'Semver: libp2p-gossipsub ~0.44.0 + libp2p-request-response 0.23.0'
     runs-on: ubuntu-latest
     needs:
       - build-binary
@@ -391,7 +391,7 @@ jobs:
       - name: Run semver-checks on libp2p-gossipsub
         run: |
           cd semver
-          ../bins/cargo-semver-checks semver-checks check-release --manifest-path="../subject/protocols/gossipsub/Cargo.toml" --verbose
+          ../bins/cargo-semver-checks semver-checks check-release --manifest-path="../subject/protocols/gossipsub/Cargo.toml" --baseline-version 0.43.0 --verbose
 
       - name: Run semver-checks on libp2p-request-response
         run: |


### PR DESCRIPTION
It seems that `libp2p-gossipsub` uses "forward versioning" where the `Cargo.toml` version reflects a "to-be-released" version rather than an already-released version. A new version of `libp2p-gossipsub` was released ~16h ago, but the `Cargo.toml` at the gitrev in our test suite already has the version number that was just released.

This caused a situation where the baseline version is actually newer than the "current," and an API addition (a type becoming `Sync`) was therefore reported as a breaking change (as the type losing `Sync`).

Pin the baseline version to the version below to avoid this problem.
