### PR TITLE
New lint: trait removed supertrait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f83bc2e401ed041b7057345ebc488c005efa0341d5541ce7004d30458d0090b"
+checksum = "599aa35200ffff8f04c1925aa1acc92fa2e08874379ef42e210a80e527e60838"
 dependencies = [
  "serde",
  "toml 0.7.4",
@@ -330,9 +330,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbc37d37da9e5bce8173f3a41b71d9bf3c674deebbaceacd0ebdabde76efb03"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.0"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
+checksum = "ca8f255e4b8027970e78db75e78831229c9815fdbfa67eb1a1b777a62e24b4a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.0"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
+checksum = "acd4f3c17c83b0ba34ffbc4f8bbd74f079413f747f84a6f89292f138057e36ab"
 dependencies = [
  "anstream",
  "anstyle",
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.0"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -580,9 +580,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -599,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -873,9 +873,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libgit2-sys"
@@ -910,9 +910,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "maplit"
@@ -965,18 +965,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl-probe"
@@ -986,9 +986,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.25.3+1.1.1t"
+version = "111.26.0+1.1.1u"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924757a6a226bf60da5f7dd0311a34d2b52283dd82ddeb103208ddc66362f80c"
+checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
 dependencies = [
  "cc",
 ]
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
@@ -1109,9 +1109,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -1169,11 +1169,11 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick 1.0.2",
  "memchr",
  "regex-syntax",
 ]
@@ -1262,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
  "bitflags",
  "errno",
@@ -1306,18 +1306,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1560,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "23.5.0"
+version = "23.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c482f7edb29027511cc68bd965b9af9582d657dea80b8b0da10314f365e05865"
+checksum = "75fc11a396935a6031e5d7355a2e87cf7dc05d4aec61e075133caab97f9dc2c0"
 dependencies = [
  "rustdoc-types 0.19.0",
  "trustfall",
@@ -1570,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "24.4.0"
+version = "24.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847abdcfad10f6374c29009aae141f47740158f339436c9def331427441a7223"
+checksum = "13e0b8bed065f0ec0a604364ebab0aea9883f9ceffa99ab77ce7021d6c7c1bc0"
 dependencies = [
  "rustdoc-types 0.20.0",
  "trustfall",
@@ -1580,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "26.1.0"
+version = "26.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebef3d4d48966c04ad6c7ba62a2199acee6bf82517dea21cbf1283f48b51c1a"
+checksum = "30861fc78e0fc9d71387ca7b317ef0d7f72801ab3e2af687ca8e779cc3140f5a"
 dependencies = [
  "rustdoc-types 0.22.0",
  "trustfall",
@@ -1628,9 +1628,9 @@ dependencies = [
  "serde",
  "serde_json",
  "trustfall",
- "trustfall-rustdoc-adapter 23.5.0",
- "trustfall-rustdoc-adapter 24.4.0",
- "trustfall-rustdoc-adapter 26.1.0",
+ "trustfall-rustdoc-adapter 23.5.1",
+ "trustfall-rustdoc-adapter 24.4.1",
+ "trustfall-rustdoc-adapter 26.1.1",
 ]
 
 [[package]]
@@ -1668,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/src/lints/trait_removed_supertrait.ron
+++ b/src/lints/trait_removed_supertrait.ron
@@ -1,7 +1,7 @@
 SemverQuery(
     id: "trait_removed_supertrait",
     human_readable_name: "supertrait removed or renamed",
-    description: "It is a breaking change to loosen generic bounds on a type since this can break users expecting the tightened bounds.",
+    description: "Removing a supertrait bound is a breaking change, since users of the trait can no longer assume it can also be used like its supertrait.",
     required_update: Major,
     reference_link: None,
     query: r#"
@@ -55,6 +55,6 @@ SemverQuery(
         "public": "public",
         "zero": 0,
     },
-    error_message: "A supertrait was removed from a trait.",
+    error_message: "A supertrait was removed from a trait, users of the trait can no longer assume it can also be used like its supertrait.",
     per_result_error_template: Some("supertrait {{join \"::\" trait_path}} of trait {{name}} in file {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/lints/trait_removed_supertrait.ron
+++ b/src/lints/trait_removed_supertrait.ron
@@ -1,0 +1,62 @@
+SemverQuery(
+    id: "trait_removed_supertrait",
+    human_readable_name: "supertrait removed or renamed",
+    description: "It is a breaking change to loosen generic bounds on a type since this can break users expecting the tightened bounds.",
+    required_update: Major,
+    reference_link: None,
+    query: r#"{
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        importable_path {
+                            path @output @tag
+                        }
+
+
+                        supertrait {
+                            trait {
+                                importable_path {
+                                    trait_path: path @output @tag
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @output
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                        }
+
+                        supertrait @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            trait {
+                                importable_path {
+                                    path @filter(op: "=", value: ["%trait_path"])
+                                }
+                            }
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "zero": 0,
+    },
+    error_message: "A supertrait was removed from a trait.",
+    per_result_error_template: Some("supertrait {{trait_path}} for trait {{name}} in file {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/lints/trait_removed_supertrait.ron
+++ b/src/lints/trait_removed_supertrait.ron
@@ -3,7 +3,7 @@ SemverQuery(
     human_readable_name: "supertrait removed or renamed",
     description: "Removing a supertrait bound is a breaking change, since users of the trait can no longer assume it can also be used like its supertrait.",
     required_update: Major,
-    reference_link: None,
+    reference_link: Some("https://doc.rust-lang.org/reference/items/traits.html#supertraits"),
     query: r#"
     {
         CrateDiff {

--- a/src/lints/trait_removed_supertrait.ron
+++ b/src/lints/trait_removed_supertrait.ron
@@ -58,5 +58,5 @@ SemverQuery(
         "zero": 0,
     },
     error_message: "A supertrait was removed from a trait.",
-    per_result_error_template: Some("supertrait {{trait_path}} for trait {{name}} in file {{span_filename}}:{{span_begin_line}}"),
+    per_result_error_template: Some("supertrait {{join \"::\" trait_path}} of trait {{name}} in file {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/lints/trait_removed_supertrait.ron
+++ b/src/lints/trait_removed_supertrait.ron
@@ -55,6 +55,6 @@ SemverQuery(
         "public": "public",
         "zero": 0,
     },
-    error_message: "A supertrait was removed from a trait, users of the trait can no longer assume it can also be used like its supertrait.",
+    error_message: "A supertrait was removed from a trait. Users of the trait can no longer assume it can also be used like its supertrait.",
     per_result_error_template: Some("supertrait {{join \"::\" trait_path}} of trait {{name}} in file {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/lints/trait_removed_supertrait.ron
+++ b/src/lints/trait_removed_supertrait.ron
@@ -13,8 +13,6 @@ SemverQuery(
                         importable_path {
                             path @output @tag
                         }
-
-
                         supertrait {
                             trait {
                                 importable_path {

--- a/src/lints/trait_removed_supertrait.ron
+++ b/src/lints/trait_removed_supertrait.ron
@@ -4,7 +4,8 @@ SemverQuery(
     description: "It is a breaking change to loosen generic bounds on a type since this can break users expecting the tightened bounds.",
     required_update: Major,
     reference_link: None,
-    query: r#"{
+    query: r#"
+    {
         CrateDiff {
             baseline {
                 item {

--- a/src/lints/trait_removed_supertrait.ron
+++ b/src/lints/trait_removed_supertrait.ron
@@ -47,7 +47,6 @@ SemverQuery(
                             filename @output
                             begin_line @output
                         }
-
                     }
                 }
             }

--- a/src/query.rs
+++ b/src/query.rs
@@ -504,4 +504,5 @@ add_lints!(
     variant_marked_non_exhaustive,
     enum_tuple_variant_field_missing,
     enum_tuple_variant_field_added,
+    trait_removed_supertrait,
 );

--- a/test_crates/trait_removed_supertrait/new/Cargo.toml
+++ b/test_crates/trait_removed_supertrait/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_removed_supertrait"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_removed_supertrait/new/src/lib.rs
+++ b/test_crates/trait_removed_supertrait/new/src/lib.rs
@@ -1,5 +1,17 @@
 pub trait SuperTrait {}
+pub trait SuperTrait2 {}
+pub trait GenericSuperTrait<T> {}
 
-pub trait BaseTrait {}
+pub trait RemovingSingleTrait {}
+pub trait RemovingOneTraitOfMultiple : SuperTrait  {}
+pub trait RemovingOneWithGenerics<T> : SuperTrait  {}
+pub trait RemovingOneWithGenericsOnTheSuperTrait<T> : SuperTrait  {}
+pub trait RemovingTraitAndLifetime<'a> : SuperTrait {}
+pub trait RemovingMultiple {}
 
 pub trait CorrectTrait : SuperTrait {}
+pub trait CorrectTraitMultipleSuperTraits : SuperTrait + SuperTrait2 {}
+pub trait CorrectTraitRemovingLifetime<'a> : SuperTrait {}
+pub trait CorrectTraitChangingTheGenericTypeBreaking : GenericSuperTrait<String> {}
+pub trait CorrectTraitChangingTheGenericTypeNonBreaking : GenericSuperTrait<i64> {}
+pub trait NotPresentOnPreviousVersion {}

--- a/test_crates/trait_removed_supertrait/new/src/lib.rs
+++ b/test_crates/trait_removed_supertrait/new/src/lib.rs
@@ -1,0 +1,5 @@
+pub trait SuperTrait {}
+
+pub trait BaseTrait {}
+
+pub trait CorrectTrait : SuperTrait {}

--- a/test_crates/trait_removed_supertrait/old/Cargo.toml
+++ b/test_crates/trait_removed_supertrait/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_removed_supertrait"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_removed_supertrait/old/src/lib.rs
+++ b/test_crates/trait_removed_supertrait/old/src/lib.rs
@@ -4,9 +4,9 @@ pub trait GenericSuperTrait<T> {}
 
 // Lint should warn us about
 pub trait RemovingSingleTrait : SuperTrait {}
-pub trait RemovingOneTraitOfMultiple : SuperTrait + SuperTrait2  {}
-pub trait RemovingOneWithGenerics<T> : SuperTrait + SuperTrait2  {}
-pub trait RemovingOneWithGenericsOnTheSuperTrait<T> : SuperTrait + GenericSuperTrait<T>  {}
+pub trait RemovingOneTraitOfMultiple : SuperTrait + SuperTrait2 {}
+pub trait RemovingOneWithGenerics<T> : SuperTrait + SuperTrait2 {}
+pub trait RemovingOneWithGenericsOnTheSuperTrait<T> : SuperTrait + GenericSuperTrait<T> {}
 pub trait RemovingTraitAndLifetime<'a> : SuperTrait + SuperTrait2 + 'a {}
 pub trait RemovingMultiple: SuperTrait + SuperTrait2 {}
 

--- a/test_crates/trait_removed_supertrait/old/src/lib.rs
+++ b/test_crates/trait_removed_supertrait/old/src/lib.rs
@@ -1,0 +1,5 @@
+pub trait SuperTrait {}
+
+pub trait BaseTrait : SuperTrait {}
+
+pub trait CorrectTrait : SuperTrait {}

--- a/test_crates/trait_removed_supertrait/old/src/lib.rs
+++ b/test_crates/trait_removed_supertrait/old/src/lib.rs
@@ -1,5 +1,18 @@
 pub trait SuperTrait {}
+pub trait SuperTrait2 {}
+pub trait GenericSuperTrait<T> {}
 
-pub trait BaseTrait : SuperTrait {}
+// Lint should warn us about
+pub trait RemovingSingleTrait : SuperTrait {}
+pub trait RemovingOneTraitOfMultiple : SuperTrait + SuperTrait2  {}
+pub trait RemovingOneWithGenerics<T> : SuperTrait + SuperTrait2  {}
+pub trait RemovingOneWithGenericsOnTheSuperTrait<T> : SuperTrait + GenericSuperTrait<T>  {}
+pub trait RemovingTraitAndLifetime<'a> : SuperTrait + SuperTrait2 + 'a {}
+pub trait RemovingMultiple: SuperTrait + SuperTrait2 {}
 
+// Lint should ignore
 pub trait CorrectTrait : SuperTrait {}
+pub trait CorrectTraitMultipleSuperTraits : SuperTrait + SuperTrait2 {}
+pub trait CorrectTraitRemovingLifetime<'a> : SuperTrait + 'a {}
+pub trait CorrectTraitChangingTheGenericTypeBreaking : GenericSuperTrait<i64> {}
+pub trait CorrectTraitChangingTheGenericTypeNonBreaking<T> : GenericSuperTrait<T> where T: Into<i64> {}

--- a/test_outputs/trait_removed_supertrait.output.ron
+++ b/test_outputs/trait_removed_supertrait.output.ron
@@ -1,0 +1,18 @@
+{
+    "./test_crates/trait_removed_supertrait/": [
+        {
+            "name": String("BaseTrait"),
+            "path": List([
+                String("trait_removed_supertrait"),
+                String("BaseTrait"),
+            ]),
+            "span_begin_line": Uint64(3),
+            "span_filename": String("src/lib.rs"),
+            "trait_path": List([
+                String("trait_removed_supertrait"),
+                String("SuperTrait"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+    ],
+}

--- a/test_outputs/trait_removed_supertrait.output.ron
+++ b/test_outputs/trait_removed_supertrait.output.ron
@@ -73,8 +73,8 @@
         {
             "name": String("RemovingMultiple"),
             "path": List([
-            String("trait_removed_supertrait"),
-            String("RemovingMultiple"),
+                String("trait_removed_supertrait"),
+                String("RemovingMultiple"),
             ]),
             "span_begin_line": Uint64(10),
             "span_filename": String("src/lib.rs"),

--- a/test_outputs/trait_removed_supertrait.output.ron
+++ b/test_outputs/trait_removed_supertrait.output.ron
@@ -93,8 +93,8 @@
             "span_begin_line": Uint64(10),
             "span_filename": String("src/lib.rs"),
             "trait_path": List([
-            String("trait_removed_supertrait"),
-            String("SuperTrait2"),
+                String("trait_removed_supertrait"),
+                String("SuperTrait2"),
             ]),
             "visibility_limit": String("public"),
         },

--- a/test_outputs/trait_removed_supertrait.output.ron
+++ b/test_outputs/trait_removed_supertrait.output.ron
@@ -87,8 +87,8 @@
         {
             "name": String("RemovingMultiple"),
             "path": List([
-            String("trait_removed_supertrait"),
-            String("RemovingMultiple"),
+                String("trait_removed_supertrait"),
+                String("RemovingMultiple"),
             ]),
             "span_begin_line": Uint64(10),
             "span_filename": String("src/lib.rs"),

--- a/test_outputs/trait_removed_supertrait.output.ron
+++ b/test_outputs/trait_removed_supertrait.output.ron
@@ -1,16 +1,100 @@
 {
     "./test_crates/trait_removed_supertrait/": [
         {
-            "name": String("BaseTrait"),
+            "name": String("RemovingSingleTrait"),
             "path": List([
                 String("trait_removed_supertrait"),
-                String("BaseTrait"),
+                String("RemovingSingleTrait"),
             ]),
-            "span_begin_line": Uint64(3),
+            "span_begin_line": Uint64(5),
             "span_filename": String("src/lib.rs"),
             "trait_path": List([
                 String("trait_removed_supertrait"),
                 String("SuperTrait"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("RemovingOneTraitOfMultiple"),
+            "path": List([
+                String("trait_removed_supertrait"),
+                String("RemovingOneTraitOfMultiple"),
+            ]),
+            "span_begin_line": Uint64(6),
+            "span_filename": String("src/lib.rs"),
+            "trait_path": List([
+                String("trait_removed_supertrait"),
+                String("SuperTrait2"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("RemovingOneWithGenerics"),
+            "path": List([
+                String("trait_removed_supertrait"),
+                String("RemovingOneWithGenerics"),
+            ]),
+            "span_begin_line": Uint64(7),
+            "span_filename": String("src/lib.rs"),
+            "trait_path": List([
+                String("trait_removed_supertrait"),
+                String("SuperTrait2"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("RemovingOneWithGenericsOnTheSuperTrait"),
+            "path": List([
+                String("trait_removed_supertrait"),
+                String("RemovingOneWithGenericsOnTheSuperTrait"),
+            ]),
+            "span_begin_line": Uint64(8),
+            "span_filename": String("src/lib.rs"),
+            "trait_path": List([
+                String("trait_removed_supertrait"),
+                String("GenericSuperTrait"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("RemovingTraitAndLifetime"),
+            "path": List([
+                String("trait_removed_supertrait"),
+                String("RemovingTraitAndLifetime"),
+            ]),
+            "span_begin_line": Uint64(9),
+            "span_filename": String("src/lib.rs"),
+            "trait_path": List([
+                String("trait_removed_supertrait"),
+                String("SuperTrait2"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("RemovingMultiple"),
+            "path": List([
+            String("trait_removed_supertrait"),
+            String("RemovingMultiple"),
+            ]),
+            "span_begin_line": Uint64(10),
+            "span_filename": String("src/lib.rs"),
+            "trait_path": List([
+            String("trait_removed_supertrait"),
+            String("SuperTrait"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("RemovingMultiple"),
+            "path": List([
+            String("trait_removed_supertrait"),
+            String("RemovingMultiple"),
+            ]),
+            "span_begin_line": Uint64(10),
+            "span_filename": String("src/lib.rs"),
+            "trait_path": List([
+            String("trait_removed_supertrait"),
+            String("SuperTrait2"),
             ]),
             "visibility_limit": String("public"),
         },

--- a/test_outputs/trait_removed_supertrait.output.ron
+++ b/test_outputs/trait_removed_supertrait.output.ron
@@ -79,8 +79,8 @@
             "span_begin_line": Uint64(10),
             "span_filename": String("src/lib.rs"),
             "trait_path": List([
-            String("trait_removed_supertrait"),
-            String("SuperTrait"),
+                String("trait_removed_supertrait"),
+                String("SuperTrait"),
             ]),
             "visibility_limit": String("public"),
         },


### PR DESCRIPTION
Resolves #232

Besides the new lint, this PR also includes a newer version of trustfall-rustdoc-adapter because we need the `supertrait` field.