### PR TITLE
Replace GNU-specific commands with more portable alternatives

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,15 +250,9 @@ expected output files to include the new items, and you can get back on track.
 ## Development Environment
 
 While cargo-semver-checks is cross platform, the development task automation scripts in the scripts
-directory are not. In particular, they require
+directory are not. In particular, a relatively modern `bash` (at least version 4.0) is required.
 
-- GNU command line tools (coreutils, grep, sed, etc.)
-- a relatively modern `bash` (at least version 4.0)
-- `curl`
-- [`jq`](https://jqlang.github.io/jq/)
-
-Linux users likely have all of these already installed or available via their package manager.
+Linux users likely have bash 5+ already installed or available via their package manager.
 Windows users can get a bash + GNU command line environment via WSL or git bash.
-Mac users can install GNU tools via homebrew. The scripts will not work
-correctly using the default bash and BSD command line utilities that come with
-Mac OS.
+Mac users can install an updated bash via homebrew. The scripts will not work
+correctly using the default version of bash that comes with Mac OS.

--- a/scripts/make_new_lint.sh
+++ b/scripts/make_new_lint.sh
@@ -85,7 +85,7 @@ if awk -v lint_name="$NEW_LINT_NAME" '
 ' "$SRC_QUERY_FILE"; then
     printf ' already exists.\n'
 else
-    tmp=${SRC_QUERY_FILE}.tmp
+    tmp="${SRC_QUERY_FILE}.tmp"
     sed -e '/^add_lints!($/ a\'"
     $NEW_LINT_NAME," "$SRC_QUERY_FILE" > "$tmp" && mv -- "$tmp" "$SRC_QUERY_FILE" || {
         code=$?

--- a/scripts/make_new_lint.sh
+++ b/scripts/make_new_lint.sh
@@ -78,19 +78,21 @@ fi
 
 # Add the new lint to the `add_lints!()` macro.
 echo -n "Registering lint in src/query.rs ..."
-set +e
-# -E = extended regex mode, which behaves more similarly to regex in most programming languages.
-# -z = use \0 as separators instead of \n, so that we can do multi-line matches.
-grep -Ez --regexp "add_lints\!\\([^)]+[ ]+$NEW_LINT_NAME," "$SRC_QUERY_FILE" >/dev/null
-OUTPUT="$?"
-set -e
-if [[ "$OUTPUT" == "0" ]]; then
-    echo ' already exists.'
+if awk -v lint_name="$NEW_LINT_NAME" '
+    /^add_lints!\(/ { searching = 1 }
+    searching && $0 ~ "[[:space:]]" lint_name "," { found = 1; exit }
+    END { if (found) { exit 0 } else { exit 1 } }
+' "$SRC_QUERY_FILE"; then
+    printf ' already exists.\n'
 else
-    # -E = extended regex mode, which behaves more similarly to regex in most programming languages.
-    # -z = use \0 as separators instead of \n, so that we can do multi-line matches.
-    sed -i'' -Ez "s/add_lints\!\\(([^)]+)\\)/add_lints\!(\\1    $NEW_LINT_NAME,\n)/" "$SRC_QUERY_FILE"
-    echo ' done!'
+    tmp=${SRC_QUERY_FILE}.tmp
+    sed -e '/^add_lints!($/ a\'"
+    $NEW_LINT_NAME," "$SRC_QUERY_FILE" > "$tmp" && mv -- "$tmp" "$SRC_QUERY_FILE" || {
+        code=$?
+        rm -f "$tmp"
+        exit "$code"
+    }
+    printf ' done!\n'
 fi
 
 echo ''

--- a/scripts/make_new_test_crate.sh
+++ b/scripts/make_new_test_crate.sh
@@ -30,7 +30,7 @@ if [[ -d "$NEW_LINT_TEST_CRATES_DIR" ]]; then
     echo ' already exists.'
 else
     cp -R "$TEST_CRATES_DIR/template" "$NEW_LINT_TEST_CRATES_DIR"
-    sed -i'' "s/template/$NEW_TEST_CRATE/g" "$NEW_LINT_TEST_CRATES_DIR/old/Cargo.toml"
-    sed -i'' "s/template/$NEW_TEST_CRATE/g" "$NEW_LINT_TEST_CRATES_DIR/new/Cargo.toml"
+    sed -e "s/template/$NEW_TEST_CRATE/g" "$TEST_CRATES_DIR/template/old/Cargo.toml" > "$NEW_LINT_TEST_CRATES_DIR/old/Cargo.toml"
+    sed -e "s/template/$NEW_TEST_CRATE/g" "$TEST_CRATES_DIR/template/new/Cargo.toml" > "$NEW_LINT_TEST_CRATES_DIR/new/Cargo.toml"
     echo ' done!'
 fi


### PR DESCRIPTION
#680 enhancements

The replacement commands are functionally equivalent with one exception: new lints are now added to the beginning of the `add_lint!()` macro instead of the end. (There is a way to append but would require a slightly more complex `awk` command). More details in the commit messages.