### PR TITLE
Link to the semver non-exhaustive section in the cargo reference.

### DIFF
--- a/src/lints/enum_marked_non_exhaustive.ron
+++ b/src/lints/enum_marked_non_exhaustive.ron
@@ -4,13 +4,7 @@ SemverQuery(
     description: "An exhaustive enum has been marked #[non_exhaustive].",
     reference: Some("An exhaustive enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile."),
     required_update: Major,
-
-    // TODO: Change the reference link once this cargo docs PR merges:
-    // https://github.com/rust-lang/cargo/pull/10877
-    //
-    // Change to this link:
-    // https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
-    reference_link: Some("https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute"),
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive"),
     query: r#"
     {
         CrateDiff {

--- a/src/lints/struct_marked_non_exhaustive.ron
+++ b/src/lints/struct_marked_non_exhaustive.ron
@@ -4,13 +4,7 @@ SemverQuery(
     description: "An exhaustive struct has been marked #[non_exhaustive].",
     reference: Some("An exhaustive struct has been marked #[non_exhaustive] making it no longer constructible using a struct literal outside its crate."),
     required_update: Major,
-
-    // TODO: Change the reference link once this cargo docs PR merges:
-    // https://github.com/rust-lang/cargo/pull/10877
-    //
-    // Change to this link:
-    // https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
-    reference_link: Some("https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute"),
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive"),
     query: r#"
     {
         CrateDiff {

--- a/src/lints/variant_marked_non_exhaustive.ron
+++ b/src/lints/variant_marked_non_exhaustive.ron
@@ -4,13 +4,7 @@ SemverQuery(
     description: "An exhaustive enum variant has been marked #[non_exhaustive].",
     reference: Some("An exhaustive enum variant has been marked #[non_exhaustive], preventing it from being constructed using a literal from outside its own crate."),
     required_update: Major,
-
-    // TODO: Change the reference link once this cargo docs PR merges:
-    // https://github.com/rust-lang/cargo/pull/10877
-    //
-    // Change to this link:
-    // https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
-    reference_link: Some("https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute"),
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive"),
     query: r#"
     {
         CrateDiff {


### PR DESCRIPTION
https://github.com/rust-lang/cargo/pull/10877 is now merged.