### PR TITLE
New lint for removed associated constant in trait

### DIFF
--- a/src/lints/trait_removed_associated_constant.ron
+++ b/src/lints/trait_removed_associated_constant.ron
@@ -1,0 +1,54 @@
+SemverQuery(
+    id: "trait_removed_associated_constant",
+    human_readable_name: "trait's associated constant was removed",
+    description: "A trait's associated constant was removed or renamed",
+    required_update: Major, 
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Trait {
+                        trait_name: name @output
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        importable_path {
+                            path @output @tag
+                        }
+
+                        associated_constant {
+                           associated_constant: name @output @tag
+
+                           span_: span {
+                              filename @output
+                              begin_line @output
+                          }
+
+                      }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                        }
+                    
+                        associated_constant @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            name @filter(op: "=", value: ["%associated_constant"])
+                        }
+                    }                
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "zero": 0,
+    },
+    error_message: "A public trait's associated constant was removed or renamed.",
+    per_result_error_template: Some("associated constant {{trait_name}}::{{associated_constant}}, previously at {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/lints/trait_removed_associated_constant.ron
+++ b/src/lints/trait_removed_associated_constant.ron
@@ -12,19 +12,19 @@ SemverQuery(
                     ... on Trait {
                         trait_name: name @output
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
+
                         importable_path {
                             path @output @tag
                         }
 
                         associated_constant {
-                           associated_constant: name @output @tag
+                            associated_constant: name @output @tag
 
-                           span_: span {
-                              filename @output
-                              begin_line @output
-                          }
-
-                      }
+                            span_: span @optional {
+                               filename @output
+                               begin_line @output
+                            }
+                        }
                     }
                 }
             }

--- a/src/query.rs
+++ b/src/query.rs
@@ -515,4 +515,5 @@ add_lints!(
     pub_static_missing,
     trait_removed_associated_type,
     module_missing,
+    trait_removed_associated_constant,
 );

--- a/test_crates/trait_removed_associated_constant/new/Cargo.toml
+++ b/test_crates/trait_removed_associated_constant/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_removed_associated_constant"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_removed_associated_constant/new/src/lib.rs
+++ b/test_crates/trait_removed_associated_constant/new/src/lib.rs
@@ -1,0 +1,11 @@
+pub trait RemovedAssociatedConstantFromTrait {
+}
+
+pub trait TraitWithConstant {
+    const APPLE: i32;
+}
+
+pub trait RemovedAssociatedConstantDefaultFromTrait: TraitWithConstant {}
+
+// this trait is private therefore removing the constant is not breaking
+trait PrivateTraitWithTypeRemoved {}

--- a/test_crates/trait_removed_associated_constant/old/Cargo.toml
+++ b/test_crates/trait_removed_associated_constant/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_removed_associated_constant"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_removed_associated_constant/old/src/lib.rs
+++ b/test_crates/trait_removed_associated_constant/old/src/lib.rs
@@ -1,0 +1,23 @@
+pub trait RemovedAssociatedConstantFromTrait {
+    const APPLE: i32;
+}
+
+pub trait TraitWithConstant {
+    const APPLE: i32;
+}
+
+pub trait RemovedAssociatedConstantDefaultFromTrait: TraitWithConstant {
+    const APPLE: i32 = 2;
+}
+
+// this trait is private therefore removing the constant is not breaking
+trait PrivateTraitWithTypeRemoved {
+    const APPLE: i32;
+}
+
+/// This trait should not be reported by the `trait_removed_associated_constant` rule:
+/// it will be removed altogether, so the correct rule to catch it is
+/// the `trait_missing` rule and not the rule for missing associated constants.
+pub trait RemovedTrait {
+    const APPLE: i32;
+}

--- a/test_outputs/trait_missing.output.ron
+++ b/test_outputs/trait_missing.output.ron
@@ -109,6 +109,18 @@
             "visibility_limit": String("public"),
         },
     ],
+    "./test_crates/trait_removed_associated_constant/": [
+        {
+            "name": String("RemovedTrait"),
+            "path": List([
+                String("trait_removed_associated_constant"),
+                String("RemovedTrait"),
+            ]),
+            "span_begin_line": Uint64(21),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+    ],
     "./test_crates/trait_unsafe_added/": [
         {
             "name": String("TraitBecomesPrivateAndUnsafe"),

--- a/test_outputs/trait_removed_associated_constant.output.ron
+++ b/test_outputs/trait_removed_associated_constant.output.ron
@@ -1,0 +1,26 @@
+{
+    "./test_crates/trait_removed_associated_constant/": [
+        {
+            "associated_constant": String("APPLE"),
+            "path": List([
+                String("trait_removed_associated_constant"),
+                String("RemovedAssociatedConstantFromTrait"),
+            ]),
+            "span_begin_line": Uint64(2),
+            "span_filename": String("src/lib.rs"),
+            "trait_name": String("RemovedAssociatedConstantFromTrait"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "associated_constant": String("APPLE"),
+            "path": List([
+                String("trait_removed_associated_constant"),
+                String("RemovedAssociatedConstantDefaultFromTrait"),
+            ]),
+            "span_begin_line": Uint64(10),
+            "span_filename": String("src/lib.rs"),
+            "trait_name": String("RemovedAssociatedConstantDefaultFromTrait"),
+            "visibility_limit": String("public"),
+        },
+    ],
+}


### PR DESCRIPTION
Adds a new lint for removing an associated constant in a trait.

Happy to add more examples if there are any.  I pretty much followed the pre-existing trait removed associated type lint, but I think I've got the hang of how Trustfall works now, so hopefully I can pick another soon.

Lint referenced here:
https://github.com/obi1kenobi/cargo-semver-checks/issues/366#issuecomment-1662820577