### PR TITLE
Resilience for cached older rustdoc JSON version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,8 +365,7 @@ jobs:
           export OLD_RUSTDOC_VERSION="$(jq .format_version subject-new/target/semver-checks/cache/registry-libp2p_core-0_37_0.json)"
 
           # Run cargo-semver-checks with the older cached file.
-          cd semver
-          ../bins/cargo-semver-checks semver-checks check-release --manifest-path="../subject-new/core/Cargo.toml" --verbose
+          bins/cargo-semver-checks semver-checks check-release --manifest-path="subject-new/core/Cargo.toml" --verbose
 
           export NEW_RUSTDOC_VERSION="$(jq .format_version subject-new/target/semver-checks/cache/registry-libp2p_core-0_37_0.json)"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,17 +353,26 @@ jobs:
           # Use a separate workspace, to avoid contaminating the cache for Swatinem/rust-cache@v2
           cp -R subject subject-new
 
+          # Show what's in the cache.
+          ls subject-new/target/semver-checks/cache/
+
           # Ensure the previous cached rustdoc file still exists.
           [ -f "subject-new/target/semver-checks/cache/registry-libp2p_core-0_37_0.json" ] || { \
-            echo "could not find libp2p-core cache file: " \
-            set -x; \
-            ls subject-new/target/semver-checks/cache/; \
+            echo "could not find libp2p-core cache file"; \
             exit 1;
           }
+
+          export OLD_RUSTDOC_VERSION="$(jq .format_version subject-new/target/semver-checks/cache/registry-libp2p_core-0_37_0.json)"
 
           # Run cargo-semver-checks with the older cached file.
           cd semver
           ../bins/cargo-semver-checks semver-checks check-release --manifest-path="../subject-new/core/Cargo.toml" --verbose
+
+          export NEW_RUSTDOC_VERSION="$(jq .format_version subject-new/target/semver-checks/cache/registry-libp2p_core-0_37_0.json)"
+
+          # Ensure the cached rustdoc versions were indeed different before and after.
+          set -x
+          [ "$OLD_RUSTDOC_VERSION" = "$NEW_RUSTDOC_VERSION" ] || exit 1
 
   run-on-rust-libp2p:
     # Run cargo-semver-checks on a crate with no semver violations,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,7 @@ jobs:
 
           # Ensure the cached rustdoc versions were indeed different before and after.
           set -x
-          [ "$OLD_RUSTDOC_VERSION" = "$NEW_RUSTDOC_VERSION" ] || exit 1
+          [ "$OLD_RUSTDOC_VERSION" != "$NEW_RUSTDOC_VERSION" ] || exit 1
 
   run-on-rust-libp2p:
     # Run cargo-semver-checks on a crate with no semver violations,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     needs:
       - lint
       - rust-tests
+      - cross-version-caching
       - run-on-rust-libp2p
       - run-on-libp2p-dcutr-relay
       - run-on-libp2p-gossipsub-request-response
@@ -262,6 +263,100 @@ jobs:
           path: bins\
           key: bins-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
+  cross-version-caching:
+    name: 'Caching across rustdoc versions'
+    runs-on: ubuntu-latest
+    needs:
+      - build-binary
+    steps:
+      - name: Checkout cargo-semver-checks
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          path: 'semver'
+
+      - name: Checkout rust-libp2p
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          repository: 'libp2p/rust-libp2p'
+          ref: '3371d7ceab242440216ae9ab99829631fa418f3b'
+          path: 'subject'
+
+      # rust-libp2p requires protobuf-compiler.
+      - name: Install protobuf-compiler
+        run: sudo apt install protobuf-compiler
+
+      - name: Restore binary
+        id: cache-binary
+        uses: actions/cache/restore@v3
+        with:
+          path: bins/
+          key: bins-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          fail-on-cache-miss: true
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.67
+          profile: minimal
+          override: true
+
+      - shell: bash
+        run: |
+          rustc --version | tee .rustc-version
+
+      - name: Restore rustdoc
+        id: cache
+        uses: actions/cache/restore@v3
+        with:
+          key: cross-version-caching-${{ runner.os }}-${{ hashFiles('.rustc-version', 'semver/**/Cargo.lock') }}-${{ github.job }}-rustdoc
+          path: subject/target/semver-checks/cache
+
+      - name: Restore cargo index and rustdoc target dir
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            subject/target/semver-checks/local-libp2p_core-0_37_0
+
+      # If we failed to set up the cache, set it up now.
+      - name: Run semver-checks
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          cd semver
+          ../bins/cargo-semver-checks semver-checks check-release --manifest-path="../subject/core/Cargo.toml" --verbose
+
+      - name: Save rustdoc
+        uses: actions/cache/save@v3
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          key: cross-version-caching-${{ runner.os }}-${{ hashFiles('.rustc-version', 'semver/**/Cargo.lock') }}-${{ github.job }}-rustdoc
+          path: subject/target/semver-checks/cache
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.68
+          profile: minimal
+          override: true
+
+      - name: Check with older rustdoc version cached
+        run: |
+          # Use a separate workspace, to avoid contaminating the cache for Swatinem/rust-cache@v2
+          cp -R subject subject-new
+
+          # Ensure the previous cached rustdoc file still exists.
+          [ -f "subject-new/target/semver-checks/cache/registry-libp2p_core-0_37_0.json" ] || { \
+            echo "could not find libp2p-core cache file: " \
+            set -x; \
+            ls subject-new/target/semver-checks/cache/; \
+            exit 1;
+          }
+
+          # Run cargo-semver-checks with the older cached file.
+          cd semver
+          ../bins/cargo-semver-checks semver-checks check-release --manifest-path="../subject-new/core/Cargo.toml" --verbose
+
   run-on-rust-libp2p:
     # Run cargo-semver-checks on a crate with no semver violations,
     # to make sure there are no false-positives.
@@ -269,7 +364,7 @@ jobs:
     # cargo-semver-checks previously reported a false-positive here,
     # since an enum variant in the crate was included by a feature:
     # https://github.com/obi1kenobi/cargo-semver-check/issues/147
-    name: 'Semver: rust-libp2p 0.47.0'
+    name: 'Semver: libp2p-core 0.37.0'
     runs-on: ubuntu-latest
     needs:
       - build-binary
@@ -322,7 +417,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
-            subject/target/semver-checks/local-libp2p_core-0_47_0
+            subject/target/semver-checks/local-libp2p_core-0_37_0
 
       - name: Run semver-checks
         run: |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,13 +461,21 @@ fn generate_versioned_crates(
                 format_args!("stale cached baseline rustdoc for {crate_name}"),
             )?;
             std::fs::remove_file(baseline_path)?;
-            let baseline_path =
-                get_baseline_rustdoc_path(config, rustdoc_cmd, baseline_loader, crate_name, version)?;
+            let baseline_path = get_baseline_rustdoc_path(
+                config,
+                rustdoc_cmd,
+                baseline_loader,
+                crate_name,
+                version,
+            )?;
             baseline_crate = load_rustdoc(&baseline_path)?;
 
-            assert_eq!(baseline_crate.version(), current_rustdoc_version,
+            assert_eq!(
+                baseline_crate.version(),
+                current_rustdoc_version,
                 "Deleting and regenerating the baseline JSON file did not resolve the rustdoc \
-                version mismatch.");
+                version mismatch."
+            );
         }
 
         baseline_crate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ use itertools::Itertools;
 use rustdoc_cmd::RustdocCommand;
 use semver::Version;
 use std::collections::HashSet;
-use std::fs;
 use std::path::{Path, PathBuf};
 
 pub use config::GlobalConfig;
@@ -442,11 +441,48 @@ fn generate_versioned_crates(
     )?;
     let current_crate = load_rustdoc(&current_path)?;
 
-    // The process of generating baseline rustdoc can overwrite
-    // the already-generated rustdoc of the current crate.
-    // For example, this happens when target-dir is specified in `.cargo/config.toml`.
-    // That's the reason why we're immediately loading the rustdocs into memory.
-    // See: https://github.com/obi1kenobi/cargo-semver-checks/issues/269
+    let current_rustdoc_version = current_crate.version();
+
+    let baseline_path =
+        get_baseline_rustdoc_path(config, rustdoc_cmd, baseline_loader, crate_name, version)?;
+    let baseline_crate = {
+        let mut baseline_crate = load_rustdoc(&baseline_path)?;
+
+        // The baseline rustdoc JSON may have been cached; ensure its rustdoc version matches
+        // the version emitted by the currently-installed toolchain.
+        //
+        // The baseline and current rustdoc JSONs should have the same version.
+        // If the baseline rustdoc version doesn't match, delete the cached baseline and rebuild it.
+        //
+        // Fix for: https://github.com/obi1kenobi/cargo-semver-checks/issues/415
+        if baseline_crate.version() != current_rustdoc_version {
+            config.shell_status(
+                "Removing",
+                format_args!("stale cached baseline rustdoc for {crate_name}"),
+            )?;
+            std::fs::remove_file(baseline_path)?;
+            let baseline_path =
+                get_baseline_rustdoc_path(config, rustdoc_cmd, baseline_loader, crate_name, version)?;
+            baseline_crate = load_rustdoc(&baseline_path)?;
+
+            assert_eq!(baseline_crate.version(), current_rustdoc_version,
+                "Deleting and regenerating the baseline JSON file did not resolve the rustdoc \
+                version mismatch.");
+        }
+
+        baseline_crate
+    };
+
+    Ok((current_crate, baseline_crate))
+}
+
+fn get_baseline_rustdoc_path(
+    config: &mut GlobalConfig,
+    rustdoc_cmd: &RustdocCommand,
+    baseline_loader: &dyn rustdoc_gen::RustdocGenerator,
+    crate_name: &str,
+    version: Option<&Version>,
+) -> anyhow::Result<PathBuf> {
     let baseline_path = baseline_loader.load_rustdoc(
         config,
         rustdoc_cmd,
@@ -457,9 +493,7 @@ fn generate_versioned_crates(
             },
         },
     )?;
-    let baseline_crate = load_rustdoc(&baseline_path)?;
-
-    Ok((current_crate, baseline_crate))
+    Ok(baseline_path)
 }
 
 fn manifest_path(project_root: &Path) -> anyhow::Result<PathBuf> {
@@ -507,7 +541,7 @@ fn get_cache_dir() -> anyhow::Result<PathBuf> {
     let project_dirs =
         ProjectDirs::from("", "", "cargo-semver-checks").context("can't determine project dirs")?;
     let cache_dir = project_dirs.cache_dir();
-    fs::create_dir_all(cache_dir).context("can't create cache dir")?;
+    std::fs::create_dir_all(cache_dir).context("can't create cache dir")?;
     Ok(cache_dir.to_path_buf())
 }
 


### PR DESCRIPTION
Ensure that cached rustdoc JSON from an older Rust toolchain version gets transparently overwritten with a newer version, instead of causing a crash.
![image](https://user-images.githubusercontent.com/2348618/227037713-a441fb7a-6668-4f50-88e8-ce291c3a8218.png)
