### PR TITLE
implement function_now_doc_hidden lint

### DIFF
--- a/src/lints/function_now_doc_hidden.ron
+++ b/src/lints/function_now_doc_hidden.ron
@@ -23,7 +23,7 @@ SemverQuery(
                 item {
                     ... on Function {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        struct_name: name @output
+                        function_name: name @output
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
@@ -44,5 +44,5 @@ SemverQuery(
         "true": true,
     },
     error_message: "A pub function is now #[doc(hidden)], removing it from the crate's public API.",
-    per_result_error_template: Some("function {{struct_name}} in file {{span_filename}}:{{span_begin_line}}"),
+    per_result_error_template: Some("function {{function_name}} in file {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/lints/function_now_doc_hidden.ron
+++ b/src/lints/function_now_doc_hidden.ron
@@ -1,0 +1,48 @@
+SemverQuery(
+    id: "function_now_doc_hidden",
+    human_readable_name: "pub function is now #[doc(hidden)]",
+    description: "A pub function is now marked #[doc(hidden)] and is thus no longer part of the public API.",
+    required_update: Major,
+    reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Function {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Function {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        struct_name: name @output
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "!=", value: ["$true"])
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+    },
+    error_message: "A pub function is now #[doc(hidden)], removing it from the crate's public API.",
+    per_result_error_template: Some("function {{struct_name}} in file {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -485,6 +485,7 @@ add_lints!(
     function_const_removed,
     function_missing,
     function_must_use_added,
+    function_now_doc_hidden,
     function_parameter_count_changed,
     function_unsafe_added,
     inherent_method_const_removed,

--- a/test_crates/function_now_doc_hidden/new/Cargo.toml
+++ b/test_crates/function_now_doc_hidden/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "function_now_doc_hidden"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/function_now_doc_hidden/new/src/lib.rs
+++ b/test_crates/function_now_doc_hidden/new/src/lib.rs
@@ -58,4 +58,14 @@ pub fn public_function_documented_with_string_hidden() {}
 
 #[doc(hidden)] // shouldn't flag under the `function_now_doc_hidden` lint,
                // this is a constant with a function value, not a real function
-const MY_FN: fn() = || {};
+pub const MY_FN: fn() = || {};
+
+fn my_private_fn() {
+    #[doc(hidden)] // shouldn't flag because functions aren't hoisted out of nested scopes
+    fn my_public_inner_fn_inside_my_private_fn() {}
+}
+
+pub fn my_public_fn() {
+    #[doc(hidden)] // shouldn't flag because functions aren't hoisted out of nested scopes
+    fn my_public_inner_fn_inside_my_public_fn() {}
+}

--- a/test_crates/function_now_doc_hidden/new/src/lib.rs
+++ b/test_crates/function_now_doc_hidden/new/src/lib.rs
@@ -62,10 +62,10 @@ pub const MY_FN: fn() = || {};
 
 fn my_private_fn() {
     #[doc(hidden)] // shouldn't flag because functions aren't hoisted out of nested scopes
-    fn my_public_inner_fn_inside_my_private_fn() {}
+    pub fn my_public_inner_fn_inside_my_private_fn() {}
 }
 
 pub fn my_public_fn() {
     #[doc(hidden)] // shouldn't flag because functions aren't hoisted out of nested scopes
-    fn my_public_inner_fn_inside_my_public_fn() {}
+    pub fn my_public_inner_fn_inside_my_public_fn() {}
 }

--- a/test_crates/function_now_doc_hidden/new/src/lib.rs
+++ b/test_crates/function_now_doc_hidden/new/src/lib.rs
@@ -1,0 +1,61 @@
+mod MyNonPublicMod {
+    // despite adding #[doc(hidden)], this function is in a
+    // private mod, so it isn't part of the crate's public
+    // api
+    #[doc(hidden)]
+    pub fn my_function() {}
+}
+
+pub mod MyPublicMod {
+    // added #[doc(hidden)], however this function is in a
+    // public mod, so it previously was part of the crate's public api
+    #[doc(hidden)]
+    pub fn my_function() {}
+}
+
+#[doc(hidden)]
+pub mod MyTopLevelDocHiddenMod {
+    #[doc(hidden)] // this shouldn't flag, as it's a top level mod
+                   // was never part of the public api of the crate
+    pub fn my_function() {}
+}
+
+mod MyNestedNonPublicMod {
+    pub mod PublicInnerMod {
+        // despite adding #[doc(hidden)], this function is in a
+        // private outer mod, so it isn't part of the crate's public
+        // api
+        #[doc(hidden)]
+        pub fn my_function() {}
+    }
+}
+
+pub mod MyNestedPublicMod {
+    pub mod PublicInnerMod {
+        // added #[doc(hidden)], however this function is in a
+        // public mod, so it previously was part of the crate's public api
+        #[doc(hidden)]
+        pub fn my_function() {}
+    }
+}
+
+#[doc(alias = "hidden")] // shouldn't flag, this is just aliased as hidden,
+                         // but it should be #[doc(hidden)]
+pub fn aliased_as_doc_hidden() {}
+
+#[doc(hidden)] // should flag, this is the simplest case of adding #[doc(hidden)] to a pub function.
+pub fn my_function() {}
+
+#[doc(hidden)] // should flag, this is the case of adding #[doc(hidden)] to a pub function with arguments and a return type.
+pub fn my_function_with_types(a: i32, b: i32) -> i32 {}
+
+#[doc(hidden)]
+fn public_function_that_goes_private() {}
+
+#[doc = "hidden"] // shouldn't flag, this is just documented with the string "hidden",
+                  // it's not actually #[doc(hidden)]
+pub fn public_function_documented_with_string_hidden() {}
+
+#[doc(hidden)] // shouldn't flag under the `function_now_doc_hidden` lint,
+               // this is a constant with a function value, not a real function
+const MY_FN: fn() = || {};

--- a/test_crates/function_now_doc_hidden/old/Cargo.toml
+++ b/test_crates/function_now_doc_hidden/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "function_now_doc_hidden"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/function_now_doc_hidden/old/src/lib.rs
+++ b/test_crates/function_now_doc_hidden/old/src/lib.rs
@@ -33,4 +33,12 @@ fn public_function_that_goes_private() {}
 
 pub fn public_function_documented_with_string_hidden() {}
 
-const MY_FN: fn() = || {};
+pub const MY_FN: fn() = || {};
+
+fn my_private_fn() {
+    fn my_public_inner_fn_inside_my_private_fn() {}
+}
+
+pub fn my_public_fn() {
+    fn my_public_inner_fn_inside_my_public_fn() {}
+}

--- a/test_crates/function_now_doc_hidden/old/src/lib.rs
+++ b/test_crates/function_now_doc_hidden/old/src/lib.rs
@@ -1,0 +1,36 @@
+mod MyNonPublicMod {
+    pub fn my_function() {}
+}
+
+pub mod MyPublicMod {
+    pub fn my_function() {}
+}
+
+#[doc(hidden)]
+pub mod MyTopLevelDocHiddenMod {
+    pub fn my_function() {}
+}
+
+mod MyNestedNonPublicMod {
+    pub mod PublicInnerMod {
+        pub fn my_function() {}
+    }
+}
+
+pub mod MyNestedPublicMod {
+    pub mod PublicInnerMod {
+        pub fn my_function() {}
+    }
+}
+
+pub fn aliased_as_doc_hidden() {}
+
+pub fn my_function() {}
+
+pub fn my_function_with_types(a: i32, b: i32) -> i32 {}
+
+fn public_function_that_goes_private() {}
+
+pub fn public_function_documented_with_string_hidden() {}
+
+const MY_FN: fn() = || {};

--- a/test_crates/function_now_doc_hidden/old/src/lib.rs
+++ b/test_crates/function_now_doc_hidden/old/src/lib.rs
@@ -36,9 +36,9 @@ pub fn public_function_documented_with_string_hidden() {}
 pub const MY_FN: fn() = || {};
 
 fn my_private_fn() {
-    fn my_public_inner_fn_inside_my_private_fn() {}
+    pub fn my_public_inner_fn_inside_my_private_fn() {}
 }
 
 pub fn my_public_fn() {
-    fn my_public_inner_fn_inside_my_public_fn() {}
+    pub fn my_public_inner_fn_inside_my_public_fn() {}
 }

--- a/test_outputs/function_now_doc_hidden.output.ron
+++ b/test_outputs/function_now_doc_hidden.output.ron
@@ -1,0 +1,43 @@
+{
+    "./test_crates/function_now_doc_hidden/": [
+        {
+            "path": List([
+                String("function_now_doc_hidden"),
+                String("MyPublicMod"),
+                String("my_function"),
+            ]),
+            "span_begin_line": Uint64(13),
+            "span_filename": String("src/lib.rs"),
+            "struct_name": String("my_function"),
+        },
+        {
+            "path": List([
+                String("function_now_doc_hidden"),
+                String("MyNestedPublicMod"),
+                String("PublicInnerMod"),
+                String("my_function"),
+            ]),
+            "span_begin_line": Uint64(38),
+            "span_filename": String("src/lib.rs"),
+            "struct_name": String("my_function"),
+        },
+        {
+            "path": List([
+                String("function_now_doc_hidden"),
+                String("my_function"),
+            ]),
+            "span_begin_line": Uint64(47),
+            "span_filename": String("src/lib.rs"),
+            "struct_name": String("my_function"),
+        },
+        {
+            "path": List([
+                String("function_now_doc_hidden"),
+                String("my_function_with_types"),
+            ]),
+            "span_begin_line": Uint64(50),
+            "span_filename": String("src/lib.rs"),
+            "struct_name": String("my_function_with_types"),
+        },
+    ],
+}

--- a/test_outputs/function_now_doc_hidden.output.ron
+++ b/test_outputs/function_now_doc_hidden.output.ron
@@ -8,7 +8,7 @@
             ]),
             "span_begin_line": Uint64(13),
             "span_filename": String("src/lib.rs"),
-            "struct_name": String("my_function"),
+            "function_name": String("my_function"),
         },
         {
             "path": List([
@@ -19,7 +19,7 @@
             ]),
             "span_begin_line": Uint64(38),
             "span_filename": String("src/lib.rs"),
-            "struct_name": String("my_function"),
+            "function_name": String("my_function"),
         },
         {
             "path": List([
@@ -28,7 +28,7 @@
             ]),
             "span_begin_line": Uint64(47),
             "span_filename": String("src/lib.rs"),
-            "struct_name": String("my_function"),
+            "function_name": String("my_function"),
         },
         {
             "path": List([
@@ -37,7 +37,7 @@
             ]),
             "span_begin_line": Uint64(50),
             "span_filename": String("src/lib.rs"),
-            "struct_name": String("my_function_with_types"),
+            "function_name": String("my_function_with_types"),
         },
     ],
 }


### PR DESCRIPTION
Implements a lint to catch functions that are public and have just had `#[doc(hidden)]` added to them.

checks the fourth checkmark on https://github.com/obi1kenobi/cargo-semver-checks/issues/578#issue-1982324505