### PR TITLE
Add comment explaining why build-binary-windows is separate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,12 @@ jobs:
           key: bins-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
   build-binary-windows:
+    # It could be easily combined into a single job with build-binary using the
+    # matrix strategy, but it is not a good idea. Building the tool on Windows
+    # is much slower and if the matrix strategy is used, there is currently no
+    # supported by GitHub Actions way to depend only on a single case. It means
+    # all semver checks below would have to wait before both binaries are built,
+    # which would make whole CI last longer.
     name: Build binary (Windows)
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
See https://github.com/obi1kenobi/cargo-semver-checks/pull/389#discussion_r1117940544