### PR TITLE
Remove ability to check bin-only targets, to fix `doc = false` issue.

### DIFF
--- a/src/rustdoc_cmd.rs
+++ b/src/rustdoc_cmd.rs
@@ -121,7 +121,8 @@ impl RustdocCommand {
             .arg("--target-dir")
             .arg(target_dir)
             .arg("--package")
-            .arg(pkg_spec);
+            .arg(pkg_spec)
+            .arg("--lib");
         if let Some(build_target) = crate_data.build_target {
             cmd.arg("--target").arg(build_target);
         }
@@ -315,27 +316,10 @@ in the metadata and stderr didn't mention it was lacking a lib target. This is p
             }
         }
 
-        // This crate does not have a lib target.
-        // For backward compatibility with older cargo-semver-checks versions,
-        // we currently preserve the old behavior of using the first bin target's rustdoc.
-        // At some future point, this is likely going to be deprecated and then become an error.
-        if let Some(bin_target) = subject_crate.targets.iter().find(|target| target.is_bin()) {
-            let bin_name = bin_target.name.as_str();
-            let rustdoc_json_file_name = bin_name.replace('-', "_");
-
-            let json_path = rustdoc_dir.join(format!("{rustdoc_json_file_name}.json"));
-            if json_path.exists() {
-                return Ok(json_path);
-            } else {
-                anyhow::bail!(
-                    "could not find expected rustdoc output for `{}`: {}",
-                    crate_name,
-                    json_path.display()
-                );
-            }
-        }
-
-        anyhow::bail!("no lib or bin targets so nothing to scan for crate {crate_name}")
+        anyhow::bail!(
+            "aborting since crate {crate_name} v{} has no lib target, so there's nothing to check",
+            crate_source.version()?
+        )
     }
 }
 

--- a/test_crates/bin_target_only/Cargo.toml
+++ b/test_crates/bin_target_only/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "bin_target_only"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/bin_target_only/src/main.rs
+++ b/test_crates/bin_target_only/src/main.rs
@@ -1,0 +1,1 @@
+pub fn main() {}

--- a/tests/rustdoc_edge_cases.rs
+++ b/tests/rustdoc_edge_cases.rs
@@ -37,6 +37,19 @@ fn proc_macro_target() {
         .failure();
 }
 
+/// Ensure that crates with only a bin target (so, no lib target) produce the correct error message
+/// since they have no library API and therefore nothing we can semver-check.
+#[test]
+fn bin_target_only() {
+    let mut cmd = Command::cargo_bin("cargo-semver-checks").unwrap();
+    cmd.current_dir("test_crates/bin_target_only")
+        .args(["semver-checks", "check-release", "--baseline-root=."])
+        .env_remove("RUST_BACKTRACE")
+        .assert()
+        .stderr("error: no crates with library targets selected, nothing to semver-check\n")
+        .failure();
+}
+
 /// Ensure that crates whose lib target has `crate-type = ["rlib"]`
 /// can be semver-checked correctly.
 #[test]


### PR DESCRIPTION
Because of a complex web of edge cases, we can _either_ choose to continue to support our legacy behavior of allowing bin-only targets to be semver-checked, _or_ we can support semver-checking lib targets that set `doc = false`. Semver-checking bin-only targets doesn't make a lot of sense, since they cannot be used as a library anyway. This functionality was always slated for removal, I just wish we had more time to deprecate & warn on it before just ripping it out like this.

Now we're in a tight spot, and this is definitely the lesser evil -- we're making the tool work for library users who produce an API that can reasonably be checked and used as such.

Fixes #660.
