### PR TITLE
Add lint for union field missing case

### DIFF
--- a/src/lints/union_field_missing.ron
+++ b/src/lints/union_field_missing.ron
@@ -1,0 +1,67 @@
+SemverQuery(
+    id: "union_field_missing",
+    human_readable_name: "pub union pub field is removed or renamed",
+    description: "pub union pub field is removed or renamed. No longer present under it's previous name, by whatever cause.",
+    required_update: Major, 
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Union {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        union_name: name @output @tag
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        field {
+                            field_name: name @output @tag
+                            visibility_limit @filter(op: "=", value: ["$public"])
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+
+                            span_: span @optional {
+                                filename @output
+                                begin_line @output
+                            }
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Union {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @filter(op: "=", value: ["%union_name"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+            
+                        field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            visibility_limit @filter(op: "=", value: ["$public"])
+                            name @filter(op: "=", value: ["%field_name"])
+                            
+                        }
+
+                        
+
+                    
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+        "zero": 0,
+    },
+    error_message: "A pub field in a pub union  has been removed.",
+    per_result_error_template: Some("union {{union_name}} in file {{span_filename}}:{{span_begin_line}} missing field {{field_name}}"),
+)

--- a/src/lints/union_field_missing.ron
+++ b/src/lints/union_field_missing.ron
@@ -41,17 +41,11 @@ SemverQuery(
                             path @filter(op: "=", value: ["%path"])
                             public_api @filter(op: "=", value: ["$true"])
                         }
-
-            
                         field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                             visibility_limit @filter(op: "=", value: ["$public"])
                             name @filter(op: "=", value: ["%field_name"])
                             
                         }
-
-                        
-
-                    
                     }
                 }
             }
@@ -62,6 +56,6 @@ SemverQuery(
         "true": true,
         "zero": 0,
     },
-    error_message: "A pub field in a pub union  has been removed.",
-    per_result_error_template: Some("union {{union_name}} in file {{span_filename}}:{{span_begin_line}} missing field {{field_name}}"),
+    error_message: "A pub field in a pub union has been removed or renamed.",
+    per_result_error_template: Some("field {{union_name}}.{{field_name}} previously in file {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/query.rs
+++ b/src/query.rs
@@ -476,6 +476,7 @@ macro_rules! add_lints {
 }
 
 add_lints!(
+    union_field_missing,
     pub_static_now_doc_hidden,
     function_abi_no_longer_unwind,
     pub_module_level_const_now_doc_hidden,

--- a/test_crates/union_field_missing/new/Cargo.toml
+++ b/test_crates/union_field_missing/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "union_field_missing"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/union_field_missing/new/src/lib.rs
+++ b/test_crates/union_field_missing/new/src/lib.rs
@@ -1,0 +1,22 @@
+// private union shouldn't cause any breaking changes
+union PrivateUnion {
+    f3: f32,
+}
+
+
+// pub union with private fields shouldn't cause any breaking changes
+pub union PubUnionPrivateField {
+    f3: f32,
+}
+
+
+// pub union with pub fields renamed should cause breaking changes
+pub union PubUnionPubFieldRenamed{
+    pub f1: u32,
+    pub f3: f32,
+}
+
+// pub union with pub fields removed should cause breaking changes
+pub union PubUnionPubFieldRemoved{
+    pub f1: u32,
+}

--- a/test_crates/union_field_missing/old/Cargo.toml
+++ b/test_crates/union_field_missing/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "union_field_missing"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/union_field_missing/old/src/lib.rs
+++ b/test_crates/union_field_missing/old/src/lib.rs
@@ -1,0 +1,25 @@
+// private union shouldn't cause any breaking changes
+union PrivateUnion {
+    f1: u32,
+    f2: f32,
+}
+
+
+// pub union with private fields shouldn't cause any breaking changes
+pub union PubUnionPrivateField {
+    f1: u32,
+    f2: f32,
+}
+
+
+// pub union with pub fields renamed should cause breaking changes
+pub union PubUnionPubFieldRenamed{
+    pub f1: u32,
+    pub f2: f32,
+}
+
+// pub union with pub fields renamed should cause breaking changes
+pub union PubUnionPubFieldRemoved{
+    pub f1: u32,
+    pub f2: f32,
+}

--- a/test_outputs/union_field_missing.output.ron
+++ b/test_outputs/union_field_missing.output.ron
@@ -1,0 +1,24 @@
+{
+    "./test_crates/union_field_missing/": [
+        {
+            "field_name": String("f2"),
+            "path": List([
+                String("union_field_missing"),
+                String("PubUnionPubFieldRenamed"),
+            ]),
+            "span_begin_line": Uint64(18),
+            "span_filename": String("src/lib.rs"),
+            "union_name": String("PubUnionPubFieldRenamed"),
+        },
+        {
+            "field_name": String("f2"),
+            "path": List([
+                String("union_field_missing"),
+                String("PubUnionPubFieldRemoved"),
+            ]),
+            "span_begin_line": Uint64(24),
+            "span_filename": String("src/lib.rs"),
+            "union_name": String("PubUnionPubFieldRemoved"),
+        },       
+    ]
+}


### PR DESCRIPTION
Covers 
>  pub union's pub field removed / renamed (no longer present under its previous name, by whatever cause)

case in Issue #633