### PR TITLE
Fix semver id

### DIFF
--- a/src/lints/exported_function_changed_abi.ron
+++ b/src/lints/exported_function_changed_abi.ron
@@ -1,5 +1,5 @@
 SemverQuery(
-    id: "function_changed_export_name",
+    id: "exported_function_changed_abi",
     human_readable_name: "exported function changed ABI",
     description: "A function marked `#[no_mangle]` or assigned an explicit `#[export_name]` changed its external ABI.",
     required_update: Major,


### PR DESCRIPTION
Follow-up to #650. Corrects the mistake of wrong semver id.

For the future, I think the `id` should not exist in the `ron` file and instead should be taken from the file name, letting us avoid these kinds of mistakes.