### PR TITLE
Add `--color` setting to CLI.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,7 @@ dependencies = [
  "ignore",
  "itertools 0.12.1",
  "log",
+ "predicates",
  "rayon",
  "ron",
  "rustc_version",
@@ -675,6 +676,15 @@ dependencies = [
  "crc32fast",
  "libz-ng-sys",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1903,6 +1913,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,7 +2084,10 @@ checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ rayon = "1.8.0"
 
 [dev-dependencies]
 assert_cmd = "2.0"
-lazy_static = "1.4.0"
 similar-asserts = { version = "1.5.0", features = ["serde"] }
 predicates = "3.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,9 @@ rayon = "1.8.0"
 
 [dev-dependencies]
 assert_cmd = "2.0"
+lazy_static = "1.4.0"
 similar-asserts = { version = "1.5.0", features = ["serde"] }
+predicates = "3.1.0"
 
 # In dev and test profiles, compile all dependencies with optimizations enabled,
 # but still checking debug assertions and overflows.

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,6 +137,12 @@ impl GlobalConfig {
         &mut self.stderr
     }
 
+    pub fn set_color_choice(mut self, choice: ColorChoice) -> Self {
+        self.stdout = StandardStream::stdout(choice);
+        self.stderr = StandardStream::stderr(choice);
+        self
+    }
+
     /// Print a message with a colored title in the style of Cargo shell messages.
     pub fn shell_print(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,7 @@ impl Check {
     pub fn log_level(&self) -> Option<&log::Level> {
         self.log_level.as_ref()
     }
-    
+
     /// Set the termcolor [color choice](termcolor::ColorChoice)
     /// If `None`, the use of colors will be determined automatically by
     /// CARGO_TERM_COLOR env var and tty type of output`
@@ -292,7 +292,7 @@ impl Check {
         self.color_choice = choice;
         self
     }
-    
+
     /// Get the current color choice.  If `None`, the use of colors is determined
     /// by the `CARGO_TERM_COLOR` env var and whether the output is a tty
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,9 +285,9 @@ impl Check {
         self.log_level.as_ref()
     }
 
-    /// Set the termcolor [color choice](termcolor::ColorChoice)
+    /// Set the termcolor [color choice](termcolor::ColorChoice).
     /// If `None`, the use of colors will be determined automatically by
-    /// the `CARGO_TERM_COLOR` env var and tty type of output
+    /// the `CARGO_TERM_COLOR` env var and tty type of output.
     pub fn with_color_choice(&mut self, choice: Option<termcolor::ColorChoice>) -> &mut Self {
         self.color_choice = choice;
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,7 +287,7 @@ impl Check {
 
     /// Set the termcolor [color choice](termcolor::ColorChoice)
     /// If `None`, the use of colors will be determined automatically by
-    /// CARGO_TERM_COLOR env var and tty type of output`
+    /// the `CARGO_TERM_COLOR` env var and tty type of output
     pub fn with_color_choice(&mut self, choice: Option<termcolor::ColorChoice>) -> &mut Self {
         self.color_choice = choice;
         self

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
         exit_on_error(true, || {
             let mut config =
                 GlobalConfig::new().set_level(args.check_release.verbosity.log_level());
-            
+
             // we don't want to set auto if the choice is not set because it would overwrite
             // the value if the CARGO_TERM_COLOR env var read in GlobalConfig::new() if it is set
             if let Some(choice) = args.check_release.color_choice {
@@ -289,14 +289,14 @@ struct CheckRelease {
 
     #[command(flatten)]
     verbosity: clap_verbosity_flag::Verbosity<clap_verbosity_flag::InfoLevel>,
-    
+
     #[arg(value_enum, long = "color")]
     /// Whether to print colors to the terminal:
     /// always, alwaysansi (always use only ANSI color codes),
     /// auto (based on whether output is a tty), and never
-    /// 
+    ///
     /// Default is auto (use colors if output is a TTY, otherwise don't use colors)
-    color_choice: Option<termcolor::ColorChoice>
+    color_choice: Option<termcolor::ColorChoice>,
 }
 
 impl From<CheckRelease> for cargo_semver_checks::Check {
@@ -381,7 +381,7 @@ impl From<CheckRelease> for cargo_semver_checks::Check {
         baseline_features.append(&mut mutual_features);
 
         // Treat --features="" as a no-op like cargo does
-        let trim_features= |features: &mut Vec<String>| {
+        let trim_features = |features: &mut Vec<String>| {
             features.retain(|feature| !(feature.is_empty() || feature == "\"\""));
         };
         trim_features(&mut current_features);

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,12 +290,12 @@ struct CheckRelease {
     #[command(flatten)]
     verbosity: clap_verbosity_flag::Verbosity<clap_verbosity_flag::InfoLevel>,
 
-    #[arg(value_enum, long = "color")]
     /// Whether to print colors to the terminal:
     /// always, alwaysansi (always use only ANSI color codes),
     /// auto (based on whether output is a tty), and never
     ///
     /// Default is auto (use colors if output is a TTY, otherwise don't use colors)
+    #[arg(value_enum, long = "color")]
     color_choice: Option<termcolor::ColorChoice>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,13 @@ fn main() {
         exit_on_error(true, || {
             let mut config =
                 GlobalConfig::new().set_level(args.check_release.verbosity.log_level());
+            
+            // we don't want to set auto if the choice is not set because it would overwrite
+            // the value if the CARGO_TERM_COLOR env var read in GlobalConfig::new() if it is set
+            if let Some(choice) = args.check_release.color_choice {
+                config = config.set_color_choice(choice);
+            }
+
             let queries = SemverQuery::all_queries();
             let mut rows = vec![["id", "type", "description"], ["==", "====", "==========="]];
             for query in queries.values() {
@@ -282,6 +289,14 @@ struct CheckRelease {
 
     #[command(flatten)]
     verbosity: clap_verbosity_flag::Verbosity<clap_verbosity_flag::InfoLevel>,
+    
+    #[arg(value_enum, long = "color")]
+    /// Whether to print colors to the terminal:
+    /// always, alwaysansi (always use only ANSI color codes),
+    /// auto (based on whether output is a tty), and never
+    /// 
+    /// Default is auto (use colors if output is a TTY, otherwise don't use colors)
+    color_choice: Option<termcolor::ColorChoice>
 }
 
 impl From<CheckRelease> for cargo_semver_checks::Check {
@@ -344,6 +359,7 @@ impl From<CheckRelease> for cargo_semver_checks::Check {
         }
 
         check.with_log_level(value.verbosity.log_level());
+        check.with_color_choice(value.color_choice);
 
         if let Some(release_type) = value.release_type {
             check.with_release_type(release_type);
@@ -365,7 +381,7 @@ impl From<CheckRelease> for cargo_semver_checks::Check {
         baseline_features.append(&mut mutual_features);
 
         // Treat --features="" as a no-op like cargo does
-        let trim_features = |features: &mut Vec<String>| {
+        let trim_features= |features: &mut Vec<String>| {
             features.retain(|feature| !(feature.is_empty() || feature == "\"\""));
         };
         trim_features(&mut current_features);

--- a/tests/color_config.rs
+++ b/tests/color_config.rs
@@ -31,6 +31,8 @@ fn run_on_crate_diff(
 
     if let Some(color_env) = color_env_var {
         cmd.env("CARGO_TERM_COLOR", color_env);
+    } else {
+        cmd.env_remove("CARGO_TERM_COLOR");
     }
 
     let pred = predicates::str::contains("\u{1b}[");

--- a/tests/color_config.rs
+++ b/tests/color_config.rs
@@ -1,0 +1,97 @@
+//! Tests the --color flag and CARGO_TERM_COLOR env var, and their interactions
+//!
+//! The --color flag should take precedence over the environment variable
+use assert_cmd::Command;
+use predicates::boolean::PredicateBooleanExt;
+
+/// helper function to run `check-release` on a given directory in `test_crates/` with the given color arg/env var
+/// - `color_arg` is the argument to `--color=<choice>`, if set
+/// - `color_env_var` sets the `CARGO_TERM_COLOR=choice`, if set
+///
+/// Panics with a failed assertion if there are colors (i.e., ANSI color codes) in the output and `assert_colors` is false, or vice versa
+fn run_on_crate_diff(
+    test_crate_name: &'static str,
+    color_arg: Option<&'static str>,
+    color_env_var: Option<&'static str>,
+    assert_colors: bool,
+) {
+    let mut cmd = Command::cargo_bin("cargo-semver-checks").unwrap();
+
+    cmd.current_dir(format!("test_crates/{}", test_crate_name))
+        .args([
+            "semver-checks",
+            "check-release",
+            "--manifest-path=new/Cargo.toml",
+            "--baseline-root=old/",
+        ]);
+
+    if let Some(color_arg) = color_arg {
+        cmd.arg("--color").arg(color_arg);
+    }
+
+    if let Some(color_env) = color_env_var {
+        cmd.env("CARGO_TERM_COLOR", color_env);
+    }
+
+    let pred = predicates::str::contains("\u{1b}[");
+
+    let assert = cmd.assert();
+
+    if assert_colors {
+        assert.stderr(pred);
+    } else {
+        assert.stderr(pred.not());
+    }
+}
+
+/// test for colors when using the --color=always flag
+#[test]
+fn always_flag() {
+    // test on a crate diff returning no errors
+    run_on_crate_diff("template", Some("always"), None, true);
+    // test on a crate diff that will return errors
+    run_on_crate_diff("enum_missing", Some("always"), None, true);
+}
+
+/// test for no colors when using the --color=never flag
+#[test]
+fn never_flag() {
+    // test on a crate diff returning no errors
+    run_on_crate_diff("template", Some("never"), None, false);
+    // test on a crate diff that will return errors
+    run_on_crate_diff("enum_missing", Some("never"), None, false);
+}
+
+/// test for colors when using the CARGO_TERM_COLOR=always env var
+#[test]
+fn always_var() {
+    // test on a crate diff returning no errors
+    run_on_crate_diff("template", None, Some("always"), true);
+    // test on a crate diff that will return errors
+    run_on_crate_diff("enum_missing", None, Some("always"), true);
+}
+
+/// test for colors when using the CARGO_TERM_COLOR=never env var
+#[test]
+fn never_var() {
+    // test on a crate diff returning no errors
+    run_on_crate_diff("template", None, Some("never"), false);
+    // test on a crate diff that will return errors
+    run_on_crate_diff("enum_missing", None, Some("never"), false);
+}
+
+/// test for the behavior of the --color flag overriding the `CARGO_TERM_COLOR` env var when they conflict
+#[test]
+fn cli_flag_overrides_env_var() {
+    // test when --color=always and CARGO_TERM_COLOR=never
+    // test on a crate diff returning no errors
+    run_on_crate_diff("template", Some("always"), Some("never"), true);
+    // test on a crate diff that will return errors
+    run_on_crate_diff("enum_missing", Some("always"), Some("never"), true);
+
+    // test when --color=never and CARGO_TERM_COLOR=always
+    // test on a crate diff returning no errors
+    run_on_crate_diff("template", Some("never"), Some("always"), false);
+    // test on a crate diff that will return errors
+    run_on_crate_diff("enum_missing", Some("never"), Some("always"), false);
+}


### PR DESCRIPTION
Fixes #719 

There is already code to recognize the `CARGO_TERM_COLOR` environment variable for setting color policy in `GlobalConfig::new()`.  This PR makes it so that the `--color=...` flag takes precedence over the env var, but if the CLI flag is not set, then the env var still applies if it is set.

I'm not super happy with needing the `if let` block that comes with `set_color_choice` in order to not overwrite the env var - I'd definitely be willing to refactor the env var detection into a different function or make some other change.

I wasn't sure if tests were necessary/how to test this.  If you want tests, let me know and I can add them.