### PR TITLE
Do not consider `#[doc(hidden)]` items part of the public API.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,13 +144,13 @@ jobs:
   rust-tests:
     name: Run tests
     runs-on: ubuntu-latest
-    continue-on-error: true  # TODO: revert this change before merging!!
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         # IMPORTANT: When updating the versions here, make sure you also update
         #            the `fails-on-too-old-rustc` job and its error message to
         #            to account for the raised minimum required version.
-        toolchain: ["1.70", "1.71", "1.72", "stable", "beta"]
+        toolchain: ["1.71", "1.72", "stable", "beta"]
         experimental: [false]
         include:
           - toolchain: "nightly"
@@ -330,7 +330,7 @@ jobs:
         id: toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: "1.70"  # Rust 1.70 uses rustdoc v24
+          toolchain: "1.73"  # Rust 1.73 uses rustdoc v26
           rustflags: ""
           cache: false
 
@@ -364,11 +364,15 @@ jobs:
       - name: Install newer rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: "1.72"  # Rust 1.72 uses rustdoc v26
+          # Make sure this version matches the env var below.
+          toolchain: "nightly"  # Rust 1.75-nightly uses rustdoc v27
+
           rustflags: ""
           cache: false
 
       - name: Check with older rustdoc version cached
+        env:
+          NEWER_RUST_VERSION: "nightly"  # Make sure this matches the version installed just above.
         run: |
           # Use a separate workspace, to avoid contaminating the cache for Swatinem/rust-cache@v2
           cp -R subject subject-new
@@ -385,9 +389,9 @@ jobs:
           export OLD_RUSTDOC_VERSION="$(jq .format_version subject-new/target/semver-checks/cache/registry-libp2p_core-0_37_0.json)"
 
           # Run cargo-semver-checks with the older cached file.
-          # In a prior step, we installed stable Rust, so we'll set that as the default
+          # In a prior step, we installed a newer Rust, so we'll set that as the default
           # for cargo-semver-checks to invoke here.
-          rustup override set stable
+          rustup override set "$NEWER_RUST_VERSION"
           bins/cargo-semver-checks semver-checks check-release --manifest-path="subject-new/core/Cargo.toml" --verbose
 
           export NEW_RUSTDOC_VERSION="$(jq .format_version subject-new/target/semver-checks/cache/registry-libp2p_core-0_37_0.json)"
@@ -432,7 +436,6 @@ jobs:
         with:
           cache: false
           rustflags: ""
-          toolchain: nightly
 
       - name: Restore rustdoc
         id: cache
@@ -526,7 +529,6 @@ jobs:
         with:
           cache: false
           rustflags: ""
-          toolchain: nightly
 
       # rust-libp2p requires protobuf-compiler.
       - name: Install protobuf-compiler
@@ -606,7 +608,6 @@ jobs:
         with:
           cache: false
           rustflags: ""
-          toolchain: nightly
 
       # rust-libp2p requires protobuf-compiler.
       - name: Install protobuf-compiler
@@ -681,7 +682,6 @@ jobs:
         with:
           cache: false
           rustflags: ""
-          toolchain: nightly
 
       # rust-libp2p requires protobuf-compiler.
       - name: Install protobuf-compiler
@@ -754,7 +754,6 @@ jobs:
         with:
           cache: false
           rustflags: ""
-          toolchain: nightly
 
       # rust-libp2p requires protobuf-compiler.
       - name: Install protobuf-compiler
@@ -823,7 +822,6 @@ jobs:
         with:
           cache: false
           rustflags: ""
-          toolchain: nightly
 
       # This job runs on macOS, not Linux like the rest.
       # It should save its cache, because no other job will save it in its place.
@@ -882,7 +880,6 @@ jobs:
         with:
           cache: false
           rustflags: ""
-          toolchain: nightly
 
       - name: Restore binary
         id: cache-binary
@@ -946,7 +943,6 @@ jobs:
         with:
           cache: false
           rustflags: ""
-          toolchain: nightly
 
       - name: Restore binary
         id: cache-binary
@@ -1009,7 +1005,6 @@ jobs:
         with:
           cache: false
           rustflags: ""
-          toolchain: nightly
 
       - name: Restore binary
         id: cache-binary
@@ -1077,7 +1072,6 @@ jobs:
         with:
           cache: false
           rustflags: ""
-          toolchain: nightly
 
       - name: Restore cargo index and rustdoc target dir
         uses: Swatinem/rust-cache@v2
@@ -1156,7 +1150,6 @@ jobs:
         with:
           cache: false
           rustflags: ""
-          toolchain: nightly
 
       - name: Restore cargo index and rustdoc target dir
         uses: Swatinem/rust-cache@v2
@@ -1234,7 +1227,6 @@ jobs:
         with:
           cache: false
           rustflags: ""
-          toolchain: nightly
 
       - name: Restore binary
         id: cache-binary
@@ -1458,7 +1450,6 @@ jobs:
         with:
           cache: false
           rustflags: ""
-          toolchain: nightly
 
       - name: Restore binary
         id: cache-binary
@@ -1556,7 +1547,6 @@ jobs:
         with:
           cache: false
           rustflags: ""
-          toolchain: nightly
 
       - name: Restore binary
         id: cache-binary
@@ -1620,7 +1610,7 @@ jobs:
         id: toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: "1.67"
+          toolchain: "1.70"
           rustflags: ""
           cache: false
 
@@ -1663,7 +1653,7 @@ jobs:
       - name: Check output
         run: |
           cd semver
-          EXPECTED="$(echo -e "Error: rustc version is not high enough: >=1.68.0 needed, got 1.67.1")"
+          EXPECTED="$(echo -e "Error: rustc version is not high enough: >=1.71.0 needed, got 1.70.0")"
           RESULT="$(cat output | grep Error)"
           diff <(echo "$RESULT") <(echo "$EXPECTED")
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
   rust-tests:
     name: Run tests
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: true  # TODO: revert this change before merging!!
     strategy:
       matrix:
         # IMPORTANT: When updating the versions here, make sure you also update
@@ -432,6 +432,7 @@ jobs:
         with:
           cache: false
           rustflags: ""
+          toolchain: nightly
 
       - name: Restore rustdoc
         id: cache
@@ -525,6 +526,7 @@ jobs:
         with:
           cache: false
           rustflags: ""
+          toolchain: nightly
 
       # rust-libp2p requires protobuf-compiler.
       - name: Install protobuf-compiler
@@ -604,6 +606,7 @@ jobs:
         with:
           cache: false
           rustflags: ""
+          toolchain: nightly
 
       # rust-libp2p requires protobuf-compiler.
       - name: Install protobuf-compiler
@@ -678,6 +681,7 @@ jobs:
         with:
           cache: false
           rustflags: ""
+          toolchain: nightly
 
       # rust-libp2p requires protobuf-compiler.
       - name: Install protobuf-compiler
@@ -750,6 +754,7 @@ jobs:
         with:
           cache: false
           rustflags: ""
+          toolchain: nightly
 
       # rust-libp2p requires protobuf-compiler.
       - name: Install protobuf-compiler
@@ -818,6 +823,7 @@ jobs:
         with:
           cache: false
           rustflags: ""
+          toolchain: nightly
 
       # This job runs on macOS, not Linux like the rest.
       # It should save its cache, because no other job will save it in its place.
@@ -876,6 +882,7 @@ jobs:
         with:
           cache: false
           rustflags: ""
+          toolchain: nightly
 
       - name: Restore binary
         id: cache-binary
@@ -939,6 +946,7 @@ jobs:
         with:
           cache: false
           rustflags: ""
+          toolchain: nightly
 
       - name: Restore binary
         id: cache-binary
@@ -1001,6 +1009,7 @@ jobs:
         with:
           cache: false
           rustflags: ""
+          toolchain: nightly
 
       - name: Restore binary
         id: cache-binary
@@ -1068,6 +1077,7 @@ jobs:
         with:
           cache: false
           rustflags: ""
+          toolchain: nightly
 
       - name: Restore cargo index and rustdoc target dir
         uses: Swatinem/rust-cache@v2
@@ -1146,6 +1156,7 @@ jobs:
         with:
           cache: false
           rustflags: ""
+          toolchain: nightly
 
       - name: Restore cargo index and rustdoc target dir
         uses: Swatinem/rust-cache@v2
@@ -1223,6 +1234,7 @@ jobs:
         with:
           cache: false
           rustflags: ""
+          toolchain: nightly
 
       - name: Restore binary
         id: cache-binary
@@ -1446,6 +1458,7 @@ jobs:
         with:
           cache: false
           rustflags: ""
+          toolchain: nightly
 
       - name: Restore binary
         id: cache-binary
@@ -1543,6 +1556,7 @@ jobs:
         with:
           cache: false
           rustflags: ""
+          toolchain: nightly
 
       - name: Restore binary
         id: cache-binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,24 +2321,6 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f59b848e09e1631f0f8711fcdcb65d4481597b869372cca5d6755737b21501"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "rustdoc-types"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7a12c7506980eaac5c9851a04e90e0062eb4417aa188a512bf7a64a1ef290f"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "rustdoc-types"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc646f09069d689083b975698bdac4edb96c2f0e7d270b701760814b886bb224"
@@ -2948,31 +2930,10 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "24.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30381ee0ff2e13945afad2d599179f6ab8616a5a34b74bd342fc30e60f46f86"
-dependencies = [
- "rustdoc-types 0.20.0",
- "trustfall",
-]
-
-[[package]]
-name = "trustfall-rustdoc-adapter"
-version = "26.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbdccb0145e51ed535c4b655c9f35b0705a0962f1bc6dca8ec864f09e8e4022"
-dependencies = [
- "rustdoc-types 0.22.0",
- "trustfall",
-]
-
-[[package]]
-name = "trustfall-rustdoc-adapter"
 version = "27.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b1829e2634f001b423f7d4d9623b12ee1ac741ae24ca80deb44655c185c087"
+source = "git+https://github.com/davidhewitt/trustfall-rustdoc-adapter.git?branch=public-api#00ca8b9373a4cc947470df096a874a0214e8a39f"
 dependencies = [
- "rustdoc-types 0.23.0",
+ "rustdoc-types",
  "trustfall",
 ]
 
@@ -3015,9 +2976,7 @@ dependencies = [
  "serde",
  "serde_json",
  "trustfall",
- "trustfall-rustdoc-adapter 24.5.3",
- "trustfall-rustdoc-adapter 26.2.3",
- "trustfall-rustdoc-adapter 27.0.3",
+ "trustfall-rustdoc-adapter",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,9 +669,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -1671,9 +1671,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "human-panic"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b82da652938b83f94cfdaaf9ae7aaadb8430d84b0dfda226998416318727eac2"
+checksum = "7a79a67745be0cb8dd2771f03b24c2f25df98d5471fe7a595d668cfa2e6f843d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1681,7 +1681,7 @@ dependencies = [
  "os_info",
  "serde",
  "serde_derive",
- "toml 0.7.8",
+ "toml 0.8.8",
  "uuid",
 ]
 
@@ -2321,6 +2321,15 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7a12c7506980eaac5c9851a04e90e0062eb4417aa188a512bf7a64a1ef290f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "rustdoc-types"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc646f09069d689083b975698bdac4edb96c2f0e7d270b701760814b886bb224"
@@ -2414,18 +2423,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2668,7 +2677,7 @@ dependencies = [
  "smol_str",
  "thiserror",
  "tokio",
- "toml 0.8.6",
+ "toml 0.8.8",
  "twox-hash",
  "windows-targets 0.48.5",
 ]
@@ -2847,14 +2856,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff9e3abce27ee2c9a37f9ad37238c1bdd4e789c84ba37df76aa4d528f5072cc"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.20.7",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -2881,9 +2890,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.20.7"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
  "indexmap 2.1.0",
  "serde",
@@ -2930,10 +2939,21 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "27.0.3"
-source = "git+https://github.com/davidhewitt/trustfall-rustdoc-adapter.git?branch=public-api#6f82578d583232c725b62215d0e2042ed4cea234"
+version = "26.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d7d1381a94d69dcdc6d0caefa08c48038d3850c94fd25bbb39702a6d7358c1"
 dependencies = [
- "rustdoc-types",
+ "rustdoc-types 0.22.0",
+ "trustfall",
+]
+
+[[package]]
+name = "trustfall-rustdoc-adapter"
+version = "27.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cafe4e40c766c6c9b4fef59700601a43b97529db2a1848accc4fe81f93ec90c2"
+dependencies = [
+ "rustdoc-types 0.23.0",
  "trustfall",
 ]
 
@@ -2976,7 +2996,8 @@ dependencies = [
  "serde",
  "serde_json",
  "trustfall",
- "trustfall-rustdoc-adapter",
+ "trustfall-rustdoc-adapter 26.2.4",
+ "trustfall-rustdoc-adapter 27.0.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2931,7 +2931,7 @@ dependencies = [
 [[package]]
 name = "trustfall-rustdoc-adapter"
 version = "27.0.3"
-source = "git+https://github.com/davidhewitt/trustfall-rustdoc-adapter.git?branch=public-api#00ca8b9373a4cc947470df096a874a0214e8a39f"
+source = "git+https://github.com/davidhewitt/trustfall-rustdoc-adapter.git?branch=public-api#6f82578d583232c725b62215d0e2042ed4cea234"
 dependencies = [
  "rustdoc-types",
  "trustfall",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.70"
 
 [dependencies]
 trustfall = "0.6.0"
-trustfall_rustdoc = { version = "0.13.1", default-features = false, features = ["v24", "v26", "v27"] }
+trustfall_rustdoc = { version = "0.13.1", default-features = false, features = ["v27"] }
 clap = { version = "4.0.0", features = ["derive", "cargo"] }
 serde_json = "1.0.82"
 anyhow = "1.0.58"
@@ -66,3 +66,6 @@ opt-level = 3
 debug-assertions = true
 overflow-checks = true
 codegen-units = 16
+
+[patch.crates-io]
+trustfall-rustdoc-adapter = { git = "https://github.com/davidhewitt/trustfall-rustdoc-adapter.git", branch = "public-api" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.70"
 
 [dependencies]
 trustfall = "0.6.0"
-trustfall_rustdoc = { version = "0.13.1", default-features = false, features = ["v27"] }
+trustfall_rustdoc = { version = "0.13.1", default-features = false, features = ["v26", "v27"] }
 clap = { version = "4.0.0", features = ["derive", "cargo"] }
 serde_json = "1.0.82"
 anyhow = "1.0.58"
@@ -66,6 +66,3 @@ opt-level = 3
 debug-assertions = true
 overflow-checks = true
 codegen-units = 16
-
-[patch.crates-io]
-trustfall-rustdoc-adapter = { git = "https://github.com/davidhewitt/trustfall-rustdoc-adapter.git", branch = "public-api" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,7 +52,7 @@ impl GlobalConfig {
                 }
             })),
             handlebars: make_handlebars_registry(),
-            minimum_rustc_version: semver::Version::new(1, 68, 0),
+            minimum_rustc_version: semver::Version::new(1, 71, 0),
         }
     }
 

--- a/src/lints/auto_trait_impl_removed.ron
+++ b/src/lints/auto_trait_impl_removed.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         impl {
@@ -44,6 +45,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         impl @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
@@ -71,6 +73,7 @@ SemverQuery(
         "public": "public",
         "zero": 0,
         "false": false,
+        "true": true,
         "auto_traits": [
             ["core", "marker", "Send"],
             ["core", "marker", "Sync"],

--- a/src/lints/constructible_struct_adds_field.ron
+++ b/src/lints/constructible_struct_adds_field.ron
@@ -23,6 +23,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         field {
@@ -52,6 +53,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         # 2. It needs to not have had any non-public fields.
@@ -72,6 +74,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "non_exhaustive": "#[non_exhaustive]",
+        "true": true,
         "zero": 0,
     },
     error_message: "A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.",

--- a/src/lints/constructible_struct_adds_private_field.ron
+++ b/src/lints/constructible_struct_adds_private_field.ron
@@ -23,6 +23,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         field {
@@ -52,6 +53,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         # 2. It needs to not have had any non-public fields.
@@ -72,6 +74,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "non_exhaustive": "#[non_exhaustive]",
+        "true": true,
         "zero": 0,
     },
     error_message: "A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.",

--- a/src/lints/constructible_struct_changed_type.ron
+++ b/src/lints/constructible_struct_changed_type.ron
@@ -36,6 +36,7 @@ More info: https://github.com/obi1kenobi/cargo-semver-checks/issues/297
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
                     }
                 }
@@ -50,6 +51,7 @@ More info: https://github.com/obi1kenobi/cargo-semver-checks/issues/297
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -64,6 +66,7 @@ More info: https://github.com/obi1kenobi/cargo-semver-checks/issues/297
     arguments: {
         "public": "public",
         "non_exhaustive": "#[non_exhaustive]",
+        "true": true,
         "zero": 0,
     },
     error_message: "A struct became an enum or union, and is no longer publicly constructible with a struct literal.",

--- a/src/lints/derive_trait_impl_removed.ron
+++ b/src/lints/derive_trait_impl_removed.ron
@@ -16,6 +16,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         impl {
@@ -52,6 +53,7 @@ SemverQuery(
 
                         importable_path @fold @transform(op: "count") @filter(op: ">", value: ["$zero"]) {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         impl @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
@@ -87,6 +89,7 @@ SemverQuery(
         "public": "public",
         "zero": 0,
         "false": false,
+        "true": true,
         "structural_eq": ["core", "marker", "StructuralEq"],
     },
     error_message: "A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.",

--- a/src/lints/enum_marked_non_exhaustive.ron
+++ b/src/lints/enum_marked_non_exhaustive.ron
@@ -18,6 +18,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -35,6 +36,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
                     }
                 }
@@ -44,6 +46,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "non_exhaustive": "#[non_exhaustive]",
+        "true": true,
     },
     error_message: "A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.",
     per_result_error_template: Some("enum {{name}} in {{span_filename}}:{{span_begin_line}}"),

--- a/src/lints/enum_missing.ron
+++ b/src/lints/enum_missing.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -40,6 +41,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "zero": 0,
+        "true": true,
     },
     error_message: "A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.",
     per_result_error_template: Some("enum {{join \"::\" path}}, previously in file {{span_filename}}:{{span_begin_line}}"),

--- a/src/lints/enum_must_use_added.ron
+++ b/src/lints/enum_must_use_added.ron
@@ -18,6 +18,7 @@ SemverQuery(
 
                         importable_path {
                             path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         attribute {
@@ -41,6 +42,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
@@ -56,6 +58,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "must_use": "must_use",
+        "true": true,
         "zero": 0,
     },
     error_message: "An enum is now #[must_use]. Downstream crates that did not use its value will get a compiler lint.",

--- a/src/lints/enum_repr_c_removed.ron
+++ b/src/lints/enum_repr_c_removed.ron
@@ -28,6 +28,7 @@ SemverQuery(
 
                         importable_path {
                             path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
                         }
                     }
                 }
@@ -49,6 +50,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -64,6 +66,7 @@ SemverQuery(
         "public": "public",
         "repr": "repr",
         "c": "C",
+        "true": true,
         "zero": 0,
     },
     error_message: "repr(C) was removed from an enum. This can cause its memory layout to change, breaking FFI use cases.",

--- a/src/lints/enum_repr_int_changed.ron
+++ b/src/lints/enum_repr_int_changed.ron
@@ -29,6 +29,7 @@ SemverQuery(
 
                         importable_path {
                             path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
                         }
                     }
                 }
@@ -41,6 +42,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         # Check that there exists an attribute that:
@@ -71,6 +73,7 @@ SemverQuery(
         "public": "public",
         "repr": "repr",
         "repr_regex": "[ui](\\d+|size)",
+        "true": true,
         "zero": 0,
     },
     error_message: "The repr(u*) or repr(i*) attribute on an enum was changed to another integer type. This can cause its memory representation to change, breaking FFI use cases.",

--- a/src/lints/enum_repr_int_removed.ron
+++ b/src/lints/enum_repr_int_removed.ron
@@ -28,6 +28,7 @@ SemverQuery(
 
                         importable_path {
                             path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
                         }
                     }
                 }
@@ -40,6 +41,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
@@ -64,6 +66,7 @@ SemverQuery(
         "public": "public",
         "repr": "repr",
         "repr_regex": "[ui](\\d+|size)",
+        "true": true,
         "zero": 0,
     },
     error_message: "repr(u*) or repr(i*) was removed from an enum. This can cause its memory representation to change, breaking FFI use cases.",

--- a/src/lints/enum_struct_variant_field_added.ron
+++ b/src/lints/enum_struct_variant_field_added.ron
@@ -26,6 +26,12 @@ SemverQuery(
                                 # clearly stated that they don't consider it exhaustive anymore.
                                 attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
 
+                                # If the variant is newly marked `#[doc(hidden)]`,
+                                # that's already a breaking change with its own rule.
+                                # Don't report new field additions, since the programmer has
+                                # clearly stated they don't consider it public API anymore.
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+
                                 variant_name: name @output @tag
 
                                 field {
@@ -55,6 +61,7 @@ SemverQuery(
                             ... on StructVariant {
                                 name @filter(op: "=", value: ["%variant_name"])
                                 attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                                     name @filter(op: "=", value: ["%field_name"])

--- a/src/lints/enum_struct_variant_field_added.ron
+++ b/src/lints/enum_struct_variant_field_added.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         variant {
@@ -47,6 +48,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         variant {
@@ -66,6 +68,7 @@ SemverQuery(
     }"#,
     arguments: {
         "public": "public",
+        "true": true,
         "zero": 0,
         "non_exhaustive": "#[non_exhaustive]",
     },

--- a/src/lints/enum_struct_variant_field_missing.ron
+++ b/src/lints/enum_struct_variant_field_missing.ron
@@ -20,9 +20,12 @@ SemverQuery(
                         variant {
                             ... on StructVariant {
                                 variant_name: name @output @tag
+                                public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 field {
                                     field_name: name @output @tag
+                                    public_api_eligible @filter(op: "=", value: ["$true"])
+
                                     span_: span @optional {
                                         filename @output
                                         begin_line @output
@@ -47,6 +50,7 @@ SemverQuery(
                         variant {
                             ... on StructVariant {
                                 name @filter(op: "=", value: ["%variant_name"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                                     name @filter(op: "=", value: ["%field_name"])

--- a/src/lints/enum_struct_variant_field_missing.ron
+++ b/src/lints/enum_struct_variant_field_missing.ron
@@ -14,6 +14,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         variant {
@@ -40,6 +41,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         variant {
@@ -58,6 +60,7 @@ SemverQuery(
     }"#,
     arguments: {
         "public": "public",
+        "true": true,
         "zero": 0,
     },
     error_message: "A publicly-visible enum has a struct variant whose field is no longer available under its prior name. It may have been renamed or removed entirely.",

--- a/src/lints/enum_tuple_variant_field_added.ron
+++ b/src/lints/enum_tuple_variant_field_added.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         variant {
@@ -48,6 +49,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         variant {
@@ -67,6 +69,7 @@ SemverQuery(
     }"#,
     arguments: {
         "public": "public",
+        "true": true,
         "zero": 0,
         "non_exhaustive": "#[non_exhaustive]",
     },

--- a/src/lints/enum_tuple_variant_field_added.ron
+++ b/src/lints/enum_tuple_variant_field_added.ron
@@ -26,6 +26,12 @@ SemverQuery(
                                 # clearly stated that they don't consider it exhaustive anymore.
                                 attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
 
+                                # If the variant is newly marked `#[doc(hidden)]`,
+                                # that's already a breaking change with its own rule.
+                                # Don't report new field additions, since the programmer has
+                                # clearly stated they don't consider it public API anymore.
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+
                                 variant_name: name @output @tag
 
                                 field {
@@ -56,6 +62,7 @@ SemverQuery(
                             ... on TupleVariant {
                                 name @filter(op: "=", value: ["%variant_name"])
                                 attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                                     name @filter(op: "=", value: ["%field_name"])

--- a/src/lints/enum_tuple_variant_field_missing.ron
+++ b/src/lints/enum_tuple_variant_field_missing.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         variant {
@@ -41,12 +42,13 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         variant {
                             ... on TupleVariant {
                                 name @filter(op: "=", value: ["%variant_name"])
-                                
+
                                 field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                                     name @filter(op: "=", value: ["%field_name"])
                                 }
@@ -59,6 +61,7 @@ SemverQuery(
     }"#,
     arguments: {
         "public": "public",
+        "true": true,
         "zero": 0,
     },
     error_message: "A field of a tuple variant in a pub enum has been removed.",

--- a/src/lints/enum_tuple_variant_field_missing.ron
+++ b/src/lints/enum_tuple_variant_field_missing.ron
@@ -21,9 +21,12 @@ SemverQuery(
                         variant {
                             ... on TupleVariant {
                                 variant_name: name @output @tag
+                                public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 field {
                                     field_name: name @output @tag
+                                    public_api_eligible @filter(op: "=", value: ["$true"])
+
                                     span_: span @optional {
                                         filename @output
                                         begin_line @output
@@ -48,6 +51,7 @@ SemverQuery(
                         variant {
                             ... on TupleVariant {
                                 name @filter(op: "=", value: ["%variant_name"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                                     name @filter(op: "=", value: ["%field_name"])

--- a/src/lints/enum_variant_added.ron
+++ b/src/lints/enum_variant_added.ron
@@ -16,6 +16,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         variant {
@@ -37,6 +38,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         variant @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
@@ -49,6 +51,7 @@ SemverQuery(
     }"#,
     arguments: {
         "public": "public",
+        "true": true,
         "zero": 0,
         "non_exhaustive": "#[non_exhaustive]",
     },

--- a/src/lints/enum_variant_missing.ron
+++ b/src/lints/enum_variant_missing.ron
@@ -19,6 +19,7 @@ SemverQuery(
 
                         variant {
                             variant_name: name @output @tag
+                            public_api_eligible @filter(op: "=", value: ["$true"])
 
                             span_: span @optional {
                                 filename @output

--- a/src/lints/enum_variant_missing.ron
+++ b/src/lints/enum_variant_missing.ron
@@ -14,6 +14,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         variant {
@@ -35,6 +36,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         variant @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
@@ -48,6 +50,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "zero": 0,
+        "true": true,
     },
     error_message: "A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.",
     per_result_error_template: Some("variant {{enum_name}}::{{variant_name}}, previously in file {{span_filename}}:{{span_begin_line}}"),

--- a/src/lints/function_changed_abi.ron
+++ b/src/lints/function_changed_abi.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         abi_: abi {
@@ -30,6 +31,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         new_abi_: abi {
@@ -47,6 +49,7 @@ SemverQuery(
     }"#,
     arguments: {
         "public": "public",
+        "true": true,
     },
     error_message: "A publicly-visible function changed its ABI.",
     per_result_error_template: Some("{{join \"::\" path}} changed ABI from {{abi_name}} to {{new_abi_name}} in {{span_filename}}:{{span_begin_line}}"),

--- a/src/lints/function_const_removed.ron
+++ b/src/lints/function_const_removed.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
                     }
                 }
@@ -28,6 +29,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {

--- a/src/lints/function_missing.ron
+++ b/src/lints/function_missing.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -40,6 +41,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "zero": 0,
+        "true": true,
     },
     error_message: "A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.",
     per_result_error_template: Some("function {{join \"::\" path}}, previously in file {{span_filename}}:{{span_begin_line}}"),

--- a/src/lints/function_must_use_added.ron
+++ b/src/lints/function_must_use_added.ron
@@ -18,6 +18,7 @@ SemverQuery(
 
                         importable_path {
                             path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         attribute {
@@ -41,6 +42,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
@@ -56,6 +58,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "must_use": "must_use",
+        "true": true,
         "zero": 0,
     },
     error_message: "A function is now #[must_use]. Downstream crates that did not use its return value will get a compiler lint.",

--- a/src/lints/function_parameter_count_changed.ron
+++ b/src/lints/function_parameter_count_changed.ron
@@ -14,6 +14,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         old_parameter_: parameter @fold @transform(op: "count") @output @tag(name: "parameters")
@@ -30,6 +31,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -43,6 +45,7 @@ SemverQuery(
     }"#,
     arguments: {
         "public": "public",
+        "true": true,
     },
     error_message: "A publicly-visible function now takes a different number of parameters.",
     per_result_error_template: Some("{{join \"::\" path}} now takes {{current_parameter_count}} parameters instead of {{old_parameter_count}}, in {{span_filename}}:{{span_begin_line}}"),

--- a/src/lints/function_unsafe_added.ron
+++ b/src/lints/function_unsafe_added.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
                     }
                 }
@@ -28,6 +29,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {

--- a/src/lints/inherent_method_const_removed.ron
+++ b/src/lints/inherent_method_const_removed.ron
@@ -22,6 +22,7 @@ SemverQuery(
                                 method_visibility: visibility_limit @filter(op: "=", value: ["$public"]) @output
                                 method_name: name @output @tag
                                 const @filter(op: "=", value: ["$true"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 span_: span @optional {
                                     filename @output
@@ -59,6 +60,7 @@ SemverQuery(
                             method {
                                 visibility_limit @filter(op: "one_of", value: ["$public_or_default"])
                                 name @filter(op: "=", value: ["%method_name"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
                             }
                         }
                         impl @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
@@ -66,6 +68,7 @@ SemverQuery(
                                 visibility_limit @filter(op: "one_of", value: ["$public_or_default"])
                                 name @filter(op: "=", value: ["%method_name"])
                                 const @filter(op: "=", value: ["$true"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
                             }
                         }
 
@@ -75,7 +78,8 @@ SemverQuery(
                             method {
                                 visibility_limit @filter(op: "one_of", value: ["$public_or_default"])
                                 name @filter(op: "=", value: ["%method_name"])
-                                unsafe @filter(op: "=", value: ["$true"])
+                                const @filter(op: "!=", value: ["$true"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 non_matching_span_: span @optional {
                                     filename @output

--- a/src/lints/inherent_method_const_removed.ron
+++ b/src/lints/inherent_method_const_removed.ron
@@ -14,6 +14,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         inherent_impl {
@@ -39,6 +40,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         # We use "impl" instead of "inherent_impl" here because moving

--- a/src/lints/inherent_method_missing.ron
+++ b/src/lints/inherent_method_missing.ron
@@ -18,6 +18,8 @@ SemverQuery(
                         }
 
                         inherent_impl {
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+
                             method {
                                 method_visibility: visibility_limit @filter(op: "=", value: ["$public"]) @output
                                 method_name: name @output @tag

--- a/src/lints/inherent_method_missing.ron
+++ b/src/lints/inherent_method_missing.ron
@@ -14,6 +14,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         inherent_impl {
@@ -38,6 +39,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         # We use "impl" instead of "inherent_impl" here because moving
@@ -58,6 +60,7 @@ SemverQuery(
         "public": "public",
         "public_or_default": ["public", "default"],
         "zero": 0,
+        "true": true,
     },
     error_message: "A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.",
     per_result_error_template: Some("{{name}}::{{method_name}}, previously in file {{span_filename}}:{{span_begin_line}}"),

--- a/src/lints/inherent_method_missing.ron
+++ b/src/lints/inherent_method_missing.ron
@@ -21,6 +21,7 @@ SemverQuery(
                             method {
                                 method_visibility: visibility_limit @filter(op: "=", value: ["$public"]) @output
                                 method_name: name @output @tag
+                                public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 span_: span @optional {
                                     filename @output

--- a/src/lints/inherent_method_must_use_added.ron
+++ b/src/lints/inherent_method_must_use_added.ron
@@ -19,6 +19,7 @@ SemverQuery(
 
                         importable_path {
                             path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         inherent_impl {
@@ -50,6 +51,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         inherent_impl {
@@ -72,6 +74,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "must_use": "must_use",
+        "true": true,
         "zero": 0,
     },
     error_message: "An inherent method is now #[must_use]. Downstream crates that did not use its return value will get a compiler lint.",

--- a/src/lints/inherent_method_must_use_added.ron
+++ b/src/lints/inherent_method_must_use_added.ron
@@ -26,6 +26,7 @@ SemverQuery(
                             method {
                                 method_visibility: visibility_limit @filter(op: "=", value: ["$public"]) @output
                                 method_name: name @tag @output
+                                public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 attribute {
                                     new_attr: raw_attribute @output
@@ -58,6 +59,7 @@ SemverQuery(
                             method {
                                 visibility_limit @filter(op: "=", value: ["$public"])
                                 name @filter(op: "=", value: ["%method_name"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                                     content {

--- a/src/lints/inherent_method_unsafe_added.ron
+++ b/src/lints/inherent_method_unsafe_added.ron
@@ -21,6 +21,7 @@ SemverQuery(
                             method {
                                 method_visibility: visibility_limit @filter(op: "=", value: ["$public"]) @output
                                 method_name: name @output @tag
+                                public_api_eligible @filter(op: "=", value: ["$true"])
                                 unsafe @filter(op: "!=", value: ["$true"])
 
                                 span_: span @optional {
@@ -59,6 +60,7 @@ SemverQuery(
                             method {
                                 visibility_limit @filter(op: "one_of", value: ["$public_or_default"])
                                 name @filter(op: "=", value: ["%method_name"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
                             }
                         }
                         impl @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
@@ -66,6 +68,7 @@ SemverQuery(
                                 visibility_limit @filter(op: "one_of", value: ["$public_or_default"])
                                 name @filter(op: "=", value: ["%method_name"])
                                 unsafe @filter(op: "!=", value: ["$true"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
                             }
                         }
 
@@ -76,6 +79,7 @@ SemverQuery(
                                 visibility_limit @filter(op: "one_of", value: ["$public_or_default"])
                                 name @filter(op: "=", value: ["%method_name"])
                                 unsafe @filter(op: "=", value: ["$true"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 non_matching_span_: span @optional {
                                     filename @output

--- a/src/lints/inherent_method_unsafe_added.ron
+++ b/src/lints/inherent_method_unsafe_added.ron
@@ -14,6 +14,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         inherent_impl {
@@ -39,6 +40,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         # We use "impl" instead of "inherent_impl" here because moving

--- a/src/lints/method_parameter_count_changed.ron
+++ b/src/lints/method_parameter_count_changed.ron
@@ -21,6 +21,7 @@ SemverQuery(
                             method {
                                 method_visibility: visibility_limit @filter(op: "=", value: ["$public"]) @output
                                 method_name: name @output @tag
+                                public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 old_parameter_: parameter @fold @transform(op: "count") @output @tag(name: "parameters")
 
@@ -66,12 +67,14 @@ SemverQuery(
                             method {
                                 visibility_limit @filter(op: "one_of", value: ["$public_or_default"])
                                 name @filter(op: "=", value: ["%method_name"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
                             }
                         }
                         impl @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                             method {
                                 visibility_limit @filter(op: "one_of", value: ["$public_or_default"])
                                 name @filter(op: "=", value: ["%method_name"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 parameter @fold @transform(op: "count") @filter(op: "=", value: ["%parameters"])
                             }
@@ -83,6 +86,7 @@ SemverQuery(
                             method {
                                 visibility_limit @filter(op: "one_of", value: ["$public_or_default"])
                                 name @filter(op: "=", value: ["%method_name"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 current_parameter_: parameter @fold @transform(op: "count") @output
 

--- a/src/lints/method_parameter_count_changed.ron
+++ b/src/lints/method_parameter_count_changed.ron
@@ -14,6 +14,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         inherent_impl {
@@ -40,6 +41,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         # We use "impl" instead of "inherent_impl" here because moving
@@ -98,6 +100,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "public_or_default": ["public", "default"],
+        "true": true,
         "zero": 0,
     },
     error_message: "A publicly-visible method now takes a different number of parameters.",

--- a/src/lints/module_missing.ron
+++ b/src/lints/module_missing.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -40,6 +41,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "zero": 0,
+        "true": true,
     },
     error_message: "A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.",
     per_result_error_template: Some("mod {{join \"::\" path}}, previously in file {{span_filename}}:{{span_begin_line}}"),

--- a/src/lints/pub_module_level_const_missing.ron
+++ b/src/lints/pub_module_level_const_missing.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -40,6 +41,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "zero": 0,
+        "true": true,
     },
     error_message: "A public const is missing, renamed, or changed from const to static.",
     per_result_error_template: Some("{{name}} in file {{span_filename}}:{{span_begin_line}}"),

--- a/src/lints/pub_static_missing.ron
+++ b/src/lints/pub_static_missing.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -41,6 +42,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "zero": 0,
+        "true": true,
     },
     error_message: "A public static is missing, renamed, or made private.",
     per_result_error_template: Some("{{name}} in file {{span_filename}}:{{span_begin_line}}"),

--- a/src/lints/sized_impl_removed.ron
+++ b/src/lints/sized_impl_removed.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         # rustdoc JSON currently *does not* explicitly state that Sized
@@ -44,6 +45,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         impl {

--- a/src/lints/struct_marked_non_exhaustive.ron
+++ b/src/lints/struct_marked_non_exhaustive.ron
@@ -21,6 +21,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -44,6 +45,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
                     }
                 }
@@ -53,6 +55,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "non_exhaustive": "#[non_exhaustive]",
+        "true": true,
         "zero": 0,
     },
     error_message: "A public struct has been marked #[non_exhaustive], which will prevent it from being constructed using a struct literal outside of its crate. It previously had no private fields, so a struct literal could be used to construct it outside its crate.",

--- a/src/lints/struct_missing.ron
+++ b/src/lints/struct_missing.ron
@@ -16,6 +16,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -44,6 +45,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "zero": 0,
+        "true": true,
     },
     error_message: "A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.",
     per_result_error_template: Some("struct {{join \"::\" path}}, previously in file {{span_filename}}:{{span_begin_line}}"),

--- a/src/lints/struct_must_use_added.ron
+++ b/src/lints/struct_must_use_added.ron
@@ -18,6 +18,7 @@ SemverQuery(
 
                         importable_path {
                             path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         attribute {
@@ -41,6 +42,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
@@ -56,6 +58,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "must_use": "must_use",
+        "true": true,
         "zero": 0,
     },
     error_message: "A struct is now #[must_use]. Downstream crates that did not use its value will get a compiler lint.",

--- a/src/lints/struct_pub_field_missing.ron
+++ b/src/lints/struct_pub_field_missing.ron
@@ -21,6 +21,7 @@ SemverQuery(
                         field {
                             field_name: name @output @tag
                             visibility_limit @filter(op: "=", value: ["$public"])
+                            public_api_eligible @filter(op: "=", value: ["$true"])
 
                             span_: span @optional {
                                 filename @output

--- a/src/lints/struct_pub_field_missing.ron
+++ b/src/lints/struct_pub_field_missing.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         field {
@@ -38,6 +39,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
@@ -52,6 +54,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "zero": 0,
+        "true": true,
     },
     error_message: "A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.",
     per_result_error_template: Some("field {{field_name}} of struct {{struct_name}}, previously in file {{span_filename}}:{{span_begin_line}}"),

--- a/src/lints/struct_repr_c_removed.ron
+++ b/src/lints/struct_repr_c_removed.ron
@@ -28,6 +28,7 @@ SemverQuery(
 
                         importable_path {
                             path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
                         }
                     }
                 }
@@ -49,6 +50,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -64,6 +66,7 @@ SemverQuery(
         "public": "public",
         "repr": "repr",
         "c": "C",
+        "true": true,
         "zero": 0,
     },
     error_message: "repr(C) was removed from a struct. This can cause its memory layout to change, breaking FFI use cases.",

--- a/src/lints/struct_repr_transparent_removed.ron
+++ b/src/lints/struct_repr_transparent_removed.ron
@@ -82,6 +82,7 @@ To avoid false-positives, this query is restricted to checking only structs that
 
                         importable_path {
                             path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
                         }
                     }
                 }
@@ -103,6 +104,7 @@ To avoid false-positives, this query is restricted to checking only structs that
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -119,6 +121,7 @@ To avoid false-positives, this query is restricted to checking only structs that
         "repr": "repr",
         "transparent": "transparent",
         "phantom_data": ["core::marker::PhantomData", "std::marker::PhantomData"],
+        "true": true,
         "one": 1,
         "zero": 0,
     },

--- a/src/lints/struct_with_pub_fields_changed_type.ron
+++ b/src/lints/struct_with_pub_fields_changed_type.ron
@@ -26,6 +26,7 @@ More info: https://github.com/obi1kenobi/cargo-semver-checks/issues/297
                         # Ensure the struct has pub fields.
                         field @fold @transform(op: "count") @filter(op: ">", value: ["$zero"]) {
                             visibility_limit @filter(op: "=", value: ["$public"])
+                            public_api_eligible @filter(op: "=", value: ["$true"])
                         }
 
                         importable_path {

--- a/src/lints/struct_with_pub_fields_changed_type.ron
+++ b/src/lints/struct_with_pub_fields_changed_type.ron
@@ -30,6 +30,7 @@ More info: https://github.com/obi1kenobi/cargo-semver-checks/issues/297
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
                     }
                 }
@@ -44,6 +45,7 @@ More info: https://github.com/obi1kenobi/cargo-semver-checks/issues/297
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -57,6 +59,7 @@ More info: https://github.com/obi1kenobi/cargo-semver-checks/issues/297
     }"#,
     arguments: {
         "public": "public",
+        "true": true,
         "zero": 0,
     },
     error_message: "A struct became an enum or union, breaking accesses to its public fields.",

--- a/src/lints/trait_method_missing.ron
+++ b/src/lints/trait_method_missing.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         method {
@@ -35,6 +36,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         method @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
@@ -48,7 +50,12 @@ SemverQuery(
     arguments: {
         "public": "public",
         "zero": 0,
+        "true": true,
     },
+    // TODO: This has a false-positive edge case, because it assumes the trait method
+    //       was *previously* callable. This might not be the case for partially-sealed traits
+    //       which can make some methods uncallable. In that case, the method removal
+    //       is not a breaking change, since it could never have been called in the first place.
     error_message: "A trait method is no longer callable, and may have been renamed or removed entirely.",
     per_result_error_template: Some("method {{method_name}} of trait {{name}}, previously in file {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/lints/trait_method_missing.ron
+++ b/src/lints/trait_method_missing.ron
@@ -21,6 +21,14 @@ SemverQuery(
                         method {
                             method_name: name @output @tag
 
+                            # TODO: Once we can check whether traits are sealed, split this lint:
+                            # - Sealed traits should ignore ineligible (~approx. `#[doc(hidden)]`)
+                            #   methods since they are indeed never public API.
+                            # - Non-sealed traits should only ignore ineligible methods
+                            #   if they have a default implementation; otherwise, implementors
+                            #   of the trait have to impl the method regardless of `#[doc(hidden)]`.
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+
                             span_: span @optional {
                                 filename @output
                                 begin_line @output

--- a/src/lints/trait_missing.ron
+++ b/src/lints/trait_missing.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -40,6 +41,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "zero": 0,
+        "true": true,
     },
     error_message: "A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.",
     per_result_error_template: Some("trait {{join \"::\" path}}, previously in file {{span_filename}}:{{span_begin_line}}"),

--- a/src/lints/trait_must_use_added.ron
+++ b/src/lints/trait_must_use_added.ron
@@ -18,6 +18,7 @@ SemverQuery(
 
                         importable_path {
                             path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         attribute {
@@ -41,6 +42,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
@@ -56,6 +58,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "must_use": "must_use",
+        "true": true,
         "zero": 0,
     },
     error_message: "A trait is now #[must_use]. Downstream crates that called a function returning an impl trait or dyn trait of this trait will get a compiler lint.",

--- a/src/lints/trait_removed_associated_constant.ron
+++ b/src/lints/trait_removed_associated_constant.ron
@@ -2,7 +2,7 @@ SemverQuery(
     id: "trait_removed_associated_constant",
     human_readable_name: "trait's associated constant was removed",
     description: "A trait's associated constant was removed or renamed",
-    required_update: Major, 
+    required_update: Major,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         associated_constant {
@@ -35,18 +36,20 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
-                    
+
                         associated_constant @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                             name @filter(op: "=", value: ["%associated_constant"])
                         }
-                    }                
+                    }
                 }
             }
         }
     }"#,
     arguments: {
         "public": "public",
+        "true": true,
         "zero": 0,
     },
     error_message: "A public trait's associated constant was removed or renamed.",

--- a/src/lints/trait_removed_associated_constant.ron
+++ b/src/lints/trait_removed_associated_constant.ron
@@ -21,6 +21,14 @@ SemverQuery(
                         associated_constant {
                             associated_constant: name @output @tag
 
+                            # TODO: Once we can check whether traits are sealed, split this lint:
+                            # - Sealed traits should ignore ineligible (~approx. `#[doc(hidden)]`)
+                            #   associated constants since they are indeed never public API.
+                            # - Non-sealed traits should only ignore ineligible constants
+                            #   if they have a default value; otherwise, implementors
+                            #   of the trait have to set the const regardless of `#[doc(hidden)]`.
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+
                             span_: span @optional {
                                filename @output
                                begin_line @output

--- a/src/lints/trait_removed_associated_type.ron
+++ b/src/lints/trait_removed_associated_type.ron
@@ -21,6 +21,13 @@ SemverQuery(
                         associated_type {
                             associated_type: name @output @tag
 
+                            # TODO: Once we can check whether traits are sealed, split this lint:
+                            # - Sealed traits should ignore ineligible (~approx. `#[doc(hidden)]`)
+                            #   associated types since they are indeed never public API.
+                            # - Non-sealed traits cannot do so, because implementors
+                            #   of the trait have to set the type regardless of `#[doc(hidden)]`.
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+
                             span_: span {
                                 filename @output
                                 begin_line @output

--- a/src/lints/trait_removed_associated_type.ron
+++ b/src/lints/trait_removed_associated_type.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         associated_type {
@@ -35,6 +36,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         associated_type @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
@@ -47,6 +49,7 @@ SemverQuery(
     }"#,
     arguments: {
         "public": "public",
+        "true": true,
         "zero": 0,
     },
     error_message: "A public trait's associated type was removed or renamed.",

--- a/src/lints/trait_removed_supertrait.ron
+++ b/src/lints/trait_removed_supertrait.ron
@@ -11,9 +11,12 @@ SemverQuery(
                 item {
                     ... on Trait {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
+
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
+
                         supertrait {
                             trait {
                                 importable_path {
@@ -32,6 +35,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         supertrait @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
@@ -53,6 +57,7 @@ SemverQuery(
     }"#,
     arguments: {
         "public": "public",
+        "true": true,
         "zero": 0,
     },
     error_message: "A supertrait was removed from a trait. Users of the trait can no longer assume it can also be used like its supertrait.",

--- a/src/lints/trait_removed_supertrait.ron
+++ b/src/lints/trait_removed_supertrait.ron
@@ -21,6 +21,7 @@ SemverQuery(
                             trait {
                                 importable_path {
                                     trait_path: path @output @tag
+                                    public_api @filter(op: "=", value: ["$true"])
                                 }
                             }
                         }

--- a/src/lints/trait_unsafe_added.ron
+++ b/src/lints/trait_unsafe_added.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
                     }
                 }
@@ -28,6 +29,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {

--- a/src/lints/trait_unsafe_removed.ron
+++ b/src/lints/trait_unsafe_removed.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
                     }
                 }
@@ -28,6 +29,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {

--- a/src/lints/tuple_struct_to_plain_struct.ron
+++ b/src/lints/tuple_struct_to_plain_struct.ron
@@ -25,6 +25,7 @@ Source: Rust for Rustaceans, Chapter 3, "Type Modifications", page 51
 
                         importable_path {
                             path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
                         }
                     }
                 }
@@ -39,6 +40,7 @@ Source: Rust for Rustaceans, Chapter 3, "Type Modifications", page 51
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -55,6 +57,7 @@ Source: Rust for Rustaceans, Chapter 3, "Type Modifications", page 51
         "tuple": "tuple",
         "plain": "plain",
         "non_exhaustive": "#[non_exhaustive]",
+        "true": true,
         "zero": 0,
     },
     error_message: "A publicly-visible, exhaustive tuple struct with pub fields changed to normal (curly-braces) struct, which cannot be constructed using the same struct literal syntax.",

--- a/src/lints/type_marked_deprecated.ron
+++ b/src/lints/type_marked_deprecated.ron
@@ -16,6 +16,7 @@ SemverQuery(
 
                         importable_path {
                             path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         attribute {
@@ -40,6 +41,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
@@ -55,6 +57,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "deprecated": "deprecated",
+        "true": true,
         "zero": 0,
     },
     error_message: "A type is now #[deprecated]. Downstream crates will get a compiler warning when using this type.",

--- a/src/lints/type_marked_deprecated.ron
+++ b/src/lints/type_marked_deprecated.ron
@@ -13,17 +13,11 @@ SemverQuery(
                         visibility_limit @filter(op: "=", value: ["$public"])
                         name @output
                         owner_type: __typename @tag @output
+                        deprecated @filter(op: "=", value: ["$true"])
 
                         importable_path {
                             path @tag @output
                             public_api @filter(op: "=", value: ["$true"])
-                        }
-
-                        attribute {
-                            new_attr: raw_attribute @output
-                            content {
-                                base @filter(op: "=", value: ["$deprecated"])
-                            }
                         }
 
                         span_: span @optional {
@@ -38,16 +32,11 @@ SemverQuery(
                     ... on ImplOwner {
                         visibility_limit @filter(op: "=", value: ["$public"]) @output
                         __typename @filter(op: "=", value: ["%owner_type"])
+                        deprecated @filter(op: "!=", value: ["$true"])
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
                             public_api @filter(op: "=", value: ["$true"])
-                        }
-
-                        attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
-                            content {
-                                base @filter(op: "=", value: ["$deprecated"])
-                            }
                         }
                     }
                 }

--- a/src/lints/type_marked_deprecated.ron
+++ b/src/lints/type_marked_deprecated.ron
@@ -45,9 +45,7 @@ SemverQuery(
     }"#,
     arguments: {
         "public": "public",
-        "deprecated": "deprecated",
         "true": true,
-        "zero": 0,
     },
     error_message: "A type is now #[deprecated]. Downstream crates will get a compiler warning when using this type.",
     per_result_error_template: Some("{{owner_type}} {{name}} in {{span_filename}}:{{span_begin_line}}"),

--- a/src/lints/unit_struct_changed_kind.ron
+++ b/src/lints/unit_struct_changed_kind.ron
@@ -23,6 +23,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
                     }
                 }
@@ -36,6 +37,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         span_: span @optional {
@@ -52,6 +54,7 @@ SemverQuery(
         "unit": "unit",
         "plain": "plain",
         "non_exhaustive": "#[non_exhaustive]",
+        "true": true,
     },
     error_message: "A public unit struct has been changed to a normal (curly-braces) struct, which cannot be constructed using the same struct literal syntax.",
     per_result_error_template: Some("struct {{name}} in {{span_filename}}:{{span_begin_line}}"),

--- a/src/lints/variant_marked_non_exhaustive.ron
+++ b/src/lints/variant_marked_non_exhaustive.ron
@@ -15,6 +15,7 @@ SemverQuery(
 
                         importable_path {
                             path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         variant {
@@ -32,6 +33,7 @@ SemverQuery(
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
                         }
 
                         variant {
@@ -51,6 +53,7 @@ SemverQuery(
     arguments: {
         "public": "public",
         "non_exhaustive": "#[non_exhaustive]",
+        "true": true,
     },
     error_message: "A public enum's variant has been marked #[non_exhaustive], which will prevent it from being constructed using a literal outside of its crate.",
     per_result_error_template: Some("variant {{name}}:{{variant_name}} in {{span_filename}}:{{span_begin_line}}"),

--- a/src/lints/variant_marked_non_exhaustive.ron
+++ b/src/lints/variant_marked_non_exhaustive.ron
@@ -20,6 +20,7 @@ SemverQuery(
 
                         variant {
                             variant_name: name @output @tag
+                            public_api_eligible @filter(op: "=", value: ["$true"])
                             attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
                         }
                     }
@@ -38,6 +39,7 @@ SemverQuery(
 
                         variant {
                             name @filter(op: "=", value: ["%variant_name"])
+                            public_api_eligible @filter(op: "=", value: ["$true"])
                             attrs @filter(op: "contains", value: ["$non_exhaustive"])
 
                             span_: span @optional {

--- a/test_crates/associated_items_hidden_from_public_api/new/Cargo.toml
+++ b/test_crates/associated_items_hidden_from_public_api/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "associated_items_hidden_from_public_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/associated_items_hidden_from_public_api/new/src/lib.rs
+++ b/test_crates/associated_items_hidden_from_public_api/new/src/lib.rs
@@ -1,0 +1,1 @@
+pub struct Example;

--- a/test_crates/associated_items_hidden_from_public_api/old/Cargo.toml
+++ b/test_crates/associated_items_hidden_from_public_api/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "associated_items_hidden_from_public_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/associated_items_hidden_from_public_api/old/src/lib.rs
+++ b/test_crates/associated_items_hidden_from_public_api/old/src/lib.rs
@@ -1,0 +1,16 @@
+pub struct Example;
+
+impl Example {
+    #[doc(hidden)]
+    pub fn directly_hidden_fn() {}
+
+    #[doc(hidden)]
+    pub const DIRECTLY_HIDDEN_CONST: i64 = 42;
+}
+
+#[doc(hidden)]
+impl Example {
+    pub fn impl_hidden_fn() {}
+
+    pub const IMPL_HIDDEN_CONST: i64 = 42;
+}

--- a/test_crates/enum_struct_field_hidden_from_public_api/new/Cargo.toml
+++ b/test_crates/enum_struct_field_hidden_from_public_api/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_struct_field_hidden_from_public_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_struct_field_hidden_from_public_api/new/src/lib.rs
+++ b/test_crates/enum_struct_field_hidden_from_public_api/new/src/lib.rs
@@ -1,0 +1,53 @@
+/// The relationship between semver and removing fields from enum variants is complex.
+///
+/// Removing hidden fields from a struct variant (whether hidden or not) is not a breaking change.
+/// Removing fields from hidden struct variants is not breaking, even if the fields
+/// themselves weren't marked as hidden.
+///
+/// For tuple variants, the same rules as above apply, with one caveat: if the tuple variant
+/// is not itself hidden, the removed fields must not cause non-hidden fields to get renumbered.
+/// This is because their index is public API and they may be accessed with `variant.1` syntax.
+pub enum RemovedHiddenFieldFromVariant {
+    Other,
+
+    #[doc(hidden)]
+    HiddenStructVariant {
+        x: i64,
+    },
+
+    VisibleStructVariant {
+        x: i64,
+    },
+
+    #[doc(hidden)]
+    HiddenTupleVariant(i64, String),
+
+    VisibleTupleVariantNoReordering(i64),
+
+    /// The removal of the hidden field makes the fields behind it have different indexes.
+    VisibleTupleVariantBreaking(i64, String, usize),
+}
+
+/// Adding fields to an exhaustive public API variant of a public API enum is always breaking,
+/// even if the new fields are hidden from the public API.
+pub enum AddedVariantField {
+    StructVariant {
+        x: i64,
+
+        #[doc(hidden)]
+        y: i64,
+    },
+
+    TupleVariant(i64, #[doc(hidden)] i64),
+
+    #[non_exhaustive]
+    NonExhaustiveStructVariant {
+        x: i64,
+
+        #[doc(hidden)]
+        y: i64,
+    },
+
+    #[non_exhaustive]
+    NonExhaustiveTupleVariant(i64, #[doc(hidden)] i64),
+}

--- a/test_crates/enum_struct_field_hidden_from_public_api/old/Cargo.toml
+++ b/test_crates/enum_struct_field_hidden_from_public_api/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_struct_field_hidden_from_public_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_struct_field_hidden_from_public_api/old/src/lib.rs
+++ b/test_crates/enum_struct_field_hidden_from_public_api/old/src/lib.rs
@@ -1,0 +1,55 @@
+/// The relationship between semver and removing fields from enum variants is complex.
+///
+/// Removing hidden fields from a struct variant (whether hidden or not) is not a breaking change.
+/// Removing fields from hidden struct variants is not breaking, even if the fields
+/// themselves weren't marked as hidden.
+///
+/// For tuple variants, the same rules as above apply, with one caveat: if the tuple variant
+/// is not itself hidden, the removed fields must not cause non-hidden fields to get renumbered.
+/// This is because their index is public API and they may be accessed with `variant.1` syntax.
+pub enum RemovedHiddenFieldFromVariant {
+    Other,
+
+    #[doc(hidden)]
+    HiddenStructVariant {
+        x: i64,
+
+        #[doc(hidden)]
+        y: i64,
+
+        z: i64,
+    },
+
+    VisibleStructVariant {
+        x: i64,
+
+        #[doc(hidden)]
+        y: i64,
+    },
+
+    #[doc(hidden)]
+    HiddenTupleVariant(i64, #[doc(hidden)] i64, String),
+
+    VisibleTupleVariantNoReordering(i64, #[doc(hidden)] i64),
+
+    /// The removal of the hidden field makes the fields behind it have different indexes.
+    VisibleTupleVariantBreaking(i64, #[doc(hidden)] i64, String, usize),
+}
+
+/// Adding fields to an exhaustive public API variant of a public API enum is always breaking,
+/// even if the new fields are hidden from the public API.
+pub enum AddedVariantField {
+    StructVariant {
+        x: i64,
+    },
+
+    TupleVariant(i64),
+
+    #[non_exhaustive]
+    NonExhaustiveStructVariant {
+        x: i64,
+    },
+
+    #[non_exhaustive]
+    NonExhaustiveTupleVariant(i64),
+}

--- a/test_crates/enum_variant_hidden_from_public_api/new/Cargo.toml
+++ b/test_crates/enum_variant_hidden_from_public_api/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_variant_hidden_from_public_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_variant_hidden_from_public_api/new/src/lib.rs
+++ b/test_crates/enum_variant_hidden_from_public_api/new/src/lib.rs
@@ -1,0 +1,35 @@
+/// Hiding a variant from the public API is a breaking change.
+pub enum HiddenVariant {
+    #[doc(hidden)]
+    ToBeHidden,
+
+    Other,
+}
+
+/// Adding a variant to an exhaustive public API enum is always breaking,
+/// even if the new variant is hidden from the public API.
+pub enum AddedVariant {
+    First,
+    Second,
+
+    #[doc(hidden)]
+    Added,
+}
+
+/// Removing a hidden variant from a public API enum is not a breaking change.
+pub enum RemovedHiddenVariant {
+    Other,
+}
+
+/// Removing fields from a hidden variant of a public API enum is not a breaking change.
+pub enum RemovedFieldFromHiddenVariant {
+    Other,
+
+    #[doc(hidden)]
+    RemovedStructField {
+        x: i64,
+    },
+
+    #[doc(hidden)]
+    RemovedTupleField(i64),
+}

--- a/test_crates/enum_variant_hidden_from_public_api/old/Cargo.toml
+++ b/test_crates/enum_variant_hidden_from_public_api/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_variant_hidden_from_public_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_variant_hidden_from_public_api/old/src/lib.rs
+++ b/test_crates/enum_variant_hidden_from_public_api/old/src/lib.rs
@@ -1,0 +1,34 @@
+/// Hiding a variant from the public API is a breaking change.
+pub enum HiddenVariant {
+    ToBeHidden,
+    Other,
+}
+
+/// Adding a variant to an exhaustive public API enum is always breaking,
+/// even if the new variant is hidden from the public API.
+pub enum AddedVariant {
+    First,
+    Second,
+}
+
+/// Removing a hidden variant from a public API enum is not a breaking change.
+pub enum RemovedHiddenVariant {
+    Other,
+
+    #[doc(hidden)]
+    ToBeRemoved,
+}
+
+/// Removing fields from a hidden variant of a public API enum is not a breaking change.
+pub enum RemovedFieldFromHiddenVariant {
+    Other,
+
+    #[doc(hidden)]
+    RemovedStructField {
+        x: i64,
+        y: i64,
+    },
+
+    #[doc(hidden)]
+    RemovedTupleField(i64, i64),
+}

--- a/test_crates/module_contents_hidden_from_public_api/new/Cargo.toml
+++ b/test_crates/module_contents_hidden_from_public_api/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "module_contents_hidden_from_public_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/module_contents_hidden_from_public_api/new/src/lib.rs
+++ b/test_crates/module_contents_hidden_from_public_api/new/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod removals {}
+
+#[doc(hidden)]
+pub fn changed_fn_signature(x: i64, y: i64, z: i64) {
+    assert_eq!(x + y, z);
+}

--- a/test_crates/module_contents_hidden_from_public_api/old/Cargo.toml
+++ b/test_crates/module_contents_hidden_from_public_api/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "module_contents_hidden_from_public_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/module_contents_hidden_from_public_api/old/src/lib.rs
+++ b/test_crates/module_contents_hidden_from_public_api/old/src/lib.rs
@@ -1,0 +1,24 @@
+pub mod removals {
+    #[doc(hidden)]
+    pub fn hidden() {}
+
+    #[doc(hidden)]
+    pub static VALUE: &'static str = "hidden";
+
+    #[doc(hidden)]
+    pub const UNCHANGING: i64 = 42;
+}
+
+#[doc(hidden)]
+pub mod module_removal {
+    pub fn parent_hidden() {}
+
+    pub static OTHER_VALUE: &'static str = "hidden";
+
+    pub const FIXED: i64 = 42;
+}
+
+#[doc(hidden)]
+pub fn changed_fn_signature(x: i64, y: i64) -> i64 {
+    x + y
+}

--- a/test_crates/struct_field_hidden_from_public_api/new/Cargo.toml
+++ b/test_crates/struct_field_hidden_from_public_api/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "struct_field_hidden_from_public_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/struct_field_hidden_from_public_api/new/src/lib.rs
+++ b/test_crates/struct_field_hidden_from_public_api/new/src/lib.rs
@@ -1,0 +1,53 @@
+/// The relationship between semver and removing struct fields is complex.
+///
+/// Removing hidden fields from a plain struct (whether hidden or not) is not a breaking change.
+/// Removing fields from hidden plain struct is not breaking, even if the fields
+/// themselves weren't marked as hidden. (Plain structs are the ones with curly braces.)
+///
+/// For tuple structs, the same rules as above apply, with one caveat: if the tuple struct
+/// is not itself hidden, the removed fields must not cause non-hidden fields to get renumbered.
+/// This is because their index is public API and they may be accessed with `value.1` syntax.
+pub mod removals {
+    #[doc(hidden)]
+    pub struct HiddenPlainStruct {
+        x: i64,
+
+        z: i64,
+    }
+
+    pub struct VisiblePlainStruct {
+        x: i64,
+    }
+
+    #[doc(hidden)]
+    pub struct HiddenTupleStruct(i64, String);
+
+    pub struct VisibleTupleStructNoReordering(i64);
+
+    /// The removal of the hidden field makes the fields behind it have different indexes.
+    pub struct VisibleTupleStructBreaking(i64, String, usize);
+}
+
+/// Adding fields to an exhaustive public API struct is always breaking,
+/// even if the new fields are hidden from the public API.
+pub mod additions {
+    pub struct PlainStruct {
+        x: i64,
+
+        #[doc(hidden)]
+        y: i64,
+    }
+
+    pub struct TupleStruct(i64, #[doc(hidden)] i64);
+
+    #[non_exhaustive]
+    pub struct NonExhaustivePlainStruct {
+        x: i64,
+
+        #[doc(hidden)]
+        y: i64,
+    }
+
+    #[non_exhaustive]
+    pub struct NonExhaustiveTupleStruct(i64, #[doc(hidden)] i64);
+}

--- a/test_crates/struct_field_hidden_from_public_api/old/Cargo.toml
+++ b/test_crates/struct_field_hidden_from_public_api/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "struct_field_hidden_from_public_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/struct_field_hidden_from_public_api/old/src/lib.rs
+++ b/test_crates/struct_field_hidden_from_public_api/old/src/lib.rs
@@ -1,0 +1,53 @@
+/// The relationship between semver and removing struct fields is complex.
+///
+/// Removing hidden fields from a plain struct (whether hidden or not) is not a breaking change.
+/// Removing fields from hidden plain struct is not breaking, even if the fields
+/// themselves weren't marked as hidden. (Plain structs are the ones with curly braces.)
+///
+/// For tuple structs, the same rules as above apply, with one caveat: if the tuple struct
+/// is not itself hidden, the removed fields must not cause non-hidden fields to get renumbered.
+/// This is because their index is public API and they may be accessed with `value.1` syntax.
+pub mod removals {
+    #[doc(hidden)]
+    pub struct HiddenPlainStruct {
+        x: i64,
+
+        #[doc(hidden)]
+        y: i64,
+
+        z: i64,
+    }
+
+    pub struct VisiblePlainStruct {
+        x: i64,
+
+        #[doc(hidden)]
+        y: i64,
+    }
+
+    #[doc(hidden)]
+    pub struct HiddenTupleStruct(i64, #[doc(hidden)] i64, String);
+
+    pub struct VisibleTupleStructNoReordering(i64, #[doc(hidden)] i64);
+
+    /// The removal of the hidden field makes the fields behind it have different indexes.
+    pub struct VisibleTupleStructBreaking(i64, #[doc(hidden)] i64, String, usize);
+}
+
+/// Adding fields to an exhaustive public API struct is always breaking,
+/// even if the new fields are hidden from the public API.
+pub mod additions {
+    pub struct PlainStruct {
+        x: i64,
+    }
+
+    pub struct TupleStruct(i64);
+
+    #[non_exhaustive]
+    pub struct NonExhaustivePlainStruct {
+        x: i64,
+    }
+
+    #[non_exhaustive]
+    pub struct NonExhaustiveTupleStruct(i64);
+}

--- a/test_crates/trait_items_hidden_from_public_api/new/Cargo.toml
+++ b/test_crates/trait_items_hidden_from_public_api/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_items_hidden_from_public_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_items_hidden_from_public_api/new/src/lib.rs
+++ b/test_crates/trait_items_hidden_from_public_api/new/src/lib.rs
@@ -1,0 +1,47 @@
+pub trait NonSealed {
+    /// Changing the bounds on an associated type is breaking,
+    /// even if the type was hidden.
+    #[doc(hidden)]
+    type Bounded: Send + Sync;
+
+    /// Removing the default value for a hidden associated const of a non-sealed trait is breaking:
+    /// any implementations of this trait are now required to specify a value for the const.
+    #[doc(hidden)]
+    const DEFAULT_REMOVED: i64;
+
+    /// Changing a function signature without a default impl in a non-sealed trait is breaking,
+    /// under the same reasoning as for associated constants without a default.
+    #[doc(hidden)]
+    fn changed_signature(x: i64, y: i64, z: i64) -> i64;
+
+    /// Removing a default impl for a function in a non-sealed trait is breaking,
+    /// even if the function was hidden: external implementors must now provide an implementation.
+    #[doc(hidden)]
+    fn default_impl_removed(x: i64, y: i64) -> i64;
+}
+
+mod private {
+    pub trait Sealed {}
+}
+
+pub trait SealedViaSupertrait : private::Sealed {
+    /// Changing the bounds on a hidden associated type of a sealed trait is not breaking per se.
+    #[doc(hidden)]
+    type Bounded: Send + Sync;
+
+    /// Removing the default value for a hidden associated const of a sealed trait is not breaking,
+    /// regardless of the presence of a default value, since all implementors of the trait
+    /// are required to be in the same crate.
+    #[doc(hidden)]
+    const DEFAULT_REMOVED: i64;
+
+    /// Changing a hidden function's signature in a sealed trait is not breaking,
+    /// since all implementors of this trait are required to be in the same crate.
+    #[doc(hidden)]
+    fn changed_signature(x: i64, y: i64, z: i64) -> i64;
+
+    /// Removing a default impl for a hidden function in a sealed trait is not breaking,
+    /// since all implementors of this trait are required to be in the same crate.
+    #[doc(hidden)]
+    fn default_impl_removed(x: i64, y: i64) -> i64;
+}

--- a/test_crates/trait_items_hidden_from_public_api/old/Cargo.toml
+++ b/test_crates/trait_items_hidden_from_public_api/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_items_hidden_from_public_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_items_hidden_from_public_api/old/src/lib.rs
+++ b/test_crates/trait_items_hidden_from_public_api/old/src/lib.rs
@@ -1,0 +1,99 @@
+pub trait NonSealed {
+    /// Removing an associated type is breaking when the trait is not hidden nor sealed,
+    /// even if the associated type was hidden.
+    #[doc(hidden)]
+    type T;
+
+    /// Changing the bounds on an associated type is breaking,
+    /// even if the type was hidden.
+    #[doc(hidden)]
+    type Bounded: Clone;
+
+    /// Removing an associated const without a default value in a non-sealed trait is breaking,
+    /// even if the const was hidden.
+    ///
+    /// This is because the trait could have been implemented by external users,
+    /// and such implementations were *required* to specify a value for this const.
+    /// It is that const value statement that will be broken.
+    #[doc(hidden)]
+    const WITHOUT_DEFAULT: i64;
+
+    /// Removing an associated const with a default value is *not* breaking,
+    /// even if the const was hidden.
+    ///
+    /// This is because the trait was possible to implement without redefining this constant.
+    /// Since the constant was hidden from the public API, any use of it was non-conformant
+    /// and constituted use of a non-public API.
+    #[doc(hidden)]
+    const WITH_DEFAULT: i64 = 5;
+
+    /// Removing the default value for a hidden associated const of a non-sealed trait is breaking:
+    /// any implementations of this trait are now required to specify a value for the const.
+    #[doc(hidden)]
+    const DEFAULT_REMOVED: i64 = 5;
+
+    /// Removing an associated function without a default impl in a non-sealed trait is breaking,
+    /// under the same reasoning as for associated constants without a default.
+    #[doc(hidden)]
+    fn implement_me();
+
+    /// Changing a function signature without a default impl in a non-sealed trait is breaking,
+    /// under the same reasoning as for associated constants without a default.
+    #[doc(hidden)]
+    fn changed_signature(x: i64, y: i64);
+
+    /// Removing a default impl for a function in a non-sealed trait is breaking,
+    /// even if the function was hidden: external implementors must now provide an implementation.
+    #[doc(hidden)]
+    fn default_impl_removed(x: i64, y: i64) -> i64 {
+        x + y
+    }
+}
+
+mod private {
+    pub trait Sealed {}
+}
+
+pub trait SealedViaSupertrait : private::Sealed {
+    /// Removing a hidden associated type is not breaking when the trait is sealed.
+    #[doc(hidden)]
+    type T;
+
+    /// Changing the bounds on a hidden associated type of a sealed trait is not breaking per se.
+    #[doc(hidden)]
+    type Bounded: Clone;
+
+    /// Removing a hidden associated const value in a sealed trait is not breaking,
+    /// regardless of the presence of a default value.
+    #[doc(hidden)]
+    const WITHOUT_DEFAULT: i64;
+
+    /// Removing a hidden associated const value in a sealed trait is not breaking,
+    /// regardless of the presence of a default value.
+    #[doc(hidden)]
+    const WITH_DEFAULT: i64 = 5;
+
+    /// Removing the default value for a hidden associated const of a sealed trait is not breaking,
+    /// regardless of the presence of a default value, since all implementors of the trait
+    /// are required to be in the same crate.
+    #[doc(hidden)]
+    const DEFAULT_REMOVED: i64 = 5;
+
+    /// Removing a hidden associated function in a sealed trait is not breaking,
+    /// regardless of the presence of a default implementation.
+    /// All implementors of the trait are required to be in the same crate.
+    #[doc(hidden)]
+    fn implement_me();
+
+    /// Changing a hidden function's signature in a sealed trait is not breaking,
+    /// since all implementors of this trait are required to be in the same crate.
+    #[doc(hidden)]
+    fn changed_signature(x: i64, y: i64);
+
+    /// Removing a default impl for a hidden function in a sealed trait is not breaking,
+    /// since all implementors of this trait are required to be in the same crate.
+    #[doc(hidden)]
+    fn default_impl_removed(x: i64, y: i64) -> i64 {
+        x + y
+    }
+}

--- a/test_crates/traits_hidden_from_public_api/new/Cargo.toml
+++ b/test_crates/traits_hidden_from_public_api/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "traits_hidden_from_public_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/traits_hidden_from_public_api/new/src/lib.rs
+++ b/test_crates/traits_hidden_from_public_api/new/src/lib.rs
@@ -1,0 +1,20 @@
+#[doc(hidden)]
+pub trait Example {
+    /// Changing the bounds on an associated type is not breaking for hidden traits.
+    type Bounded: Send + Sync;
+
+    /// Changing the type of an associated const is not breaking for hidden traits.
+    const CHANGED: String;
+
+    /// Removing the default value for an associated const is not breaking for hidden traits.
+    const WITH_DEFAULT: i64;
+
+    /// Changing the default value of an associated const is not breaking for hidden traits.
+    const THE_ANSWER: i64 = 53;
+
+    /// Changing a function signature is not breaking for hidden traits.
+    fn changed_signature(x: i64, y: i64, z: i64) -> i64;
+
+    /// Removing a default impl for a function is not breaking for hidden traits.
+    fn default_impl_removed(x: i64, y: i64) -> i64;
+}

--- a/test_crates/traits_hidden_from_public_api/old/Cargo.toml
+++ b/test_crates/traits_hidden_from_public_api/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "traits_hidden_from_public_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/traits_hidden_from_public_api/old/src/lib.rs
+++ b/test_crates/traits_hidden_from_public_api/old/src/lib.rs
@@ -1,0 +1,31 @@
+#[doc(hidden)]
+pub trait Example {
+    /// Removing an associated type is not breaking for hidden traits.
+    type T;
+
+    /// Changing the bounds on an associated type is not breaking for hidden traits.
+    type Bounded: Clone;
+
+    /// Removing an associated const is not breaking for hidden traits.
+    const N: i64;
+
+    /// Changing the type of an associated const is not breaking for hidden traits.
+    const CHANGED: usize;
+
+    /// Removing the default value for an associated const is not breaking for hidden traits.
+    const WITH_DEFAULT: i64 = 5;
+
+    /// Changing the default value of an associated const is not breaking for hidden traits.
+    const THE_ANSWER: i64 = 42;
+
+    /// Removing an associated function is not breaking for hidden traits.
+    fn implement_me();
+
+    /// Changing a function signature is not breaking for hidden traits.
+    fn changed_signature(x: i64, y: i64);
+
+    /// Removing a default impl for a function is not breaking for hidden traits.
+    fn default_impl_removed(x: i64, y: i64) -> i64 {
+        x + y
+    }
+}

--- a/test_crates/type_hidden_from_public_api/new/Cargo.toml
+++ b/test_crates/type_hidden_from_public_api/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "type_hidden_from_public_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/type_hidden_from_public_api/new/src/lib.rs
+++ b/test_crates/type_hidden_from_public_api/new/src/lib.rs
@@ -1,0 +1,22 @@
+#[doc(hidden)]
+pub struct ExamplePlainStruct {
+    pub x: i64,
+}
+
+#[doc(hidden)]
+pub struct ExampleTupleStruct(i64);
+
+#[doc(hidden)]
+pub struct ExampleUnitStruct;
+
+#[doc(hidden)]
+pub enum ExampleEnum {
+    First,
+    Second,
+}
+
+#[doc(hidden)]
+pub union ExampleUnion {
+    pub signed: i64,
+    pub unsigned: u64,
+}

--- a/test_crates/type_hidden_from_public_api/old/Cargo.toml
+++ b/test_crates/type_hidden_from_public_api/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "type_hidden_from_public_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/type_hidden_from_public_api/old/src/lib.rs
+++ b/test_crates/type_hidden_from_public_api/old/src/lib.rs
@@ -1,0 +1,43 @@
+pub struct ExamplePlainStruct {
+    pub x: i64,
+}
+
+pub struct ExampleTupleStruct(i64);
+
+pub struct ExampleUnitStruct;
+
+pub enum ExampleEnum {
+    First,
+    Second,
+}
+
+pub union ExampleUnion {
+    pub signed: i64,
+    pub unsigned: u64,
+}
+
+/// This module gets removed completely, and this is not a breaking change
+/// because it was never public API in the first place.
+///
+/// Since the module itself is also `#[doc(hidden)]`, it shouldn't get reported
+/// by the `module_missing` lint either.
+#[doc(hidden)]
+pub mod to_be_removed {
+    pub struct RemovedPlainStruct {
+        pub x: i64,
+    }
+
+    pub struct RemovedTupleStruct(i64);
+
+    pub struct RemovedUnitStruct;
+
+    pub enum RemovedEnum {
+        First,
+        Second,
+    }
+
+    pub union RemovedUnion {
+        pub signed: i64,
+        pub unsigned: u64,
+    }
+}

--- a/test_outputs/enum_struct_variant_field_added.output.ron
+++ b/test_outputs/enum_struct_variant_field_added.output.ron
@@ -1,4 +1,17 @@
 {
+    "./test_crates/enum_struct_field_hidden_from_public_api/": [
+        {
+            "enum_name": String("AddedVariantField"),
+            "field_name": String("y"),
+            "path": List([
+                String("enum_struct_field_hidden_from_public_api"),
+                String("AddedVariantField"),
+            ]),
+            "span_begin_line": Uint64(38),
+            "span_filename": String("src/lib.rs"),
+            "variant_name": String("StructVariant"),
+        },
+    ],
     "./test_crates/enum_struct_variant_field_added/": [
         {
             "enum_name": String("PubEnum"),

--- a/test_outputs/enum_tuple_variant_field_added.output.ron
+++ b/test_outputs/enum_tuple_variant_field_added.output.ron
@@ -1,4 +1,17 @@
 {
+    "./test_crates/enum_struct_field_hidden_from_public_api/": [
+        {
+            "enum_name": String("AddedVariantField"),
+            "field_name": String("1"),
+            "path": List([
+                String("enum_struct_field_hidden_from_public_api"),
+                String("AddedVariantField"),
+            ]),
+            "span_begin_line": Uint64(41),
+            "span_filename": String("src/lib.rs"),
+            "variant_name": String("TupleVariant"),
+        },
+    ],
     "./test_crates/enum_tuple_variant_field_added/": [
         {
             "enum_name": String("PublicEnum"),

--- a/test_outputs/enum_tuple_variant_field_missing.output.ron
+++ b/test_outputs/enum_tuple_variant_field_missing.output.ron
@@ -1,4 +1,17 @@
 {
+    "./test_crates/enum_struct_field_hidden_from_public_api/": [
+        {
+            "enum_name": String("RemovedHiddenFieldFromVariant"),
+            "field_name": String("3"),
+            "path": List([
+                String("enum_struct_field_hidden_from_public_api"),
+                String("RemovedHiddenFieldFromVariant"),
+            ]),
+            "span_begin_line": Uint64(36),
+            "span_filename": String("src/lib.rs"),
+            "variant_name": String("VisibleTupleVariantBreaking"),
+        },
+    ],
     "./test_crates/enum_tuple_variant_field_missing/": [
         {
             "enum_name": String("PublicEnum"),

--- a/test_outputs/enum_variant_added.output.ron
+++ b/test_outputs/enum_variant_added.output.ron
@@ -12,4 +12,17 @@
             "visibility_limit": String("public"),
         },
     ],
+    "./test_crates/enum_variant_hidden_from_public_api/": [
+        {
+            "enum_name": String("AddedVariant"),
+            "path": List([
+                String("enum_variant_hidden_from_public_api"),
+                String("AddedVariant"),
+            ]),
+            "span_begin_line": Uint64(16),
+            "span_filename": String("src/lib.rs"),
+            "variant_name": String("Added"),
+            "visibility_limit": String("public"),
+        },
+    ],
 }

--- a/test_outputs/inherent_method_const_removed.output.ron
+++ b/test_outputs/inherent_method_const_removed.output.ron
@@ -4,8 +4,12 @@
             "method_name": String("associated_fn"),
             "method_visibility": String("public"),
             "name": String("Foo"),
-            "non_matching_span_begin_line": List([]),
-            "non_matching_span_filename": List([]),
+            "non_matching_span_begin_line": List([
+                Uint64(4),
+            ]),
+            "non_matching_span_filename": List([
+                String("src/lib.rs"),
+            ]),
             "path": List([
                 String("inherent_method_const_removed"),
                 String("Foo"),
@@ -18,8 +22,12 @@
             "method_name": String("method"),
             "method_visibility": String("public"),
             "name": String("Foo"),
-            "non_matching_span_begin_line": List([]),
-            "non_matching_span_filename": List([]),
+            "non_matching_span_begin_line": List([
+                Uint64(8),
+            ]),
+            "non_matching_span_filename": List([
+                String("src/lib.rs"),
+            ]),
             "path": List([
                 String("inherent_method_const_removed"),
                 String("Foo"),

--- a/test_outputs/type_marked_deprecated.output.ron
+++ b/test_outputs/type_marked_deprecated.output.ron
@@ -2,7 +2,6 @@
     "./test_crates/type_marked_deprecated/": [
         {
             "name": String("EnumToDeprecatedEnum"),
-            "new_attr": String("#[deprecated]"),
             "owner_type": String("Enum"),
             "path": List([
                 String("type_marked_deprecated"),
@@ -15,7 +14,6 @@
         },
         {
             "name": String("EnumToDeprecatedMessageEnum"),
-            "new_attr": String("#[deprecated = \"This attribute was added\"]"),
             "owner_type": String("Enum"),
             "path": List([
                 String("type_marked_deprecated"),
@@ -28,7 +26,6 @@
         },
         {
             "name": String("StructToDeprecatedStruct"),
-            "new_attr": String("#[deprecated]"),
             "owner_type": String("Struct"),
             "path": List([
                 String("type_marked_deprecated"),
@@ -41,7 +38,6 @@
         },
         {
             "name": String("StructToDeprecatedMessageStruct"),
-            "new_attr": String("#[deprecated = \"This attribute was added\"]"),
             "owner_type": String("Struct"),
             "path": List([
                 String("type_marked_deprecated"),


### PR DESCRIPTION
Based on the approach that @davidhewitt and I prototyped a few months ago, which has since matured and been merged: https://github.com/obi1kenobi/trustfall-rustdoc-adapter/pull/260/

This gets us almost all of the edge cases around `#[doc(hidden)]`: structs, fields, enums, variants, fields within variants, functions, methods, (free or associated) constants, statics, etc. There are test cases in this PR for each of them.

The remaining edge cases require knowledge of whether traits are sealed, so we can accurately determine if e.g. the deletion of a `#[doc(hidden)]` trait associated type is a breaking change because it might affect implementations outside the crate. Sealed traits are of interest for many other lints as well (see #5) so I'm sure we'll get that too before long.

This PR should resolve a *vast majority* of the current false-positives encountered in practice by users of cargo-semver-checks, as measured by our study of the top 1000 Rust crates across all their releases since 2017: https://predr.ag/blog/semver-violations-are-common-better-tooling-is-the-answer/