### PR TITLE
implement enum_repr_transparent_removed lint

### DIFF
--- a/src/lints/enum_repr_transparent_removed.ron
+++ b/src/lints/enum_repr_transparent_removed.ron
@@ -1,0 +1,108 @@
+SemverQuery(
+    id: "enum_repr_transparent_removed",
+    human_readable_name: "enum repr(transparent) removed",
+    description: "A enum is no longer repr(transparent).",
+    reference: Some(r#"
+repr(transparent) was removed from an enum. This can cause its memory layout to change,
+breaking FFI use cases.
+
+Unlike with structs, repr(transparent) is always part of the ABI for enums since
+all variants inherit the visibility of their parent type. Note that 
+> [repr(transparent)] can only be used on single-variant enum with a single non-zero-sized field
+> (there may be additional zero-sized fields). [...]
+https://doc.rust-lang.org/nomicon/other-reprs.html#reprtransparent
+
+cargo-semver-checks currently can't check whether a field is zero-sized or not.
+
+However, the most commonly-used kind of zero-sized field is core::marker::PhantomData,
+and we can hardcode its detection and proper handling.
+
+To avoid false-positives, this query is restricted to checking only enums that in the baseline:
+- are repr(transparent);
+- have exactly one variant
+- which has at most one non-PhantomData field
+"#),
+    required_update: Major,
+
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#repr-transparent-remove"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Enum {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+
+                        attribute {
+                            old_attr: raw_attribute @output
+                            content {
+                                base @filter(op: "=", value: ["$repr"])
+                                argument {
+                                    base @filter(op: "=", value: ["$transparent"])
+                                }
+                            }
+                        }
+
+                        # To avoid false-positives (as described above), we check two things:
+                        # - this enum has one variant
+                        # - this variant has a total of one field that isn't PhantomData
+
+                        variant @fold @transform(op: "count") @filter(op: "=", value: ["$one"]) {
+                            transparent_variant_name: name @output
+                            field @fold @transform(op: "count") @filter(op: "=", value: ["$one"]) {
+                                raw_type @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                                    ... on ResolvedPathType {
+                                        name @filter(op: "one_of", value: ["$phantom_data"])
+                                    }
+                                }
+                            }
+                        }
+
+                        importable_path {
+                            path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Enum {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @output
+
+                        attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            content {
+                                base @filter(op: "=", value: ["$repr"])
+                                argument {
+                                    base @filter(op: "=", value: ["$transparent"])
+                                }
+                            }
+                        }
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "repr": "repr",
+        "transparent": "transparent",
+        "phantom_data": ["core::marker::PhantomData", "std::marker::PhantomData"],
+        "true": true,
+        "one": 1,
+        "zero": 0,
+    },
+    error_message: "repr(transparent) was removed from an enum. This can cause its memory layout to change, breaking FFI use cases.",
+    per_result_error_template: Some("enum {{name}} in {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -478,6 +478,7 @@ add_lints!(
     enum_repr_c_removed,
     enum_repr_int_changed,
     enum_repr_int_removed,
+    enum_repr_transparent_removed,
     enum_struct_variant_field_added,
     enum_struct_variant_field_missing,
     enum_variant_added,

--- a/test_crates/enum_repr_transparent_removed/new/Cargo.toml
+++ b/test_crates/enum_repr_transparent_removed/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_repr_transparent_removed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_repr_transparent_removed/new/src/lib.rs
+++ b/test_crates/enum_repr_transparent_removed/new/src/lib.rs
@@ -6,83 +6,83 @@ pub enum Bar {
     Baz { quux: usize },
 }
 
-pub enum StructWithZeroSizedData<T> {
+pub enum StructStyleWithZeroSizedData<T> {
     Bar {
         bar: usize,
         _marker: std::marker::PhantomData<T>,
     },
 }
 
-pub enum TupleWithZeroSizedData<T> {
+pub enum TupleStyleWithZeroSizedData<T> {
     Bar(usize, core::marker::PhantomData<T>),
 }
 
-pub enum StructWithFoo {
+pub enum StructStyleWithFoo {
     Bar {
         bar: Foo,
         _marker: std::marker::PhantomData<&'static usize>,
     },
 }
 
-pub enum TupleWithFoo {
+pub enum TupleStyleWithFoo {
     Bar(Foo, std::marker::PhantomData<&'static usize>),
 }
 
-pub enum StructWithRef {
+pub enum StructStyleWithRef {
     Bar {
         bar: &'static usize,
         _marker: std::marker::PhantomData<&'static usize>,
     },
 }
 
-pub enum TupleWithRef {
+pub enum TupleStyleWithRef {
     Bar(&'static usize, std::marker::PhantomData<&'static usize>),
 }
 
-pub enum StructWithTuple {
+pub enum StructStyleWithTupleStyle {
     Bar {
         bar: (usize, i64),
         _marker: std::marker::PhantomData<&'static usize>,
     },
 }
 
-pub enum TupleWithTuple {
+pub enum TupleStyleWithTuple {
     Bar((usize, i64), std::marker::PhantomData<&'static usize>),
 }
 
-pub enum StructWithGeneric {
+pub enum StructStyleWithGeneric {
     Bar {
-        bar: StructWithZeroSizedData<usize>,
+        bar: StructStyleWithZeroSizedData<usize>,
         _marker: std::marker::PhantomData<&'static usize>,
     },
 }
 
-pub enum TupleWithGeneric {
+pub enum TupleStyleWithGeneric {
     Bar(
-        StructWithZeroSizedData<usize>,
+        StructStyleWithZeroSizedData<usize>,
         std::marker::PhantomData<&'static usize>,
     ),
 }
 
-pub enum StructWithSpecificZeroSizedData {
+pub enum StructStyleWithSpecificZeroSizedData {
     Bar {
         bar: usize,
         _marker: std::marker::PhantomData<&'static usize>,
     },
 }
 
-pub enum TupleWithSpecificZeroSizedData {
+pub enum TupleStyleWithSpecificZeroSizedData {
     Bar(usize, std::marker::PhantomData<&'static usize>),
 }
 
 // A trailing comma corner case - checks if attributes are parsed correctly.
 
 #[repr(transparent)]
-pub enum TrailingCommaTupleStyle {
+pub enum TupleStyleTrailingComma {
     Foo(usize),
 }
 
 #[repr(transparent)]
-pub enum TrailingCommaStructStyle {
+pub enum StructStyleTrailingComma {
     Foo { bar: usize },
 }

--- a/test_crates/enum_repr_transparent_removed/new/src/lib.rs
+++ b/test_crates/enum_repr_transparent_removed/new/src/lib.rs
@@ -1,0 +1,88 @@
+pub enum Foo {
+    Bar(usize),
+}
+
+pub enum Bar {
+    Baz { quux: usize },
+}
+
+pub enum StructWithZeroSizedData<T> {
+    Bar {
+        bar: usize,
+        _marker: std::marker::PhantomData<T>,
+    },
+}
+
+pub enum TupleWithZeroSizedData<T> {
+    Bar(usize, core::marker::PhantomData<T>),
+}
+
+pub enum StructWithFoo {
+    Bar {
+        bar: Foo,
+        _marker: std::marker::PhantomData<&'static usize>,
+    },
+}
+
+pub enum TupleWithFoo {
+    Bar(Foo, std::marker::PhantomData<&'static usize>),
+}
+
+pub enum StructWithRef {
+    Bar {
+        bar: &'static usize,
+        _marker: std::marker::PhantomData<&'static usize>,
+    },
+}
+
+pub enum TupleWithRef {
+    Bar(&'static usize, std::marker::PhantomData<&'static usize>),
+}
+
+pub enum StructWithTuple {
+    Bar {
+        bar: (usize, i64),
+        _marker: std::marker::PhantomData<&'static usize>,
+    },
+}
+
+pub enum TupleWithTuple {
+    Bar((usize, i64), std::marker::PhantomData<&'static usize>),
+}
+
+pub enum StructWithGeneric {
+    Bar {
+        bar: StructWithZeroSizedData<usize>,
+        _marker: std::marker::PhantomData<&'static usize>,
+    },
+}
+
+pub enum TupleWithGeneric {
+    Bar(
+        StructWithZeroSizedData<usize>,
+        std::marker::PhantomData<&'static usize>,
+    ),
+}
+
+pub enum StructWithSpecificZeroSizedData {
+    Bar {
+        bar: usize,
+        _marker: std::marker::PhantomData<&'static usize>,
+    },
+}
+
+pub enum TupleWithSpecificZeroSizedData {
+    Bar(usize, std::marker::PhantomData<&'static usize>),
+}
+
+// A trailing comma corner case - checks if attributes are parsed correctly.
+
+#[repr(transparent)]
+pub enum TrailingCommaTupleStyle {
+    Foo(usize),
+}
+
+#[repr(transparent)]
+pub enum TrailingCommaStructStyle {
+    Foo { bar: usize },
+}

--- a/test_crates/enum_repr_transparent_removed/old/Cargo.toml
+++ b/test_crates/enum_repr_transparent_removed/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_repr_transparent_removed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_repr_transparent_removed/old/src/lib.rs
+++ b/test_crates/enum_repr_transparent_removed/old/src/lib.rs
@@ -9,7 +9,7 @@ pub enum Bar {
 }
 
 #[repr(transparent)]
-pub enum StructWithZeroSizedData<T> {
+pub enum StructStyleWithZeroSizedData<T> {
     Bar {
         bar: usize,
         _marker: std::marker::PhantomData<T>,
@@ -17,12 +17,12 @@ pub enum StructWithZeroSizedData<T> {
 }
 
 #[repr(transparent)]
-pub enum TupleWithZeroSizedData<T> {
+pub enum TupleStyleWithZeroSizedData<T> {
     Bar(usize, core::marker::PhantomData<T>),
 }
 
 #[repr(transparent)]
-pub enum StructWithSpecificZeroSizedData {
+pub enum StructStyleWithSpecificZeroSizedData {
     Bar {
         bar: usize,
         _marker: std::marker::PhantomData<&'static usize>,
@@ -30,12 +30,12 @@ pub enum StructWithSpecificZeroSizedData {
 }
 
 #[repr(transparent)]
-pub enum TupleWithSpecificZeroSizedData {
+pub enum TupleStyleWithSpecificZeroSizedData {
     Bar(usize, std::marker::PhantomData<&'static usize>),
 }
 
 #[repr(transparent)]
-pub enum StructWithFoo {
+pub enum StructStyleWithFoo {
     Bar {
         bar: Foo,
         _marker: std::marker::PhantomData<&'static usize>,
@@ -43,12 +43,12 @@ pub enum StructWithFoo {
 }
 
 #[repr(transparent)]
-pub enum TupleWithFoo {
+pub enum TupleStyleWithFoo {
     Bar(Foo, std::marker::PhantomData<&'static usize>),
 }
 
 #[repr(transparent)]
-pub enum StructWithRef {
+pub enum StructStyleWithRef {
     Bar {
         bar: &'static usize,
         _marker: std::marker::PhantomData<&'static usize>,
@@ -56,12 +56,12 @@ pub enum StructWithRef {
 }
 
 #[repr(transparent)]
-pub enum TupleWithRef {
+pub enum TupleStyleWithRef {
     Bar(&'static usize, std::marker::PhantomData<&'static usize>),
 }
 
 #[repr(transparent)]
-pub enum StructWithTuple {
+pub enum StructStyleWithTupleStyle {
     Bar {
         bar: (usize, i64),
         _marker: std::marker::PhantomData<&'static usize>,
@@ -69,22 +69,22 @@ pub enum StructWithTuple {
 }
 
 #[repr(transparent)]
-pub enum TupleWithTuple {
+pub enum TupleStyleWithTuple {
     Bar((usize, i64), std::marker::PhantomData<&'static usize>),
 }
 
 #[repr(transparent)]
-pub enum StructWithGeneric {
+pub enum StructStyleWithGeneric {
     Bar {
-        bar: StructWithZeroSizedData<usize>,
+        bar: StructStyleWithZeroSizedData<usize>,
         _marker: std::marker::PhantomData<&'static usize>,
     },
 }
 
 #[repr(transparent)]
-pub enum TupleWithGeneric {
+pub enum TupleStyleWithGeneric {
     Bar(
-        StructWithZeroSizedData<usize>,
+        StructStyleWithZeroSizedData<usize>,
         std::marker::PhantomData<&'static usize>,
     ),
 }
@@ -92,11 +92,11 @@ pub enum TupleWithGeneric {
 // A trailing comma corner case - checks if attributes are parsed correctly.
 
 #[repr(transparent, )]
-pub enum TrailingCommaTupleStyle {
+pub enum TupleStyleTrailingComma {
     Foo(usize),
 }
 
 #[repr(transparent, )]
-pub enum TrailingCommaStructStyle {
+pub enum StructStyleTrailingComma {
     Foo { bar: usize },
 }

--- a/test_crates/enum_repr_transparent_removed/old/src/lib.rs
+++ b/test_crates/enum_repr_transparent_removed/old/src/lib.rs
@@ -1,0 +1,102 @@
+#[repr(transparent)]
+pub enum Foo {
+    Bar(usize),
+}
+
+#[repr(transparent)]
+pub enum Bar {
+    Baz { quux: usize },
+}
+
+#[repr(transparent)]
+pub enum StructWithZeroSizedData<T> {
+    Bar {
+        bar: usize,
+        _marker: std::marker::PhantomData<T>,
+    },
+}
+
+#[repr(transparent)]
+pub enum TupleWithZeroSizedData<T> {
+    Bar(usize, core::marker::PhantomData<T>),
+}
+
+#[repr(transparent)]
+pub enum StructWithSpecificZeroSizedData {
+    Bar {
+        bar: usize,
+        _marker: std::marker::PhantomData<&'static usize>,
+    },
+}
+
+#[repr(transparent)]
+pub enum TupleWithSpecificZeroSizedData {
+    Bar(usize, std::marker::PhantomData<&'static usize>),
+}
+
+#[repr(transparent)]
+pub enum StructWithFoo {
+    Bar {
+        bar: Foo,
+        _marker: std::marker::PhantomData<&'static usize>,
+    },
+}
+
+#[repr(transparent)]
+pub enum TupleWithFoo {
+    Bar(Foo, std::marker::PhantomData<&'static usize>),
+}
+
+#[repr(transparent)]
+pub enum StructWithRef {
+    Bar {
+        bar: &'static usize,
+        _marker: std::marker::PhantomData<&'static usize>,
+    },
+}
+
+#[repr(transparent)]
+pub enum TupleWithRef {
+    Bar(&'static usize, std::marker::PhantomData<&'static usize>),
+}
+
+#[repr(transparent)]
+pub enum StructWithTuple {
+    Bar {
+        bar: (usize, i64),
+        _marker: std::marker::PhantomData<&'static usize>,
+    },
+}
+
+#[repr(transparent)]
+pub enum TupleWithTuple {
+    Bar((usize, i64), std::marker::PhantomData<&'static usize>),
+}
+
+#[repr(transparent)]
+pub enum StructWithGeneric {
+    Bar {
+        bar: StructWithZeroSizedData<usize>,
+        _marker: std::marker::PhantomData<&'static usize>,
+    },
+}
+
+#[repr(transparent)]
+pub enum TupleWithGeneric {
+    Bar(
+        StructWithZeroSizedData<usize>,
+        std::marker::PhantomData<&'static usize>,
+    ),
+}
+
+// A trailing comma corner case - checks if attributes are parsed correctly.
+
+#[repr(transparent, )]
+pub enum TrailingCommaTupleStyle {
+    Foo(usize),
+}
+
+#[repr(transparent, )]
+pub enum TrailingCommaStructStyle {
+    Foo { bar: usize },
+}

--- a/test_outputs/enum_repr_transparent_removed.output.ron
+++ b/test_outputs/enum_repr_transparent_removed.output.ron
@@ -1,0 +1,200 @@
+{
+    "./test_crates/enum_repr_transparent_removed/": [
+        {
+            "name": String("Foo"),
+            "old_attr": String("#[repr(transparent)]"),
+            "path": List([
+                String("enum_repr_transparent_removed"),
+                String("Foo"),
+            ]),
+            "span_begin_line": Uint64(1),
+            "span_filename": String("src/lib.rs"),
+            "transparent_variant_name": List([
+                String("Bar"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("Bar"),
+            "old_attr": String("#[repr(transparent)]"),
+            "path": List([
+                String("enum_repr_transparent_removed"),
+                String("Bar"),
+            ]),
+            "span_begin_line": Uint64(5),
+            "span_filename": String("src/lib.rs"),
+            "transparent_variant_name": List([
+                String("Baz"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("StructWithZeroSizedData"),
+            "old_attr": String("#[repr(transparent)]"),
+            "path": List([
+                String("enum_repr_transparent_removed"),
+                String("StructWithZeroSizedData"),
+            ]),
+            "span_begin_line": Uint64(9),
+            "span_filename": String("src/lib.rs"),
+            "transparent_variant_name": List([
+                String("Bar"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("TupleWithZeroSizedData"),
+            "old_attr": String("#[repr(transparent)]"),
+            "path": List([
+                String("enum_repr_transparent_removed"),
+                String("TupleWithZeroSizedData"),
+            ]),
+            "span_begin_line": Uint64(16),
+            "span_filename": String("src/lib.rs"),
+            "transparent_variant_name": List([
+                String("Bar"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("StructWithFoo"),
+            "old_attr": String("#[repr(transparent)]"),
+            "path": List([
+                String("enum_repr_transparent_removed"),
+                String("StructWithFoo"),
+            ]),
+            "span_begin_line": Uint64(20),
+            "span_filename": String("src/lib.rs"),
+            "transparent_variant_name": List([
+                String("Bar"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("TupleWithFoo"),
+            "old_attr": String("#[repr(transparent)]"),
+            "path": List([
+                String("enum_repr_transparent_removed"),
+                String("TupleWithFoo"),
+            ]),
+            "span_begin_line": Uint64(27),
+            "span_filename": String("src/lib.rs"),
+            "transparent_variant_name": List([
+                String("Bar"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("StructWithRef"),
+            "old_attr": String("#[repr(transparent)]"),
+            "path": List([
+                String("enum_repr_transparent_removed"),
+                String("StructWithRef"),
+            ]),
+            "span_begin_line": Uint64(31),
+            "span_filename": String("src/lib.rs"),
+            "transparent_variant_name": List([
+                String("Bar"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("TupleWithRef"),
+            "old_attr": String("#[repr(transparent)]"),
+            "path": List([
+                String("enum_repr_transparent_removed"),
+                String("TupleWithRef"),
+            ]),
+            "span_begin_line": Uint64(38),
+            "span_filename": String("src/lib.rs"),
+            "transparent_variant_name": List([
+                String("Bar"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("StructWithTuple"),
+            "old_attr": String("#[repr(transparent)]"),
+            "path": List([
+                String("enum_repr_transparent_removed"),
+                String("StructWithTuple"),
+            ]),
+            "span_begin_line": Uint64(42),
+            "span_filename": String("src/lib.rs"),
+            "transparent_variant_name": List([
+                String("Bar"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("TupleWithTuple"),
+            "old_attr": String("#[repr(transparent)]"),
+            "path": List([
+                String("enum_repr_transparent_removed"),
+                String("TupleWithTuple"),
+            ]),
+            "span_begin_line": Uint64(49),
+            "span_filename": String("src/lib.rs"),
+            "transparent_variant_name": List([
+                String("Bar"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("StructWithGeneric"),
+            "old_attr": String("#[repr(transparent)]"),
+            "path": List([
+                String("enum_repr_transparent_removed"),
+                String("StructWithGeneric"),
+            ]),
+            "span_begin_line": Uint64(53),
+            "span_filename": String("src/lib.rs"),
+            "transparent_variant_name": List([
+                String("Bar"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("TupleWithGeneric"),
+            "old_attr": String("#[repr(transparent)]"),
+            "path": List([
+                String("enum_repr_transparent_removed"),
+                String("TupleWithGeneric"),
+            ]),
+            "span_begin_line": Uint64(60),
+            "span_filename": String("src/lib.rs"),
+            "transparent_variant_name": List([
+                String("Bar"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("StructWithSpecificZeroSizedData"),
+            "old_attr": String("#[repr(transparent)]"),
+            "path": List([
+                String("enum_repr_transparent_removed"),
+                String("StructWithSpecificZeroSizedData"),
+            ]),
+            "span_begin_line": Uint64(67),
+            "span_filename": String("src/lib.rs"),
+            "transparent_variant_name": List([
+                String("Bar"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("TupleWithSpecificZeroSizedData"),
+            "old_attr": String("#[repr(transparent)]"),
+            "path": List([
+                String("enum_repr_transparent_removed"),
+                String("TupleWithSpecificZeroSizedData"),
+            ]),
+            "span_begin_line": Uint64(74),
+            "span_filename": String("src/lib.rs"),
+            "transparent_variant_name": List([
+                String("Bar"),
+            ]),
+            "visibility_limit": String("public"),
+        },
+    ],
+}

--- a/test_outputs/enum_repr_transparent_removed.output.ron
+++ b/test_outputs/enum_repr_transparent_removed.output.ron
@@ -29,11 +29,11 @@
             "visibility_limit": String("public"),
         },
         {
-            "name": String("StructWithZeroSizedData"),
+            "name": String("StructStyleWithZeroSizedData"),
             "old_attr": String("#[repr(transparent)]"),
             "path": List([
                 String("enum_repr_transparent_removed"),
-                String("StructWithZeroSizedData"),
+                String("StructStyleWithZeroSizedData"),
             ]),
             "span_begin_line": Uint64(9),
             "span_filename": String("src/lib.rs"),
@@ -43,11 +43,11 @@
             "visibility_limit": String("public"),
         },
         {
-            "name": String("TupleWithZeroSizedData"),
+            "name": String("TupleStyleWithZeroSizedData"),
             "old_attr": String("#[repr(transparent)]"),
             "path": List([
                 String("enum_repr_transparent_removed"),
-                String("TupleWithZeroSizedData"),
+                String("TupleStyleWithZeroSizedData"),
             ]),
             "span_begin_line": Uint64(16),
             "span_filename": String("src/lib.rs"),
@@ -57,11 +57,11 @@
             "visibility_limit": String("public"),
         },
         {
-            "name": String("StructWithFoo"),
+            "name": String("StructStyleWithFoo"),
             "old_attr": String("#[repr(transparent)]"),
             "path": List([
                 String("enum_repr_transparent_removed"),
-                String("StructWithFoo"),
+                String("StructStyleWithFoo"),
             ]),
             "span_begin_line": Uint64(20),
             "span_filename": String("src/lib.rs"),
@@ -71,11 +71,11 @@
             "visibility_limit": String("public"),
         },
         {
-            "name": String("TupleWithFoo"),
+            "name": String("TupleStyleWithFoo"),
             "old_attr": String("#[repr(transparent)]"),
             "path": List([
                 String("enum_repr_transparent_removed"),
-                String("TupleWithFoo"),
+                String("TupleStyleWithFoo"),
             ]),
             "span_begin_line": Uint64(27),
             "span_filename": String("src/lib.rs"),
@@ -85,11 +85,11 @@
             "visibility_limit": String("public"),
         },
         {
-            "name": String("StructWithRef"),
+            "name": String("StructStyleWithRef"),
             "old_attr": String("#[repr(transparent)]"),
             "path": List([
                 String("enum_repr_transparent_removed"),
-                String("StructWithRef"),
+                String("StructStyleWithRef"),
             ]),
             "span_begin_line": Uint64(31),
             "span_filename": String("src/lib.rs"),
@@ -99,11 +99,11 @@
             "visibility_limit": String("public"),
         },
         {
-            "name": String("TupleWithRef"),
+            "name": String("TupleStyleWithRef"),
             "old_attr": String("#[repr(transparent)]"),
             "path": List([
                 String("enum_repr_transparent_removed"),
-                String("TupleWithRef"),
+                String("TupleStyleWithRef"),
             ]),
             "span_begin_line": Uint64(38),
             "span_filename": String("src/lib.rs"),
@@ -113,11 +113,11 @@
             "visibility_limit": String("public"),
         },
         {
-            "name": String("StructWithTuple"),
+            "name": String("StructStyleWithTupleStyle"),
             "old_attr": String("#[repr(transparent)]"),
             "path": List([
                 String("enum_repr_transparent_removed"),
-                String("StructWithTuple"),
+                String("StructStyleWithTupleStyle"),
             ]),
             "span_begin_line": Uint64(42),
             "span_filename": String("src/lib.rs"),
@@ -127,11 +127,11 @@
             "visibility_limit": String("public"),
         },
         {
-            "name": String("TupleWithTuple"),
+            "name": String("TupleStyleWithTuple"),
             "old_attr": String("#[repr(transparent)]"),
             "path": List([
                 String("enum_repr_transparent_removed"),
-                String("TupleWithTuple"),
+                String("TupleStyleWithTuple"),
             ]),
             "span_begin_line": Uint64(49),
             "span_filename": String("src/lib.rs"),
@@ -141,11 +141,11 @@
             "visibility_limit": String("public"),
         },
         {
-            "name": String("StructWithGeneric"),
+            "name": String("StructStyleWithGeneric"),
             "old_attr": String("#[repr(transparent)]"),
             "path": List([
                 String("enum_repr_transparent_removed"),
-                String("StructWithGeneric"),
+                String("StructStyleWithGeneric"),
             ]),
             "span_begin_line": Uint64(53),
             "span_filename": String("src/lib.rs"),
@@ -155,11 +155,11 @@
             "visibility_limit": String("public"),
         },
         {
-            "name": String("TupleWithGeneric"),
+            "name": String("TupleStyleWithGeneric"),
             "old_attr": String("#[repr(transparent)]"),
             "path": List([
                 String("enum_repr_transparent_removed"),
-                String("TupleWithGeneric"),
+                String("TupleStyleWithGeneric"),
             ]),
             "span_begin_line": Uint64(60),
             "span_filename": String("src/lib.rs"),
@@ -169,11 +169,11 @@
             "visibility_limit": String("public"),
         },
         {
-            "name": String("StructWithSpecificZeroSizedData"),
+            "name": String("StructStyleWithSpecificZeroSizedData"),
             "old_attr": String("#[repr(transparent)]"),
             "path": List([
                 String("enum_repr_transparent_removed"),
-                String("StructWithSpecificZeroSizedData"),
+                String("StructStyleWithSpecificZeroSizedData"),
             ]),
             "span_begin_line": Uint64(67),
             "span_filename": String("src/lib.rs"),
@@ -183,11 +183,11 @@
             "visibility_limit": String("public"),
         },
         {
-            "name": String("TupleWithSpecificZeroSizedData"),
+            "name": String("TupleStyleWithSpecificZeroSizedData"),
             "old_attr": String("#[repr(transparent)]"),
             "path": List([
                 String("enum_repr_transparent_removed"),
-                String("TupleWithSpecificZeroSizedData"),
+                String("TupleStyleWithSpecificZeroSizedData"),
             ]),
             "span_begin_line": Uint64(74),
             "span_filename": String("src/lib.rs"),


### PR DESCRIPTION
Still getting used to query syntax, so there might be some subtle bugs in the query. I mostly reused the test suite from `struct_repr_transparent_removed`.

My understanding is that:
```graphql
variant @fold @transform(op: "count") @filter(op: "=", value: ["$one"]) {
    transparent_variant_name: name @output
    field @fold @transform(op: "count") @filter(op: "=", value: ["$one"]) {
        raw_type @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
            ... on ResolvedPathType {
                name @filter(op: "one_of", value: ["$phantom_data"])
            }
        }
    }
}
```
translates to:
```
[take enums]: where
    there is a exactly one variant: where
        it contains exactly on field: where
            it contains exactly one field: where
                the number of rawtypes in this field that are not PhantomData is 1 (could be 0 or 1)
```