### PR TITLE
Use sccache for GitHub Actions CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,10 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@stable
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: 'semver'
+
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.3
 
@@ -254,6 +258,10 @@ jobs:
 
       - name: Install rust
         uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: 'semver'
 
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,10 @@ jobs:
   build-binary:
     name: Build binary
     runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: 0
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -210,9 +214,8 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: 'semver'
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.3
 
       - uses: r7kamura/rust-problem-matchers@v1
 
@@ -238,6 +241,10 @@ jobs:
     # which would make whole CI last longer.
     name: Build binary (Windows)
     runs-on: windows-latest
+    env:
+      CARGO_INCREMENTAL: 0
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -248,9 +255,8 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: 'semver'
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.3
 
       - uses: r7kamura/rust-problem-matchers@v1
 


### PR DESCRIPTION
Hoping we can get similar build speed improvements as this PR, which inspired this one: https://github.com/hapsoc/fluke/issues/118