### PR TITLE
Ensure missing span_filename and span_begin_line shows user friendly error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,14 @@ Now it's time to fill in these files!
   removal of public fields were to report that a struct was removed.
   Struct removal has its own lint, so there's no reason to also report that
   the removed struct also had its fields removed.
+- Note that your lint must output `span_filename` and `span_begin_line` for it
+  to be a valid lint. The pattern we commonly use is:
+  ```
+  span_: span @optional {
+    filename @output
+    begin_line @output
+  }
+  ```
 - Re-run [`./scripts/regenerate_test_rustdocs.sh`](https://github.com/obi1kenobi/cargo-semver-checks/tree/main/scripts/regenerate_test_rustdocs.sh)
   to generate rustdoc JSON files for your new test crates.
 
@@ -184,6 +192,22 @@ Actual output:
     ],
 }
 ```
+
+If your lint fails with the following error:
+```
+---- query::tests_lints::struct_missing stdout ----
+thread 'query::tests_lints::struct_missing' panicked at 'a valid query must have span_filename', src/query.rs:390:22
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+```
+
+It likely means that your lint does not specify the `span_filename` and `span_begin_line` of where the error occurs. To fix this, add the following to the part of query that catches the error:
+```
+span_: span @optional {
+  filename @output
+  begin_line @output
+}
+```
+
 
 Inspect the "actual" output:
 - Does it report the semver issue your lint was supposed to catch? If not, the lint query

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,7 +212,7 @@ Congrats on the new lint!
 If your lint fails with an error similar to the following:
 ```
 ---- query::tests_lints::enum_missing stdout ----
-thread 'query::tests_lints::enum_missing' panicked at 'A valid query must output both span_filename and span_begin_line. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for how to do this.', src/query.rs:395:26
+thread 'query::tests_lints::enum_missing' panicked at 'A valid query must output both `span_filename` and `span_begin_line`. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for how to do this.', src/query.rs:395:26
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,22 +193,6 @@ Actual output:
 }
 ```
 
-If your lint fails with the following error:
-```
----- query::tests_lints::struct_missing stdout ----
-thread 'query::tests_lints::struct_missing' panicked at 'a valid query must have span_filename', src/query.rs:390:22
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-```
-
-It likely means that your lint does not specify the `span_filename` and `span_begin_line` of where the error occurs. To fix this, add the following to the part of query that catches the error:
-```
-span_: span @optional {
-  filename @output
-  begin_line @output
-}
-```
-
-
 Inspect the "actual" output:
 - Does it report the semver issue your lint was supposed to catch? If not, the lint query
   or the test crates' code may need to be tweaked.
@@ -223,7 +207,24 @@ the "actual" output, then re-run `cargo test` and make sure everything passes.
 
 Congrats on the new lint!
 
-### Troubleshooting: Other lints' tests failed too
+### Troubleshooting
+#### A valid query must output span_filename and/or span_begin_line
+If your lint fails with an error similar to the following:
+```
+---- query::tests_lints::enum_missing stdout ----
+thread 'query::tests_lints::enum_missing' panicked at 'A valid query must output both span_filename and span_begin_line. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for how to do this.', src/query.rs:395:26
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+```
+
+It likely means that your lint does not specify the `span_filename` and `span_begin_line` of where the error occurs. To fix this, add the following to the part of query that catches the error:
+```
+span_: span @optional {
+  filename @output
+  begin_line @output
+}
+```
+
+#### Other lints' tests failed too
 
 This is not always a problem! In process of testing a lint, it's frequently desirable to include
 test code that contains a related semver issue in order to ensure the lint differentiates between

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,14 @@ We'll use the [`scripts/make_new_lint.sh`](https://github.com/obi1kenobi/cargo-s
 
 Now it's time to fill in these files!
 - Define the lint in `src/lints/<lint_name>.ron`.
+- Make sure your lint outputs `span_filename` and `span_begin_line` for it
+  to be a valid lint. The pattern we commonly use is:
+  ```
+  span_: span @optional {
+    filename @output
+    begin_line @output
+  }
+  ```
 - Demonstrate the semver issue your lint is looking for by adding suitable code in
   the `test_crates/<lint_name>/old` and `test_crates/<lint_name>/new` crates.
 - Add code to the test crates that aims to catch for false-positives
@@ -146,14 +154,6 @@ Now it's time to fill in these files!
   removal of public fields were to report that a struct was removed.
   Struct removal has its own lint, so there's no reason to also report that
   the removed struct also had its fields removed.
-- Note that your lint must output `span_filename` and `span_begin_line` for it
-  to be a valid lint. The pattern we commonly use is:
-  ```
-  span_: span @optional {
-    filename @output
-    begin_line @output
-  }
-  ```
 - Re-run [`./scripts/regenerate_test_rustdocs.sh`](https://github.com/obi1kenobi/cargo-semver-checks/tree/main/scripts/regenerate_test_rustdocs.sh)
   to generate rustdoc JSON files for your new test crates.
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -390,9 +390,9 @@ mod tests {
 
                 match (filename, line) {
                     (Some(filename), Some(line)) => (filename.to_owned(), line.as_usize()),
-                    (Some(_filename), _) => panic!("A valid query must have span_filename. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for details."),
-                    (_, Some(_line)) => panic!("A valid query must have span_begin_line. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for details."),
-                    _ => panic!("A valid query must have both span_filename and span_begin_line. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for details."),
+                    (Some(_filename), _) => panic!("A valid query must output span_filename. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for details."),
+                    (_, Some(_line)) => panic!("A valid query must output span_begin_line. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for details."),
+                    _ => panic!("A valid query must output both span_filename and span_begin_line. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for details."),
                 }
             };
             for value in results.values_mut() {

--- a/src/query.rs
+++ b/src/query.rs
@@ -385,10 +385,13 @@ mod tests {
         // nondeterminism in how the results are ordered.
         let sort_individual_outputs = |results: &mut TestOutput| {
             let key_func = |elem: &BTreeMap<String, FieldValue>| {
-                (
-                    elem["span_filename"].as_str().unwrap().to_owned(),
-                    elem["span_begin_line"].as_usize().unwrap(),
-                )
+                let filename = elem.get("span_filename")
+                    .and_then(|value| value.as_str())
+                    .expect("a valid query must have span_filename");
+                let line = elem.get("span_begin_line")
+                    .expect("a valid query must have span_begin_line");
+                    
+                (filename.to_owned(), line.as_usize())
             };
             for value in results.values_mut() {
                 value.sort_unstable_by_key(key_func);

--- a/src/query.rs
+++ b/src/query.rs
@@ -385,12 +385,14 @@ mod tests {
         // nondeterminism in how the results are ordered.
         let sort_individual_outputs = |results: &mut TestOutput| {
             let key_func = |elem: &BTreeMap<String, FieldValue>| {
-                let filename = elem.get("span_filename")
+                let filename = elem
+                    .get("span_filename")
                     .and_then(|value| value.as_str())
                     .expect("a valid query must have span_filename");
-                let line = elem.get("span_begin_line")
+                let line = elem
+                    .get("span_begin_line")
                     .expect("a valid query must have span_begin_line");
-                    
+
                 (filename.to_owned(), line.as_usize())
             };
             for value in results.values_mut() {

--- a/src/query.rs
+++ b/src/query.rs
@@ -390,9 +390,9 @@ mod tests {
 
                 match (filename, line) {
                     (Some(filename), Some(line)) => (filename.to_owned(), line.as_usize()),
-                    (Some(_filename), _) => panic!("A valid query must output span_filename. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for details."),
-                    (_, Some(_line)) => panic!("A valid query must output span_begin_line. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for details."),
-                    _ => panic!("A valid query must output both span_filename and span_begin_line. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for details."),
+                    (Some(_filename), _) => panic!("A valid query must output `span_filename`. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for details."),
+                    (_, Some(_line)) => panic!("A valid query must output `span_begin_line`. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for details."),
+                    _ => panic!("A valid query must output both `span_filename` and `span_begin_line`. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for details."),
                 }
             };
             for value in results.values_mut() {

--- a/src/query.rs
+++ b/src/query.rs
@@ -385,15 +385,15 @@ mod tests {
         // nondeterminism in how the results are ordered.
         let sort_individual_outputs = |results: &mut TestOutput| {
             let key_func = |elem: &BTreeMap<String, FieldValue>| {
-                let filename = elem
-                    .get("span_filename")
-                    .and_then(|value| value.as_str())
-                    .expect("a valid query must have span_filename");
-                let line = elem
-                    .get("span_begin_line")
-                    .expect("a valid query must have span_begin_line");
+                let filename = elem.get("span_filename").and_then(|value| value.as_str());
+                let line = elem.get("span_begin_line");
 
-                (filename.to_owned(), line.as_usize())
+                match (filename, line) {
+                    (Some(filename), Some(line)) => (filename.to_owned(), line.as_usize()),
+                    (Some(_filename), _) => panic!("A valid query must have span_filename. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for details."),
+                    (_, Some(_line)) => panic!("A valid query must have span_begin_line. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for details."),
+                    _ => panic!("A valid query must have both span_filename and span_begin_line. See https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md for details."),
+                }
             };
             for value in results.values_mut() {
                 value.sort_unstable_by_key(key_func);


### PR DESCRIPTION
1. Shows user-friendly error when span_filename and span_begin_line are missing
2. Updates contributing guide to guide people when they encounter the error while also making a note to prevent people from making this mistake