### PR TITLE
add item_removed_from_public_api lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3178,8 +3178,6 @@ dependencies = [
 [[package]]
 name = "trustfall-rustdoc-adapter"
 version = "26.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3b046aa70f7199223e1ef4dc46b2d904ce42f4a3fb726ee712c98ea44e782e"
 dependencies = [
  "rustdoc-types 0.22.0",
  "trustfall",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,6 @@ opt-level = 3
 debug-assertions = true
 overflow-checks = true
 codegen-units = 16
+
+[patch.crates-io]
+trustfall-rustdoc-adapter = { path = "../trustfall-rustdoc-adapter" }

--- a/src/lints/item_removed_from_public_api.ron
+++ b/src/lints/item_removed_from_public_api.ron
@@ -1,0 +1,56 @@
+SemverQuery(
+    id: "item_removed_from_public_api",
+    human_readable_name: "item removed from public API",
+    description: "An item has been marked as `#[doc(hidden)]` without being marked `#[deprecated]`.",
+    required_update: Major,
+    reference_link: None,  // Link to cargo-semver-checks discussion?
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Function {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        name @output
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        baseline_span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Function {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "!=", value: ["$true"])
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+        "zero": 0,
+    },
+    // FIXME message
+    error_message: "A publicly-visible item FIXME ERROR MESSAGE =) ",
+    // FIXME template
+    per_result_error_template: Some("function {{join \"::\" path}}, previously in file {{span_filename}}:{{span_begin_line}}"),
+)


### PR DESCRIPTION
Accompaniment to https://github.com/obi1kenobi/trustfall-rustdoc-adapter/pull/260

Relates #120 

This new lint adds a rule to make marking items as `#[doc(hidden)]` a breaking change unless they are also deprecated at the same time.

For #120 the existing lints probably need to be changed to require that the items be `public_api`, which should be a mechanical change.