### PR TITLE
Treat quoted empty string as an empty string

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -343,7 +343,7 @@ impl From<CheckRelease> for cargo_semver_checks::Check {
 
         // Treat --features="" as a no-op like cargo does
         let trim_features = |features: &mut Vec<String>| {
-            features.retain(|feature| !feature.is_empty());
+            features.retain(|feature| !(feature.is_empty() || feature == "\"\""));
         };
         trim_features(&mut current_features);
         trim_features(&mut baseline_features);
@@ -370,8 +370,8 @@ fn features_empty_string_is_no_op() {
 
     let empty_features = CheckRelease {
         features: vec![String::new()],
-        current_features: vec![String::new(), String::new()],
-        baseline_features: vec![String::new()],
+        current_features: vec![String::new(), "\"\"".to_string()],
+        baseline_features: vec!["\"\"".to_string()],
         ..no_features.clone()
     };
 


### PR DESCRIPTION
In #566 , I forgot that when cargo semver-checks is not invoked via a shell (as in, say, cargo-semver-checks-action), it is our job to treat empty quoted strings like empty strings.