### PR TITLE
Added lint enum_tuple_variant_field_now_doc_hidden

### DIFF
--- a/src/lints/enum_tuple_variant_field_now_doc_hidden.ron
+++ b/src/lints/enum_tuple_variant_field_now_doc_hidden.ron
@@ -25,7 +25,6 @@ SemverQuery(
                                 field {
                                     field_name: name @output @tag
                                     public_api_eligible @filter(op: "=", value: ["$true"])
-
                                 }
                             }
                         }
@@ -49,7 +48,6 @@ SemverQuery(
                                 field {
                                     public_api_eligible @filter(op: "!=", value: ["$true"])
                                     name @filter(op: "=", value: ["%field_name"])
-
                                     span_: span @optional {
                                         filename @output
                                         begin_line @output

--- a/src/lints/enum_tuple_variant_field_now_doc_hidden.ron
+++ b/src/lints/enum_tuple_variant_field_now_doc_hidden.ron
@@ -1,0 +1,68 @@
+SemverQuery(
+    id: "enum_tuple_variant_field_now_doc_hidden",
+    human_readable_name: "pub enum tuple variant field is now #[doc(hidden)]",
+    description: "A pub enum tuple variant field is now marked #[doc(hidden)] and is thus no longer part of the public API.",
+    required_update: Major
+    reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Enum {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        enum_name: name @output @tag
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+                        variant {
+                            ... on TupleVariant {
+                                variant_name: name @output @tag
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+
+                                field {
+                                    field_name: name @output @tag
+                                    public_api_eligible @filter(op: "=", value: ["$true"])
+
+                                }
+                            }
+                        }
+
+                        
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Enum {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        enum_name: name @output
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                        }
+
+                        field {
+                            
+                            public_api_eligible @filter(op: "!=", value: ["$true"])
+                            name @filter(op: "=", value: ["%field_name"])
+
+                            span_: span @optional {
+                                filename @output
+                                begin_line @output
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+    },
+    error_message: "A pub field of a pub enum tuple variant is now marked #[doc(hidden)] and is no longer part of the public API.",
+    per_result_error_template: Some("field {{enum_name}}.{{field_name}} in file {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/lints/enum_tuple_variant_field_now_doc_hidden.ron
+++ b/src/lints/enum_tuple_variant_field_now_doc_hidden.ron
@@ -2,7 +2,7 @@ SemverQuery(
     id: "enum_tuple_variant_field_now_doc_hidden",
     human_readable_name: "pub enum tuple variant field is now #[doc(hidden)]",
     description: "A pub enum tuple variant field is now marked #[doc(hidden)] and is thus no longer part of the public API.",
-    required_update: Major
+    required_update: Major,
     reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
     query: r#"
     {
@@ -29,8 +29,6 @@ SemverQuery(
                                 }
                             }
                         }
-
-                        
                     }
                 }
             }
@@ -43,15 +41,20 @@ SemverQuery(
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
                         }
+                        variant {
+                            ... on TupleVariant {
+                                name @filter(op: "=", value: ["%variant_name"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
 
-                        field {
-                            
-                            public_api_eligible @filter(op: "!=", value: ["$true"])
-                            name @filter(op: "=", value: ["%field_name"])
+                                field {
+                                    public_api_eligible @filter(op: "!=", value: ["$true"])
+                                    name @filter(op: "=", value: ["%field_name"])
 
-                            span_: span @optional {
-                                filename @output
-                                begin_line @output
+                                    span_: span @optional {
+                                        filename @output
+                                        begin_line @output
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/lints/enum_tuple_variant_field_now_doc_hidden.ron
+++ b/src/lints/enum_tuple_variant_field_now_doc_hidden.ron
@@ -36,7 +36,7 @@ SemverQuery(
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        enum_name: name @output
+                        name @filter(op: "=", value: ["%enum_name"])
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
@@ -66,6 +66,6 @@ SemverQuery(
         "public": "public",
         "true": true,
     },
-    error_message: "A pub field of a pub enum tuple variant is now marked #[doc(hidden)] and is no longer part of the public API.",
+    error_message: "A field of a pub enum tuple variant is now marked #[doc(hidden)] and is no longer part of the public API.",
     per_result_error_template: Some("field {{enum_name}}.{{field_name}} in file {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/query.rs
+++ b/src/query.rs
@@ -469,6 +469,7 @@ macro_rules! add_lints {
 }
 
 add_lints!(
+    enum_tuple_variant_field_now_doc_hidden,
     trait_method_now_doc_hidden,
     auto_trait_impl_removed,
     constructible_struct_adds_field,

--- a/test_crates/enum_tuple_variant_field_now_doc_hidden/new/Cargo.toml
+++ b/test_crates/enum_tuple_variant_field_now_doc_hidden/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_tuple_variant_field_now_doc_hidden"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_tuple_variant_field_now_doc_hidden/new/src/lib.rs
+++ b/test_crates/enum_tuple_variant_field_now_doc_hidden/new/src/lib.rs
@@ -1,0 +1,17 @@
+//Adding #[doc(hidden)] should not affect since the enum is not a part of public API
+enum NonPublicEnum {
+    TupleVariant(#[doc(hidden)] i32,u8),
+}
+// basic test case(adding #[doc(hidden)] to public enum tuple variant)
+pub enum PulicEnumA {
+    TupleVariantWithPublicField(#[doc(hidden)] u8,i32),
+}
+// Should not affect since there the field was already hidden
+pub enum PulicEnumB {
+    TupleVariantWithPublicFieldHidden(#[doc(hidden)] i64, u8),
+}
+// should not affect since the public enum was not a part of Public API 
+#[doc(hidden)]
+pub enum PulicEnumC{
+    TupleVariantWithPublicField(#[doc(hidden)] u8,i64),
+}

--- a/test_crates/enum_tuple_variant_field_now_doc_hidden/new/src/lib.rs
+++ b/test_crates/enum_tuple_variant_field_now_doc_hidden/new/src/lib.rs
@@ -1,17 +1,17 @@
 //Adding #[doc(hidden)] should not affect since the enum is not a part of public API
 enum NonPublicEnum {
-    TupleVariant(#[doc(hidden)] i32,u8),
+    TupleVariant(#[doc(hidden)] i32, u8),
 }
 // basic test case(adding #[doc(hidden)] to public enum tuple variant)
 pub enum PulicEnumA {
-    TupleVariantWithPublicField(#[doc(hidden)] u8,i32),
+    TupleVariantWithPublicField(#[doc(hidden)] u8, i32),
 }
 // Should not affect since there the field was already hidden
 pub enum PulicEnumB {
     TupleVariantWithPublicFieldHidden(#[doc(hidden)] i64, u8),
 }
-// should not affect since the public enum was not a part of Public API 
+// should not affect since the public enum was not a part of Public API
 #[doc(hidden)]
-pub enum PulicEnumC{
-    TupleVariantWithPublicField(#[doc(hidden)] u8,i64),
+pub enum PulicEnumC {
+    TupleVariantWithPublicField(#[doc(hidden)] u8, i64),
 }

--- a/test_crates/enum_tuple_variant_field_now_doc_hidden/old/Cargo.toml
+++ b/test_crates/enum_tuple_variant_field_now_doc_hidden/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_tuple_variant_field_now_doc_hidden"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_tuple_variant_field_now_doc_hidden/old/src/lib.rs
+++ b/test_crates/enum_tuple_variant_field_now_doc_hidden/old/src/lib.rs
@@ -1,13 +1,13 @@
 enum NonPublicEnum {
-    TupleVariant(i32,u8),
+    TupleVariant(i32, u8),
 }
 pub enum PulicEnumA {
-    TupleVariantWithPublicField(u8,i32),
+    TupleVariantWithPublicField(u8, i32),
 }
 pub enum PulicEnumB {
     TupleVariantWithPublicFieldHidden(#[doc(hidden)] i64, u8),
 }
 #[doc(hidden)]
-pub enum PulicEnumC{
-    TupleVariantWithPublicField(u8,i64),
+pub enum PulicEnumC {
+    TupleVariantWithPublicField(u8, i64),
 }

--- a/test_crates/enum_tuple_variant_field_now_doc_hidden/old/src/lib.rs
+++ b/test_crates/enum_tuple_variant_field_now_doc_hidden/old/src/lib.rs
@@ -1,0 +1,13 @@
+enum NonPublicEnum {
+    TupleVariant(i32,u8),
+}
+pub enum PulicEnumA {
+    TupleVariantWithPublicField(u8,i32),
+}
+pub enum PulicEnumB {
+    TupleVariantWithPublicFieldHidden(#[doc(hidden)] i64, u8),
+}
+#[doc(hidden)]
+pub enum PulicEnumC{
+    TupleVariantWithPublicField(u8,i64),
+}

--- a/test_outputs/enum_tuple_variant_field_now_doc_hidden.output.ron
+++ b/test_outputs/enum_tuple_variant_field_now_doc_hidden.output.ron
@@ -1,0 +1,5 @@
+{
+    "./test_crates/enum_tuple_variant_field_now_doc_hidden/": [
+        // TODO
+    ]
+}

--- a/test_outputs/enum_tuple_variant_field_now_doc_hidden.output.ron
+++ b/test_outputs/enum_tuple_variant_field_now_doc_hidden.output.ron
@@ -1,5 +1,15 @@
 {
     "./test_crates/enum_tuple_variant_field_now_doc_hidden/": [
-        // TODO
-    ]
+         {
+            "enum_name": String("PulicEnumA"),
+            "field_name": String("0"),
+            "path": List([
+                String("enum_tuple_variant_field_now_doc_hidden"),
+                String("PulicEnumA"),
+            ]),
+            "span_begin_line": Uint64(7),
+            "span_filename": String("src/lib.rs"),
+            "variant_name": String("TupleVariantWithPublicField"),
+        },
+    ],
 }


### PR DESCRIPTION
Lint for when a field in tuple variant in public enum is now marked as #[doc(hidden)]

Issue mentioned in #578 