### PR TITLE
Minor QOL update to speed up reruns of regenerate_test_rustdocs script

### DIFF
--- a/scripts/regenerate_test_rustdocs.sh
+++ b/scripts/regenerate_test_rustdocs.sh
@@ -7,26 +7,58 @@ export CARGO_TARGET_DIR=/tmp/test_crates
 RUSTDOC_OUTPUT_DIR="$CARGO_TARGET_DIR/doc"
 TOPLEVEL="$(git rev-parse --show-toplevel)"
 TARGET_DIR="$TOPLEVEL/localdata/test_data"
+TOOLCHAIN=
 
 # Allow setting an explicit toolchain, like +nightly or +beta.
 set +u
-TOOLCHAIN="$1"
+if [[ $1 == +* ]]; then
+    TOOLCHAIN="$1"
+    shift
+fi
 set -u
 echo "Generating rustdoc with: $(cargo $TOOLCHAIN --version)"
 RUSTDOC_CMD="cargo $TOOLCHAIN rustdoc"
 
 # Run rustdoc on test_crates/*/{new,old}/
-for crate_pair in $(find "$TOPLEVEL/test_crates/" -maxdepth 1 -mindepth 1 -type d); do
-    # Removing path prefix, leaving only the directory name without forward slashes
-    crate_pair=${crate_pair#"$TOPLEVEL/test_crates/"}
+shopt -s globstar
+dir_is_newer_than_file() {
+    local dir=$1
+    local file=$2
+    local f
+    for f in "$dir"/**; do
+        if [[ $f -nt $file ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+if [[ $# -eq 0 ]]; then
+    set -- "$TOPLEVEL/test_crates/"*/
+    always_update=
+else
+    always_update=1
+fi
+for crate_pair; do
+    # Strip all but last path component from crate_pair
+    crate_pair=${crate_pair%/}
+    crate_pair=${crate_pair##*/}
 
     if [[ -f "$TOPLEVEL/test_crates/$crate_pair/new/Cargo.toml" ]]; then
         if [[ -f "$TOPLEVEL/test_crates/$crate_pair/old/Cargo.toml" ]]; then
             for crate_version in "new" "old"; do
                 crate="$crate_pair/$crate_version"
+                crate_dir=$TOPLEVEL/test_crates/$crate
+                target=$TARGET_DIR/$crate/rustdoc.json
+
+                if [[ -z $always_update ]] && ! dir_is_newer_than_file "$crate_dir" "$target"; then
+                    printf 'No updates needed for %s.\n' "$crate"
+                    continue
+                fi
+
                 echo "Generating: $crate"
 
-                pushd "$TOPLEVEL/test_crates/$crate"
+                pushd "$crate_dir"
 
                 # Determine whether to warn on lints or allow them.
                 CAP_LINTS="warn"
@@ -38,7 +70,7 @@ for crate_pair in $(find "$TOPLEVEL/test_crates/" -maxdepth 1 -mindepth 1 -type 
 
                 RUSTC_BOOTSTRAP=1 $RUSTDOC_CMD -- -Zunstable-options --document-private-items --document-hidden-items --cap-lints "$CAP_LINTS" --output-format=json
                 mkdir -p "$TARGET_DIR/$crate"
-                mv "$RUSTDOC_OUTPUT_DIR/$crate_pair.json" "$TARGET_DIR/$crate/rustdoc.json"
+                mv "$RUSTDOC_OUTPUT_DIR/$crate_pair.json" "$target"
                 popd
             done
         else


### PR DESCRIPTION
- By default, check timestamps and skip generation if not needed
- Allow explicit test_crates as arguments to force regeneration

On my ancient Linux laptop, a full regeneration takes

```
$ time ./scripts/regenerate_test_rustdocs.sh test_crates/*
...
real	1m33.753s
user	1m18.191s
sys	0m13.961s
```

while a run where regenerate does nothing takes

```
$ time ./scripts/regenerate_test_rustdocs.sh
...
real	0m0.183s
user	0m0.125s
sys	0m0.055s
```

Not earth shattering, but I make a lot of typos when making the test crates and this makes my life a little easier, figured I'd share.