### PR TITLE
Parallel lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
+ "rayon",
  "ron",
  "rustc_version",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ toml = "0.7.6"
 directories = "5.0.1"
 sha2 = "0.10.6"
 rustc_version = "0.4.0"
+rayon = "1.8.0"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, env, io::Write, iter::Peekable, sync::Arc, time::Instant};
+use std::{collections::BTreeMap, sync::Arc, time::Instant};
 
 use anyhow::Context;
 use clap::crate_version;
@@ -6,29 +6,13 @@ use itertools::Itertools;
 use rayon::prelude::*;
 use termcolor::Color;
 use termcolor_output::{colored, colored_ln};
-use trustfall::{FieldValue, TransparentValue};
+use trustfall::TransparentValue;
 use trustfall_rustdoc::{VersionedCrate, VersionedIndexedCrate, VersionedRustdocAdapter};
 
 use crate::{
     query::{ActualSemverUpdate, RequiredSemverUpdate, SemverQuery},
     CrateReport, GlobalConfig, ReleaseType,
 };
-
-type QueryResultItem = BTreeMap<Arc<str>, FieldValue>;
-
-struct QueryWithResults<'a> {
-    name: &'a str,
-    results: Peekable<Box<dyn Iterator<Item = QueryResultItem> + 'a>>,
-}
-
-impl<'a> QueryWithResults<'a> {
-    fn new(
-        name: &'a str,
-        results: Peekable<Box<dyn Iterator<Item = QueryResultItem> + 'a>>,
-    ) -> Self {
-        Self { name, results }
-    }
-}
 
 fn classify_semver_version_change(
     current_version: Option<&str>,

--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -119,14 +119,26 @@ pub(super) fn run_check_release(
     )?;
     config
         .log_verbose(|config| {
-            config.shell_status(
-                "Starting",
-                format_args!(
-                    "{} checks, {} unnecessary",
-                    queries_to_run.len(),
-                    skipped_queries
-                ),
-            )
+            let current_num_threads = rayon::current_num_threads();
+            if current_num_threads == 1 {
+                config.shell_status(
+                    "Starting",
+                    format_args!(
+                        "{} checks, {} unnecessary",
+                        queries_to_run.len(),
+                        skipped_queries
+                    ),
+                )
+            } else {
+                config.shell_status(
+                    "Starting",
+                    format_args!(
+                        "{} checks, {} unnecessary on {current_num_threads} threads",
+                        queries_to_run.len(),
+                        skipped_queries
+                    ),
+                )
+            }
         })
         .expect("print failed");
 


### PR DESCRIPTION
Closes #621.

The rayon implementation lacks the per query "Running {query}\r" dynamic messages as I couldn't think of any sensible way to do that with multiple threads.