### PR TITLE
Refer to v2 of the action in README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1448,9 +1448,4 @@ jobs:
           persist-credentials: false
 
       - name: Check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v1
-        with:
-          # cargo-semver-checks currently doesn't have a --lib target,
-          # so we explicitly ask for the binary target to be checked instead.
-          # For library crates, you almost always want the default `--lib` value here.
-          crate-target: --bin cargo-semver-checks
+        uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ cargo semver-checks check-release
 Or use as a [GitHub Action](https://github.com/obi1kenobi/cargo-semver-checks-action) (used in .github/workflows/ci.yml in this repo):
 ```yaml
 - name: Check semver
-  uses: obi1kenobi/cargo-semver-checks-action@v1
+  uses: obi1kenobi/cargo-semver-checks-action@v2
 ```
 
 ![image](https://user-images.githubusercontent.com/2348618/180127698-240e4bed-5581-4cbd-9f47-038affbc4a3e.png)


### PR DESCRIPTION
Since the new action is finally released, it would be great to recommend it officially instead of referring to v1 ;)

Besides that, as cargo-semver-checks now include a library target, we can use the action to run checks on it.