### PR TITLE
Improved error message when no baseline version found on crates.io

### DIFF
--- a/src/rustdoc_gen.rs
+++ b/src/rustdoc_gen.rs
@@ -586,7 +586,7 @@ impl RustdocFromRegistry {
         let mut index = crates_index::Index::new_cargo_default()?;
 
         config.shell_status("Updating", "index")?;
-        while need_retry(index.update()).map_err(human_readable_message)? {
+        while need_retry(index.update())? {
             config.shell_status("Blocking", "waiting for lock on registry index")?;
             std::thread::sleep(REGISTRY_BACKOFF);
         }
@@ -709,35 +709,18 @@ impl RustdocGenerator for RustdocFromRegistry {
 
 const REGISTRY_BACKOFF: std::time::Duration = std::time::Duration::from_secs(1);
 
-/// Change the error message to be more human readable.
-fn human_readable_message(err: crates_index::Error) -> anyhow::Error {
-    if let crates_index::Error::Git(ref err) = err {
-        if err.class() == git2::ErrorClass::Index && err.code() == git2::ErrorCode::NotFound {
-            return anyhow::anyhow!(
-                "{}. The registry is crates.io. \
-        Crates published on a custom registry cannot be checked \
-        using default settings, \
-        see https://github.com/obi1kenobi/cargo-semver-checks/issues/166",
-                err
-            );
-        }
-    }
-
-    err.into()
-}
-
 /// Check if we need to retry retrieving the Index.
-fn need_retry(res: Result<(), crates_index::Error>) -> Result<bool, crates_index::Error> {
+fn need_retry(res: Result<(), crates_index::Error>) -> anyhow::Result<bool> {
     match res {
         Ok(()) => Ok(false),
         Err(crates_index::Error::Git(err)) => {
             if err.class() == git2::ErrorClass::Index && err.code() == git2::ErrorCode::Locked {
                 Ok(true)
             } else {
-                Err(crates_index::Error::Git(err))
+                Err(crates_index::Error::Git(err).into())
             }
         }
-        Err(err) => Err(err),
+        Err(err) => Err(err.into()),
     }
 }
 

--- a/src/rustdoc_gen.rs
+++ b/src/rustdoc_gen.rs
@@ -658,18 +658,15 @@ impl RustdocGenerator for RustdocFromRegistry {
         rustdoc_cmd: &RustdocCommand,
         crate_data: CrateDataForRustdoc,
     ) -> anyhow::Result<PathBuf> {
-        let crate_ = self
-            .index
-            .crate_(crate_data.name)
-            .with_context(|| {
-                anyhow::format_err!(
-                    "{} not found in registry. The registry is crates.io. \
+        let crate_ = self.index.crate_(crate_data.name).with_context(|| {
+            anyhow::format_err!(
+                "{} not found in registry. The registry is crates.io. \
         Crates published on a custom registry cannot be checked \
         using default settings, \
         see https://github.com/obi1kenobi/cargo-semver-checks/issues/166",
-                    crate_data.name
-                )
-            })?;
+                crate_data.name
+            )
+        })?;
 
         let base_version = if let Some(base) = self.version.as_ref() {
             base.to_string()

--- a/src/rustdoc_gen.rs
+++ b/src/rustdoc_gen.rs
@@ -661,7 +661,15 @@ impl RustdocGenerator for RustdocFromRegistry {
         let crate_ = self
             .index
             .crate_(crate_data.name)
-            .with_context(|| anyhow::format_err!("{} not found in registry", crate_data.name))?;
+            .with_context(|| {
+                anyhow::format_err!(
+                    "{} not found in registry. The registry is crates.io. \
+        Crates published on a custom registry cannot be checked \
+        using default settings, \
+        see https://github.com/obi1kenobi/cargo-semver-checks/issues/166",
+                    crate_data.name
+                )
+            })?;
 
         let base_version = if let Some(base) = self.version.as_ref() {
             base.to_string()

--- a/src/rustdoc_gen.rs
+++ b/src/rustdoc_gen.rs
@@ -660,10 +660,9 @@ impl RustdocGenerator for RustdocFromRegistry {
     ) -> anyhow::Result<PathBuf> {
         let crate_ = self.index.crate_(crate_data.name).with_context(|| {
             anyhow::format_err!(
-                "{} not found in registry. The registry is crates.io. \
-        Crates published on a custom registry cannot be checked \
-        using default settings, \
-        see https://github.com/obi1kenobi/cargo-semver-checks/issues/166",
+                "{} not found in registry (crates.io). \
+       For workarounds check \
+        https://github.com/obi1kenobi/cargo-semver-checks#does-the-crate-im-checking-have-to-be-published-on-cratesio",
                 crate_data.name
             )
         })?;

--- a/src/rustdoc_gen.rs
+++ b/src/rustdoc_gen.rs
@@ -661,7 +661,7 @@ impl RustdocGenerator for RustdocFromRegistry {
         let crate_ = self.index.crate_(crate_data.name).with_context(|| {
             anyhow::format_err!(
                 "{} not found in registry (crates.io). \
-       For workarounds check \
+        For workarounds check \
         https://github.com/obi1kenobi/cargo-semver-checks#does-the-crate-im-checking-have-to-be-published-on-cratesio",
                 crate_data.name
             )


### PR DESCRIPTION
Fixes https://github.com/obi1kenobi/cargo-semver-checks/issues/183. 

The new error message now is:

```
Error: tinylang not found in registry. The registry is crates.io. Crates published on a custom registry cannot be checked using default settings, see https://github.com/obi1kenobi/cargo-semver-checks/issues/166
``` 

Where `tinylang` is the crate I tested the program. 

Let me know how you want to change the error message :)