### PR TITLE
add trait_method_now_doc_hidden lint

### DIFF
--- a/src/lints/trait_method_now_doc_hidden.ron
+++ b/src/lints/trait_method_now_doc_hidden.ron
@@ -1,0 +1,56 @@
+SemverQuery(
+    id: "trait_method_now_doc_hidden",
+    human_readable_name: "pub trait method is now #[doc(hidden)]",
+    description: "A public trait method is now marked as #[doc(hidden)] and has thus been removed from the public API",
+    required_update: Major,
+    reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        method {
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+                            name @output @tag
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        method {
+                            public_api_eligible @filter(op: "!=", value: ["$true"])
+                            name @filter(op: "=", value: ["%name"])
+                            span_: span @optional {
+                                filename @output
+                                begin_line @output
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true
+    },
+    error_message: "A function in a pub trait is now #[doc(hidden)], which removes it from the crate's public API",
+    per_result_error_template: Some("function {{name}} in {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -469,6 +469,7 @@ macro_rules! add_lints {
 }
 
 add_lints!(
+    trait_method_now_doc_hidden,
     auto_trait_impl_removed,
     constructible_struct_adds_field,
     constructible_struct_adds_private_field,

--- a/test_crates/trait_method_now_doc_hidden/new/Cargo.toml
+++ b/test_crates/trait_method_now_doc_hidden/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_method_now_doc_hidden"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_method_now_doc_hidden/new/src/lib.rs
+++ b/test_crates/trait_method_now_doc_hidden/new/src/lib.rs
@@ -1,0 +1,45 @@
+// Tests adapted from the traig_now_doc_hidden lint and tests
+
+// since this is not a public trait, it isn't semver-breaking if we add
+// #[doc(hidden)] to one of the methods
+trait NonPublicTrait {
+    #[doc(hidden)]
+    fn method(&self);
+}
+
+// this is a public trait, so it is semver-breaking if we add doc hidden to
+// any method
+pub trait PublicTrait {
+    #[doc(hidden)]
+    fn assoc_function();
+    #[doc(hidden)]
+    fn method(&self);
+}
+
+mod NonPublicMod {
+    // although this is a public trait, it is part of a non-public module,
+    // so it is not semver-breaking to add doc hidden on a method
+    pub trait PublicInnerTrait {
+        #[doc(hidden)]
+        fn method(&self);
+    }
+}
+
+#[doc(hidden)]
+pub mod HiddenMod {
+    // although this is in a public module and a public trait, the module
+    // has always been marked doc hidden, so it is not a semver breaking
+    // change to add doc hidden to an already hidden method
+    // (would it do anything?)
+    pub trait PublicInnerTrait {
+        #[doc(hidden)]
+        fn method(&self);
+    }
+}
+
+// since this is in a hidden trait, hiding a method is not semver breaking
+#[doc(hidden)]
+pub trait HiddenTrait {
+    #[doc(hidden)]
+    fn method(&self);
+}

--- a/test_crates/trait_method_now_doc_hidden/new/src/lib.rs
+++ b/test_crates/trait_method_now_doc_hidden/new/src/lib.rs
@@ -1,4 +1,4 @@
-// Tests adapted from the traig_now_doc_hidden lint and tests
+// Tests adapted from the trait_now_doc_hidden lint and tests
 
 // since this is not a public trait, it isn't semver-breaking if we add
 // #[doc(hidden)] to one of the methods

--- a/test_crates/trait_method_now_doc_hidden/old/Cargo.toml
+++ b/test_crates/trait_method_now_doc_hidden/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_method_now_doc_hidden"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_method_now_doc_hidden/old/src/lib.rs
+++ b/test_crates/trait_method_now_doc_hidden/old/src/lib.rs
@@ -1,0 +1,39 @@
+// Tests adapted from the trait_now_doc_hidden lint and tests
+
+// since this is not a public trait, it isn't semver-breaking if we add
+// #[doc(hidden)] to one of the methods
+trait NonPublicTrait {
+    fn method(&self);
+}
+
+// this is a public trait, so it is semver-breaking if we add doc hidden to
+// any method
+pub trait PublicTrait {
+    fn assoc_function();
+    fn method(&self);
+}
+
+mod NonPublicMod {
+    // although this is a public trait, it is part of a non-public module,
+    // so it is not semver-breaking to add doc hidden on a method
+    pub trait PublicInnerTrait {
+        fn method(&self);
+    }
+}
+
+#[doc(hidden)]
+pub mod HiddenMod {
+    // although this is in a public module and a public trait, the module
+    // has always been marked doc hidden, so it is not a semver breaking
+    // change to add doc hidden to an already hidden method
+    // (would it do anything?)
+    pub trait PublicInnerTrait {
+        fn method(&self);
+    }
+}
+
+// since this is in a hidden trait, hiding a method is not semver breaking
+#[doc(hidden)]
+pub trait HiddenTrait {
+    fn method(&self);
+}

--- a/test_outputs/trait_method_now_doc_hidden.output.ron
+++ b/test_outputs/trait_method_now_doc_hidden.output.ron
@@ -1,0 +1,33 @@
+{
+    "./test_crates/trait_method_now_doc_hidden/": [
+        {
+            "name": String("assoc_function"),
+            "path": List([
+                String("trait_method_now_doc_hidden"),
+                String("PublicTrait"),
+            ]),
+            "span_begin_line": Uint64(14),
+            "span_filename": String("src/lib.rs"),
+        },
+        {
+            "name": String("method"),
+            "path": List([
+                String("trait_method_now_doc_hidden"),
+                String("PublicTrait"),
+            ]),
+            "span_begin_line": Uint64(16),
+            "span_filename": String("src/lib.rs"),
+        },
+    ],
+    "./test_crates/trait_now_doc_hidden/": [
+        {
+            "name": String("my_trait_fn"),
+            "path": List([
+                String("trait_now_doc_hidden"),
+                String("PublicTraitHiddenVariant"),
+            ]),
+            "span_begin_line": Uint64(54),
+            "span_filename": String("src/lib.rs"),
+        },
+    ],
+}


### PR DESCRIPTION
Matches when a previously public trait method/function has been marked as #[doc(hidden)], which is a semver-breaking change. 

It matches trait methods and trait associated functions, but the other lints were listed under trait_method instead of trait_function or something else, so I followed that pattern.

Fixes part of #578  https://github.com/obi1kenobi/cargo-semver-checks/issues/578#issue-1982324505 