### PR TITLE
Add lint pub_static_now_doc_hidden

### DIFF
--- a/src/lints/pub_static_now_doc_hidden.ron
+++ b/src/lints/pub_static_now_doc_hidden.ron
@@ -1,0 +1,48 @@
+SemverQuery(
+    id: "pub_static_now_doc_hidden",
+    human_readable_name: "pub static is now #[doc(hidden)]",
+    description: "A pub static is now marked #[doc(hidden)] and is thus no longer part of the public API.",
+    required_update: Major,
+    reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Static {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Static {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        static_name: name @output
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "!=", value: ["$true"])
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+    },
+    error_message: "A pub static is now #[doc(hidden)], removing it from the crate's public API.",
+    per_result_error_template: Some("{{static_name}} in file {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -476,6 +476,7 @@ macro_rules! add_lints {
 }
 
 add_lints!(
+    pub_static_now_doc_hidden,
     function_abi_no_longer_unwind,
     pub_module_level_const_now_doc_hidden,
     enum_struct_variant_field_now_doc_hidden,

--- a/test_crates/pub_static_now_doc_hidden/new/Cargo.toml
+++ b/test_crates/pub_static_now_doc_hidden/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "pub_static_now_doc_hidden"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/pub_static_now_doc_hidden/new/src/lib.rs
+++ b/test_crates/pub_static_now_doc_hidden/new/src/lib.rs
@@ -1,0 +1,22 @@
+pub static GlobalStaticA: i32 = 0;
+//Should be caught on adding #[doc(hidden)]
+#[doc(hidden)]
+pub static GlobalStaticB: i32 = 0;
+
+mod PrivateModule {
+    pub static PrivateModuleStaticA: i32 = 0;
+    //Should not be caught since its in a private module
+    #[doc(hidden)]
+    pub static PrivateModuleStaticB: i32 = 0;
+    #[doc(hidden)]
+    static PrivateModuleStaticC: i32 = 0;
+}
+pub mod PublicModule {
+    pub static PublicModuleStaticA: i32 = 0;
+    //Should be caught on adding #[doc(hidden)] since its a public static in a public module
+    #[doc(hidden)]
+    pub static PublicModuleStaticB: i32 = 0;
+    //Should not be caught since its not a public static
+    #[doc(hidden)]
+    static PublicModuleStaticC: i32 = 0;
+}

--- a/test_crates/pub_static_now_doc_hidden/old/Cargo.toml
+++ b/test_crates/pub_static_now_doc_hidden/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "pub_static_now_doc_hidden"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/pub_static_now_doc_hidden/old/src/lib.rs
+++ b/test_crates/pub_static_now_doc_hidden/old/src/lib.rs
@@ -1,0 +1,13 @@
+pub static GlobalStaticA: i32 = 0;
+pub static GlobalStaticB: i32 = 0;
+
+mod PrivateModule {
+    pub static PrivateModuleStaticA: i32 = 0;
+    pub static PrivateModuleStaticB: i32 = 0;
+    static PrivateModuleStaticC: i32 = 0;
+}
+pub mod PublicModule {
+    pub static PublicModuleStaticA: i32 = 0;
+    pub static PublicModuleStaticB: i32 = 0;
+    static PublicModuleStaticC: i32 = 0;
+}

--- a/test_outputs/pub_static_now_doc_hidden.output.ron
+++ b/test_outputs/pub_static_now_doc_hidden.output.ron
@@ -1,0 +1,23 @@
+{
+     "./test_crates/pub_static_now_doc_hidden/": [
+        {
+            "path": List([
+                String("pub_static_now_doc_hidden"),
+                String("GlobalStaticB"),
+            ]),
+            "span_begin_line": Uint64(4),
+            "span_filename": String("src/lib.rs"),
+            "static_name": String("GlobalStaticB"),
+        },
+        {
+            "path": List([
+                String("pub_static_now_doc_hidden"),
+                String("PublicModule"),
+                String("PublicModuleStaticB"),
+            ]),
+            "span_begin_line": Uint64(18),
+            "span_filename": String("src/lib.rs"),
+            "static_name": String("PublicModuleStaticB"),
+        },
+    ],
+}


### PR DESCRIPTION
Lint for when a public static is now marked as #[doc(hidden)]

Issue mentioned in https://github.com/obi1kenobi/cargo-semver-checks/issues/578