### PR TITLE
update repr-related reference links

### DIFF
--- a/src/lints/enum_repr_c_removed.ron
+++ b/src/lints/enum_repr_c_removed.ron
@@ -5,9 +5,7 @@ SemverQuery(
     reference: Some("An enum that used to be repr(C) is no longer repr(C). This can cause its memory layout to change, breaking FFI use cases."),
     required_update: Major,
 
-    // TODO: Change the reference link to point to the cargo semver reference
-    //       once it has a section on repr(C).
-    reference_link: Some("https://doc.rust-lang.org/nomicon/other-reprs.html#reprc"),
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#repr-c-remove"),
     query: r#"
     {
         CrateDiff {

--- a/src/lints/enum_repr_int_changed.ron
+++ b/src/lints/enum_repr_int_changed.ron
@@ -5,9 +5,7 @@ SemverQuery(
     reference: Some("The repr(u*) or repr(i*) attribute on an enum was changed to another integer type. This can cause its memory representation to change, breaking FFI use cases."),
     required_update: Major,
 
-    // TODO: Change the reference link to point to the cargo semver reference
-    //       once it has a section on repr(u*)/repr(i*).
-    reference_link: Some("https://doc.rust-lang.org/nomicon/other-reprs.html#repru-repri"),
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#repr-int-enum-change"),
     query: r#"
     {
         CrateDiff {

--- a/src/lints/enum_repr_int_removed.ron
+++ b/src/lints/enum_repr_int_removed.ron
@@ -5,9 +5,7 @@ SemverQuery(
     reference: Some("The repr(u*) or repr(i*) attribute was removed from an enum. This can cause its memory representation to change, breaking FFI use cases."),
     required_update: Major,
 
-    // TODO: Change the reference link to point to the cargo semver reference
-    //       once it has a section on repr(u*)/repr(i*).
-    reference_link: Some("https://doc.rust-lang.org/nomicon/other-reprs.html#repru-repri"),
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#repr-int-enum-remove"),
     query: r#"
     {
         CrateDiff {

--- a/src/lints/struct_repr_c_removed.ron
+++ b/src/lints/struct_repr_c_removed.ron
@@ -5,9 +5,7 @@ SemverQuery(
     reference: Some("A struct that used to be repr(C) is no longer repr(C). This can cause its memory layout to change, breaking FFI use cases."),
     required_update: Major,
 
-    // TODO: Change the reference link to point to the cargo semver reference
-    //       once it has a section on repr(C).
-    reference_link: Some("https://doc.rust-lang.org/nomicon/other-reprs.html#reprc"),
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#repr-c-remove"),
     query: r#"
     {
         CrateDiff {

--- a/src/lints/struct_repr_transparent_removed.ron
+++ b/src/lints/struct_repr_transparent_removed.ron
@@ -27,9 +27,7 @@ To avoid false-positives, this query is restricted to checking only structs that
 "#),
     required_update: Major,
 
-    // TODO: Change the reference link to point to the cargo semver reference
-    //       once it has a section on repr(transparent).
-    reference_link: Some("https://doc.rust-lang.org/nomicon/other-reprs.html#reprtransparent"),
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#repr-transparent-remove"),
     query: r#"
     {
         CrateDiff {


### PR DESCRIPTION
Looks like an `enum_repr_transparent_removed` is missing (it's there for `struct`). I'll add that on in another PR.

Reference: https://doc.rust-lang.org/cargo/reference/semver.html#repr-transparent-remove