### PR TITLE
Raise compile-time and runtime MSRV to Rust 1.74.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,16 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-binary
+    env:
+      OLDER_RUST: "1.74"    # Rust 1.74 uses rustdoc v27
+      NEWER_RUST: "nightly" # Rust 1.78-nightly uses rustdoc v28
     steps:
+      - name: Put env vars in outputs
+        id: vars
+        run:
+          echo "older-rust=$OLDER_RUST" >> $GITHUB_OUTPUT
+          echo "newer-rust=$NEWER_RUST" >> $GITHUB_OUTPUT
+
       - name: Checkout cargo-semver-checks
         uses: actions/checkout@v4
         with:
@@ -334,7 +343,7 @@ jobs:
         id: toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: "1.73"  # Rust 1.73 uses rustdoc v26
+          toolchain: ${{ steps.vars.outputs.OLDER_RUST }}
           rustflags: ""
           cache: false
 
@@ -368,15 +377,11 @@ jobs:
       - name: Install newer rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          # Make sure this version matches the env var below.
-          toolchain: "nightly"  # Rust 1.75-nightly uses rustdoc v27
-
+          toolchain: ${{ steps.vars.outputs.NEWER_RUST }}
           rustflags: ""
           cache: false
 
       - name: Check with older rustdoc version cached
-        env:
-          NEWER_RUST_VERSION: "nightly"  # Make sure this matches the version installed just above.
         run: |
           # Use a separate workspace, to avoid contaminating the cache for Swatinem/rust-cache@v2
           cp -R subject subject-new
@@ -395,7 +400,7 @@ jobs:
           # Run cargo-semver-checks with the older cached file.
           # In a prior step, we installed a newer Rust, so we'll set that as the default
           # for cargo-semver-checks to invoke here.
-          rustup override set "$NEWER_RUST_VERSION"
+          rustup override set "$NEWER_RUST"
           bins/cargo-semver-checks semver-checks check-release --manifest-path="subject-new/core/Cargo.toml" --verbose
 
           export NEW_RUSTDOC_VERSION="$(jq .format_version subject-new/target/semver-checks/cache/registry-libp2p_core-0_37_0.json)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         # IMPORTANT: When updating the versions here, make sure you also update
         #            the `fails-on-too-old-rustc` job and its error message to
         #            to account for the raised minimum required version.
-        toolchain: ["1.71", "1.72", "1.73", "1.74", "1.75", "stable", "beta"]
+        toolchain: ["1.74", "1.75", "stable", "beta"]
         experimental: [false]
         include:
           - toolchain: "nightly"
@@ -1684,7 +1684,7 @@ jobs:
         id: toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: "1.70"
+          toolchain: "1.73"
           rustflags: ""
           cache: false
 
@@ -1727,7 +1727,7 @@ jobs:
       - name: Check output
         run: |
           cd semver
-          EXPECTED="$(echo -e "error: rustc version is not high enough: >=1.71.0 needed, got 1.70.0")"
+          EXPECTED="$(echo -e "error: rustc version is not high enough: >=1.74.0 needed, got 1.73.0")"
           RESULT="$(cat output | grep 'error: rustc version')"
           diff <(echo "$RESULT") <(echo "$EXPECTED")
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2284,15 +2284,6 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7a12c7506980eaac5c9851a04e90e0062eb4417aa188a512bf7a64a1ef290f"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "rustdoc-types"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc646f09069d689083b975698bdac4edb96c2f0e7d270b701760814b886bb224"
@@ -2887,16 +2878,6 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "26.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24f09de16f8bc6078483fbd4f5517e8fe19e96d52484bc74acb7b1384d4d163"
-dependencies = [
- "rustdoc-types 0.22.0",
- "trustfall",
-]
-
-[[package]]
-name = "trustfall-rustdoc-adapter"
 version = "27.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d4b5cfa41c632f61cd180fb0b3710c2f593d90eaca32a424ac61b91bbd94035"
@@ -2953,7 +2934,6 @@ dependencies = [
  "serde",
  "serde_json",
  "trustfall",
- "trustfall-rustdoc-adapter 26.3.2",
  "trustfall-rustdoc-adapter 27.1.2",
  "trustfall-rustdoc-adapter 28.0.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ repository = "https://github.com/obi1kenobi/cargo-semver-checks"
 readme = "./README.md"
 keywords = ["semver", "check", "crate", "cargo"]
 categories = ["command-line-utilities", "development-tools::cargo-plugins"]
-rust-version = "1.70"
+rust-version = "1.74"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 trustfall = "0.7.1"
-trustfall_rustdoc = { version = "0.14.1", default-features = false, features = ["v26", "v27", "v28"] }
+trustfall_rustdoc = { version = "0.14.1", default-features = false, features = ["v27", "v28"] }
 clap = { version = "4.0.0", features = ["derive", "cargo"] }
 serde_json = "1.0.82"
 anyhow = "1.0.58"

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,7 +52,7 @@ impl GlobalConfig {
                 }
             })),
             handlebars: make_handlebars_registry(),
-            minimum_rustc_version: semver::Version::new(1, 71, 0),
+            minimum_rustc_version: semver::Version::new(1, 74, 0),
         }
     }
 


### PR DESCRIPTION
cargo-semver-checks now requires Rust 1.74+ in order to compile, and only supports rustdoc generated by Rust 1.74+ meaning the installed Rust at runtime must be 1.74+ as well.

This is largely motivated by many of our dependencies raising their MSRVs to 1.74, which made it tedious for us to support older Rust versions.
