### PR TITLE
Detect when `build.target` is configured, and allow overriding it from the command line

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub struct Check {
     release_type: Option<ReleaseType>,
     current_feature_config: rustdoc_gen::FeatureConfig,
     baseline_feature_config: rustdoc_gen::FeatureConfig,
+    /// Which `--target` to use, if unset pass no flag
     build_target: Option<String>,
 }
 
@@ -302,6 +303,8 @@ impl Check {
         self
     }
 
+    /// Set what `--target` to build the documentation with, by default will not pass any flag
+    /// relying on the users cargo configuration.
     pub fn with_build_target(&mut self, build_target: String) -> &mut Self {
         self.build_target = Some(build_target);
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub struct Check {
     release_type: Option<ReleaseType>,
     current_feature_config: rustdoc_gen::FeatureConfig,
     baseline_feature_config: rustdoc_gen::FeatureConfig,
-    target: Option<String>,
+    build_target: Option<String>,
 }
 
 /// The kind of release we're making.
@@ -237,7 +237,7 @@ impl Check {
             release_type: None,
             current_feature_config: rustdoc_gen::FeatureConfig::default_for_current(),
             baseline_feature_config: rustdoc_gen::FeatureConfig::default_for_baseline(),
-            target: None,
+            build_target: None,
         }
     }
 
@@ -302,8 +302,8 @@ impl Check {
         self
     }
 
-    pub fn with_target(&mut self, target: String) -> &mut Self {
-        self.target = Some(target);
+    pub fn with_build_target(&mut self, build_target: String) -> &mut Self {
+        self.build_target = Some(build_target);
         self
     }
 
@@ -426,7 +426,7 @@ impl Check {
                                 crate_type: rustdoc_gen::CrateType::Current,
                                 name: &name,
                                 feature_config: &self.current_feature_config,
-                                target: self.target.as_deref(),
+                                build_target: self.build_target.as_deref(),
                             },
                             CrateDataForRustdoc {
                                 crate_type: rustdoc_gen::CrateType::Baseline {
@@ -434,7 +434,7 @@ impl Check {
                                 },
                                 name: &name,
                                 feature_config: &self.baseline_feature_config,
-                                target: self.target.as_deref(),
+                                build_target: self.build_target.as_deref(),
                             },
                         )?;
 
@@ -494,7 +494,7 @@ impl Check {
                                     crate_type: rustdoc_gen::CrateType::Current,
                                     name: crate_name,
                                     feature_config: &self.current_feature_config,
-                                    target: self.target.as_deref(),
+                                    build_target: self.build_target.as_deref(),
                                 },
                                 CrateDataForRustdoc {
                                     crate_type: rustdoc_gen::CrateType::Baseline {
@@ -502,7 +502,7 @@ impl Check {
                                     },
                                     name: crate_name,
                                     feature_config: &self.baseline_feature_config,
-                                    target: self.target.as_deref(),
+                                    build_target: self.build_target.as_deref(),
                                 },
                             )?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub struct Check {
     release_type: Option<ReleaseType>,
     current_feature_config: rustdoc_gen::FeatureConfig,
     baseline_feature_config: rustdoc_gen::FeatureConfig,
+    target: Option<String>,
 }
 
 /// The kind of release we're making.
@@ -236,6 +237,7 @@ impl Check {
             release_type: None,
             current_feature_config: rustdoc_gen::FeatureConfig::default_for_current(),
             baseline_feature_config: rustdoc_gen::FeatureConfig::default_for_baseline(),
+            target: None,
         }
     }
 
@@ -297,6 +299,11 @@ impl Check {
     ) -> &mut Self {
         self.current_feature_config.extra_features = extra_current_features;
         self.baseline_feature_config.extra_features = extra_baseline_features;
+        self
+    }
+
+    pub fn with_target(&mut self, target: String) -> &mut Self {
+        self.target = Some(target);
         self
     }
 
@@ -419,6 +426,7 @@ impl Check {
                                 crate_type: rustdoc_gen::CrateType::Current,
                                 name: &name,
                                 feature_config: &self.current_feature_config,
+                                target: self.target.as_deref(),
                             },
                             CrateDataForRustdoc {
                                 crate_type: rustdoc_gen::CrateType::Baseline {
@@ -426,6 +434,7 @@ impl Check {
                                 },
                                 name: &name,
                                 feature_config: &self.baseline_feature_config,
+                                target: self.target.as_deref(),
                             },
                         )?;
 
@@ -485,6 +494,7 @@ impl Check {
                                     crate_type: rustdoc_gen::CrateType::Current,
                                     name: crate_name,
                                     feature_config: &self.current_feature_config,
+                                    target: self.target.as_deref(),
                                 },
                                 CrateDataForRustdoc {
                                     crate_type: rustdoc_gen::CrateType::Baseline {
@@ -492,6 +502,7 @@ impl Check {
                                     },
                                     name: crate_name,
                                     feature_config: &self.baseline_feature_config,
+                                    target: self.target.as_deref(),
                                 },
                             )?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,8 +258,8 @@ struct CheckRelease {
     all_features: bool,
 
     /// Which target to build the crate for, to check platform-specific APIs.
-    #[arg(long)]
-    target: Option<String>,
+    #[arg(long = "target")]
+    build_target: Option<String>,
 
     #[command(flatten)]
     verbosity: clap_verbosity_flag::Verbosity<clap_verbosity_flag::InfoLevel>,
@@ -354,8 +354,8 @@ impl From<CheckRelease> for cargo_semver_checks::Check {
 
         check.with_extra_features(current_features, baseline_features);
 
-        if let Some(target) = value.target {
-            check.with_target(target);
+        if let Some(build_target) = value.build_target {
+            check.with_build_target(build_target);
         }
 
         check

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,7 +257,8 @@ struct CheckRelease {
     )]
     all_features: bool,
 
-    /// Which target to build the crate for, to check platform-specific APIs.
+    /// Which target to build the crate for, to check platform-specific APIs, e.g.
+    /// `x86_64-unknown-linux-gnu`.
     #[arg(long = "target")]
     build_target: Option<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,6 +257,10 @@ struct CheckRelease {
     )]
     all_features: bool,
 
+    /// Which target to build the crate for, to check platform-specific APIs.
+    #[arg(long)]
+    target: Option<String>,
+
     #[command(flatten)]
     verbosity: clap_verbosity_flag::Verbosity<clap_verbosity_flag::InfoLevel>,
 }
@@ -349,6 +353,11 @@ impl From<CheckRelease> for cargo_semver_checks::Check {
         trim_features(&mut baseline_features);
 
         check.with_extra_features(current_features, baseline_features);
+
+        if let Some(target) = value.target {
+            check.with_target(target);
+        }
+
         check
     }
 }

--- a/src/rustdoc_cmd.rs
+++ b/src/rustdoc_cmd.rs
@@ -107,8 +107,8 @@ impl RustdocCommand {
             .arg(target_dir)
             .arg("--package")
             .arg(pkg_spec);
-        if let Some(target) = crate_data.target {
-            cmd.arg("--target").arg(target);
+        if let Some(build_target) = crate_data.build_target {
+            cmd.arg("--target").arg(build_target);
         }
         if !self.deps {
             cmd.arg("--no-deps");
@@ -133,10 +133,10 @@ impl RustdocCommand {
             }
         }
 
-        let rustdoc_dir = if let Some(target) = crate_data.target {
-            target_dir.join(target).join("doc")
+        let rustdoc_dir = if let Some(build_target) = crate_data.build_target {
+            target_dir.join(build_target).join("doc")
         } else {
-            let target = {
+            let build_target = {
                 let output = std::process::Command::new("cargo")
                     .env("RUSTC_BOOTSTRAP", "1")
                     .args([
@@ -165,8 +165,8 @@ impl RustdocCommand {
                 }
             };
 
-            if let Some(target) = target {
-                target_dir.join(target).join("doc")
+            if let Some(build_target) = build_target {
+                target_dir.join(build_target).join("doc")
             } else {
                 target_dir.join("doc")
             }

--- a/src/rustdoc_cmd.rs
+++ b/src/rustdoc_cmd.rs
@@ -142,6 +142,7 @@ impl RustdocCommand {
                     .args([
                         "config",
                         "-Zunstable-options",
+                        "--color=never",
                         "get",
                         "--format=json-value",
                         "build.target",
@@ -149,9 +150,11 @@ impl RustdocCommand {
                     .output()?;
                 if output.status.success() {
                     serde_json::from_slice::<Option<String>>(&output.stdout)?
-                } else if output
-                    .stderr
-                    .starts_with(b"error: config value `build.target` is not set")
+                } else if std::str::from_utf8(&output.stderr)
+                    .context("non-utf8 cargo output")?
+                    // this is the only way to detect a not set config value currently:
+                    //      https://github.com/rust-lang/cargo/issues/13223
+                    .contains("config value `build.target` is not set")
                 {
                     None
                 } else {

--- a/src/rustdoc_cmd.rs
+++ b/src/rustdoc_cmd.rs
@@ -136,6 +136,9 @@ impl RustdocCommand {
         let rustdoc_dir = if let Some(build_target) = crate_data.build_target {
             target_dir.join(build_target).join("doc")
         } else {
+            // If not passing an explicit `--target` flag, cargo may still pick a target to use
+            // instead of the "host" target, based on its config files and environment variables.
+
             let build_target = {
                 let output = std::process::Command::new("cargo")
                     .env("RUSTC_BOOTSTRAP", "1")

--- a/src/rustdoc_gen.rs
+++ b/src/rustdoc_gen.rs
@@ -300,7 +300,7 @@ pub(crate) struct CrateDataForRustdoc<'a> {
     pub(crate) crate_type: CrateType<'a>,
     pub(crate) name: &'a str,
     pub(crate) feature_config: &'a FeatureConfig,
-    pub(crate) target: Option<&'a str>,
+    pub(crate) build_target: Option<&'a str>,
 }
 
 impl<'a> CrateType<'a> {

--- a/src/rustdoc_gen.rs
+++ b/src/rustdoc_gen.rs
@@ -300,6 +300,7 @@ pub(crate) struct CrateDataForRustdoc<'a> {
     pub(crate) crate_type: CrateType<'a>,
     pub(crate) name: &'a str,
     pub(crate) feature_config: &'a FeatureConfig,
+    pub(crate) target: Option<&'a str>,
 }
 
 impl<'a> CrateType<'a> {

--- a/tests/specified_target.rs
+++ b/tests/specified_target.rs
@@ -1,0 +1,34 @@
+use assert_cmd::Command;
+
+fn base() -> Command {
+    let mut cmd = Command::cargo_bin("cargo-semver-checks").unwrap();
+    cmd.args([
+        "semver-checks",
+        "check-release",
+        "--manifest-path=test_crates/template/new",
+        "--baseline-root=test_crates/template/old",
+    ]);
+    cmd
+}
+
+#[test]
+fn with_default() {
+    base().env_remove("CARGO_BUILD_TARGET").assert().success();
+}
+
+#[test]
+fn with_env_var() {
+    base()
+        .env("CARGO_BUILD_TARGET", "x86_64-unknown-linux-gnu")
+        .assert()
+        .success();
+}
+
+#[test]
+fn with_flag() {
+    base()
+        .env_remove("CARGO_BUILD_TARGET")
+        .arg("--target=x86_64-unknown-linux-gnu")
+        .assert()
+        .success();
+}


### PR DESCRIPTION
This allows checking the correct directory for the json files. There are two more correct approaches to this, but neither are usable currently:

 1. The most correct approach would be to read the `compiler-artifact` messages from `cargo --message-format=json`. Unfortunately as of the current nightly these don't work when using `--output-format=json`, they have an empty list of files.
 2. The next option would be to use `--out-dir` to tell cargo/rustdoc to place the json file in a known directory. As of the current nightly cargo doesn't support `--out-dir` with `cargo doc`, and attempting to pass it through to rustdoc directly results in an error because it is given more than once.

So instead, we query cargo to see if the user has configured `build.target` through either a config file or environment variables.

fixes #586, #579 

Also, because it was easy after fixing the above I added a CLI flag to allow setting which target to build for.

fixes #579 more :grin: