### PR TITLE
Print crate features in verbose mode (#711)

### DIFF
--- a/src/rustdoc_cmd.rs
+++ b/src/rustdoc_cmd.rs
@@ -405,6 +405,17 @@ fn create_placeholder_rustdoc_manifest(
                     ..DependencyDetail::default()
                 },
             };
+            config.log_verbose(|config| {
+                if project_with_features.features.is_empty() {
+                    return Ok(());
+                }
+                writeln!(
+                    config.stderr(),
+                    "             Features: {}",
+                    project_with_features.features.join(","),
+                )?;
+                Ok(())
+            })?;
             let mut deps = DepsSet::new();
             deps.insert(
                 crate_source.name()?.to_string(),


### PR DESCRIPTION
Resolves #711. 

Implements the format as described in https://github.com/obi1kenobi/cargo-semver-checks/issues/711#issuecomment-2025950808. 

Note: I used a join without spaces to make the output usable as a command-line argument if copy-pasted.