### PR TITLE
improve config function consistency

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ impl GlobalConfig {
         &self.minimum_rustc_version
     }
 
-    pub fn set_level(mut self, level: Option<log::Level>) -> Self {
+    pub fn set_log_level(&mut self, level: Option<log::Level>) -> &mut Self {
         self.level = level;
         self
     }
@@ -174,8 +174,9 @@ impl GlobalConfig {
     /// Defaults to the global color choice setting set by [`ColorChoice::write_global`]
     /// *at the time of calling `set_stderr`*.
     /// Call [`GlobalConfig::set_err_color_choice`] to customize the color choice after if needed.
-    pub fn set_stderr(&mut self, err: Box<dyn Write + 'static>) {
+    pub fn set_stderr(&mut self, err: Box<dyn Write + 'static>) -> &mut Self {
         self.stderr = AutoStream::auto(err);
+        self
     }
 
     /// Sets the stdout output stream
@@ -183,8 +184,9 @@ impl GlobalConfig {
     /// Defaults to the global color choice setting set by [`ColorChoice::write_global`].
     /// *at the time of calling `set_stdout`*.
     /// Call [`GlobalConfig::set_out_color_choice`] to customize the color choice after if needed.
-    pub fn set_stdout(&mut self, out: Box<dyn Write + 'static>) {
+    pub fn set_stdout(&mut self, out: Box<dyn Write + 'static>) -> &mut Self {
         self.stdout = AutoStream::auto(out);
+        self
     }
 
     /// Individually set the color choice setting for [`GlobalConfig::stderr`]
@@ -193,7 +195,7 @@ impl GlobalConfig {
     /// in [`ColorChoice::write_global`] if you are using the `anstream` crate.
     ///
     /// See also [`GlobalConfig::set_out_color_choice`] and [`GlobalConfig::set_color_choice`]
-    pub fn set_err_color_choice(&mut self, use_color: bool) {
+    pub fn set_err_color_choice(&mut self, use_color: bool) -> &mut Self {
         // `anstream` doesn't have a good mechanism to set color choice (on one stream)
         // without making a new object, so we have to make a new autostream, but since we need
         // to move the `RawStream` inner, we temporarily replace it with /dev/null
@@ -209,6 +211,7 @@ impl GlobalConfig {
                 ColorChoice::Never
             },
         );
+        self
     }
 
     /// Individually set the color choice setting for [`GlobalConfig::stdout`]
@@ -217,7 +220,7 @@ impl GlobalConfig {
     /// in [`ColorChoice::write_global`] if you are using the `anstream` crate.
     ///
     /// See also [`GlobalConfig::set_err_color_choice`] and [`GlobalConfig::set_color_choice`]
-    pub fn set_out_color_choice(&mut self, use_color: bool) {
+    pub fn set_out_color_choice(&mut self, use_color: bool) -> &mut Self {
         // `anstream` doesn't have a good mechanism to set color choice (on one stream)
         // without making a new object, so we have to make a new autostream, but since we need
         // to move the `RawStream` inner, we temporarily replace it with /dev/null
@@ -233,6 +236,7 @@ impl GlobalConfig {
                 ColorChoice::Never
             },
         );
+        self
     }
 
     /// Sets the color choice for both [`GlobalConfig::stderr`] and [`GlobalConfig::stdout`]
@@ -241,9 +245,10 @@ impl GlobalConfig {
     /// are set using [`GlobalConfig::set_stdout`] and `err`, which can be set beforehand
     ///
     /// See also [`GlobalConfig::set_err_color_choice`] and [`GlobalConfig::set_out_color_choice`]
-    pub fn set_color_choice(&mut self, use_color: bool) {
+    pub fn set_color_choice(&mut self, use_color: bool) -> &mut Self {
         self.set_err_color_choice(use_color);
         self.set_out_color_choice(use_color);
+        self
     }
 
     /// Gets the color choice (i.e., whether to output colors) for the configured stderr
@@ -359,7 +364,7 @@ mod tests {
     #[test]
     fn test_log_level_info() {
         let mut config = GlobalConfig::new();
-        config = config.set_level(Some(log::Level::Info));
+        config.set_log_level(Some(log::Level::Info));
 
         assert!(config.is_info());
         assert!(!config.is_verbose());
@@ -369,7 +374,7 @@ mod tests {
     #[test]
     fn test_log_level_debug() {
         let mut config = GlobalConfig::new();
-        config = config.set_level(Some(log::Level::Debug));
+        config.set_log_level(Some(log::Level::Debug));
 
         assert!(config.is_info());
         assert!(config.is_verbose());
@@ -379,7 +384,7 @@ mod tests {
     #[test]
     fn test_log_level_trace() {
         let mut config = GlobalConfig::new();
-        config = config.set_level(Some(log::Level::Trace));
+        config.set_log_level(Some(log::Level::Trace));
 
         assert!(config.is_info());
         assert!(config.is_verbose());
@@ -389,7 +394,7 @@ mod tests {
     #[test]
     fn test_log_level_none() {
         let mut config = GlobalConfig::new();
-        config = config.set_level(None);
+        config.set_log_level(None);
 
         assert!(!config.is_info());
         assert!(!config.is_verbose());
@@ -399,12 +404,16 @@ mod tests {
     #[test]
     fn test_set_color_choice() {
         assert_color_choice(
-            |config| config.set_color_choice(false),
+            |config| {
+                config.set_color_choice(false);
+            },
             Some(false),
             Some(false),
         );
         assert_color_choice(
-            |config| config.set_color_choice(true),
+            |config| {
+                config.set_color_choice(true);
+            },
             Some(true),
             Some(true),
         );
@@ -413,21 +422,37 @@ mod tests {
     #[test]
     fn test_set_out_color_choice() {
         assert_color_choice(
-            |config| config.set_out_color_choice(false),
+            |config| {
+                config.set_out_color_choice(false);
+            },
             Some(false),
             None,
         );
-        assert_color_choice(|config| config.set_out_color_choice(true), Some(true), None);
+        assert_color_choice(
+            |config| {
+                config.set_out_color_choice(true);
+            },
+            Some(true),
+            None,
+        );
     }
 
     #[test]
     fn test_set_err_color_choice() {
         assert_color_choice(
-            |config| config.set_err_color_choice(false),
+            |config| {
+                config.set_err_color_choice(false);
+            },
             None,
             Some(false),
         );
-        assert_color_choice(|config| config.set_err_color_choice(true), None, Some(true));
+        assert_color_choice(
+            |config| {
+                config.set_err_color_choice(true);
+            },
+            None,
+            Some(true),
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ impl PackageSelection {
         }
     }
 
-    pub fn with_excluded_packages(&mut self, packages: Vec<String>) -> &mut Self {
+    pub fn set_excluded_packages(&mut self, packages: Vec<String>) -> &mut Self {
         self.excluded_packages = packages;
         self
     }
@@ -256,51 +256,51 @@ impl Check {
         }
     }
 
-    pub fn with_package_selection(&mut self, selection: PackageSelection) -> &mut Self {
+    pub fn set_package_selection(&mut self, selection: PackageSelection) -> &mut Self {
         self.scope.mode = ScopeMode::DenyList(selection);
         self
     }
 
-    pub fn with_packages(&mut self, packages: Vec<String>) -> &mut Self {
+    pub fn set_packages(&mut self, packages: Vec<String>) -> &mut Self {
         self.scope.mode = ScopeMode::AllowList(packages);
         self
     }
 
-    pub fn with_baseline(&mut self, baseline: Rustdoc) -> &mut Self {
+    pub fn set_baseline(&mut self, baseline: Rustdoc) -> &mut Self {
         self.baseline = baseline;
         self
     }
 
-    pub fn with_release_type(&mut self, release_type: ReleaseType) -> &mut Self {
+    pub fn set_release_type(&mut self, release_type: ReleaseType) -> &mut Self {
         self.release_type = Some(release_type);
         self
     }
 
-    pub fn with_only_explicit_features(&mut self) -> &mut Self {
+    pub fn set_only_explicit_features(&mut self) -> &mut Self {
         self.current_feature_config.features_group = rustdoc_gen::FeaturesGroup::None;
         self.baseline_feature_config.features_group = rustdoc_gen::FeaturesGroup::None;
         self
     }
 
-    pub fn with_default_features(&mut self) -> &mut Self {
+    pub fn set_default_features(&mut self) -> &mut Self {
         self.current_feature_config.features_group = rustdoc_gen::FeaturesGroup::Default;
         self.baseline_feature_config.features_group = rustdoc_gen::FeaturesGroup::Default;
         self
     }
 
-    pub fn with_heuristically_included_features(&mut self) -> &mut Self {
+    pub fn set_heuristically_included_features(&mut self) -> &mut Self {
         self.current_feature_config.features_group = rustdoc_gen::FeaturesGroup::Heuristic;
         self.baseline_feature_config.features_group = rustdoc_gen::FeaturesGroup::Heuristic;
         self
     }
 
-    pub fn with_all_features(&mut self) -> &mut Self {
+    pub fn set_all_features(&mut self) -> &mut Self {
         self.current_feature_config.features_group = rustdoc_gen::FeaturesGroup::All;
         self.baseline_feature_config.features_group = rustdoc_gen::FeaturesGroup::All;
         self
     }
 
-    pub fn with_extra_features(
+    pub fn set_extra_features(
         &mut self,
         extra_current_features: Vec<String>,
         extra_baseline_features: Vec<String>,
@@ -312,7 +312,7 @@ impl Check {
 
     /// Set what `--target` to build the documentation with, by default will not pass any flag
     /// relying on the users cargo configuration.
-    pub fn with_build_target(&mut self, build_target: String) -> &mut Self {
+    pub fn set_build_target(&mut self, build_target: String) -> &mut Self {
         self.build_target = Some(build_target);
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,25 +276,25 @@ impl Check {
         self
     }
 
-    pub fn set_only_explicit_features(&mut self) -> &mut Self {
+    pub fn with_only_explicit_features(&mut self) -> &mut Self {
         self.current_feature_config.features_group = rustdoc_gen::FeaturesGroup::None;
         self.baseline_feature_config.features_group = rustdoc_gen::FeaturesGroup::None;
         self
     }
 
-    pub fn set_default_features(&mut self) -> &mut Self {
+    pub fn with_default_features(&mut self) -> &mut Self {
         self.current_feature_config.features_group = rustdoc_gen::FeaturesGroup::Default;
         self.baseline_feature_config.features_group = rustdoc_gen::FeaturesGroup::Default;
         self
     }
 
-    pub fn set_heuristically_included_features(&mut self) -> &mut Self {
+    pub fn with_heuristically_included_features(&mut self) -> &mut Self {
         self.current_feature_config.features_group = rustdoc_gen::FeaturesGroup::Heuristic;
         self.baseline_feature_config.features_group = rustdoc_gen::FeaturesGroup::Heuristic;
         self
     }
 
-    pub fn set_all_features(&mut self) -> &mut Self {
+    pub fn with_all_features(&mut self) -> &mut Self {
         self.current_feature_config.features_group = rustdoc_gen::FeaturesGroup::All;
         self.baseline_feature_config.features_group = rustdoc_gen::FeaturesGroup::All;
         self

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,13 +393,13 @@ impl From<CheckRelease> for cargo_semver_checks::Check {
         }
 
         if value.all_features {
-            check.set_all_features();
+            check.with_all_features();
         } else if value.default_features {
-            check.set_default_features();
+            check.with_default_features();
         } else if value.only_explicit_features {
-            check.set_only_explicit_features();
+            check.with_only_explicit_features();
         } else {
-            check.set_heuristically_included_features();
+            check.with_heuristically_included_features();
         }
         let mut mutual_features = value.features;
         let mut current_features = value.current_features;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,8 @@ fn main() {
         std::process::exit(0);
     } else if args.list {
         exit_on_error(true, || {
-            let mut config =
-                GlobalConfig::new().set_level(args.check_release.verbosity.log_level());
+            let mut config = GlobalConfig::new();
+            config.set_log_level(args.check_release.verbosity.log_level());
 
             let queries = SemverQuery::all_queries();
             let mut rows = vec![["id", "type", "description"], ["==", "====", "==========="]];
@@ -92,7 +92,7 @@ fn main() {
 
     let mut config = GlobalConfig::new();
 
-    config = config.set_level(check_release.verbosity.log_level());
+    config.set_log_level(check_release.verbosity.log_level());
 
     let check: cargo_semver_checks::Check = check_release.into();
 
@@ -351,18 +351,18 @@ impl From<CheckRelease> for cargo_semver_checks::Check {
         if value.workspace.all || value.workspace.workspace {
             // Specified explicit `--workspace` or `--all`.
             let mut selection = PackageSelection::new(ScopeSelection::Workspace);
-            selection.with_excluded_packages(value.workspace.exclude);
-            check.with_package_selection(selection);
+            selection.set_excluded_packages(value.workspace.exclude);
+            check.set_package_selection(selection);
         } else if !value.workspace.package.is_empty() {
             // Specified explicit `--package`.
-            check.with_packages(value.workspace.package);
+            check.set_packages(value.workspace.package);
         } else if !value.workspace.exclude.is_empty() {
             // Specified `--exclude` without `--workspace/--all`.
             // Leave the scope selection to the default ("workspace if the manifest is a workspace")
             // while excluding any specified packages.
             let mut selection = PackageSelection::new(ScopeSelection::DefaultMembers);
-            selection.with_excluded_packages(value.workspace.exclude);
-            check.with_package_selection(selection);
+            selection.set_excluded_packages(value.workspace.exclude);
+            check.set_package_selection(selection);
         }
         let custom_baseline = {
             if let Some(baseline_version) = value.baseline_version {
@@ -385,21 +385,21 @@ impl From<CheckRelease> for cargo_semver_checks::Check {
             }
         };
         if let Some(baseline) = custom_baseline {
-            check.with_baseline(baseline);
+            check.set_baseline(baseline);
         }
 
         if let Some(release_type) = value.release_type {
-            check.with_release_type(release_type);
+            check.set_release_type(release_type);
         }
 
         if value.all_features {
-            check.with_all_features();
+            check.set_all_features();
         } else if value.default_features {
-            check.with_default_features();
+            check.set_default_features();
         } else if value.only_explicit_features {
-            check.with_only_explicit_features();
+            check.set_only_explicit_features();
         } else {
-            check.with_heuristically_included_features();
+            check.set_heuristically_included_features();
         }
         let mut mutual_features = value.features;
         let mut current_features = value.current_features;
@@ -414,10 +414,10 @@ impl From<CheckRelease> for cargo_semver_checks::Check {
         trim_features(&mut current_features);
         trim_features(&mut baseline_features);
 
-        check.with_extra_features(current_features, baseline_features);
+        check.set_extra_features(current_features, baseline_features);
 
         if let Some(build_target) = value.build_target {
-            check.with_build_target(build_target);
+            check.set_build_target(build_target);
         }
 
         check

--- a/tests/lib_tests.rs
+++ b/tests/lib_tests.rs
@@ -6,7 +6,7 @@ fn major_required_bump_if_breaking_change() {
     let baseline = Rustdoc::from_root("test_crates/trait_missing/new/");
     let mut config = GlobalConfig::new();
     let mut check = Check::new(current);
-    let check = check.with_baseline(baseline);
+    let check = check.set_baseline(baseline);
     let report = check.check_release(&mut config).unwrap();
     assert!(!report.success());
     let (_crate_name, crate_report) = report.crate_reports().iter().next().unwrap();
@@ -20,7 +20,7 @@ fn major_required_bump_if_breaking_change_and_major_bump_detected() {
     let current = Rustdoc::from_root("test_crates/trait_missing_with_major_bump/old/");
     let baseline = Rustdoc::from_root("test_crates/trait_missing_with_major_bump/new/");
     let mut check = Check::new(current);
-    let check = check.with_baseline(baseline);
+    let check = check.set_baseline(baseline);
     let report = check.check_release(&mut GlobalConfig::new()).unwrap();
     // semver is successful because the new crate has a major bump version
     assert!(report.success());


### PR DESCRIPTION
Fixes #764 

Config structs (`Check`, `GlobalConfig`, `PackageSelection`) now adhere to the following conventions for setter methods:

- method is called `set_[property]`
- method signature is `fn(&mut self, T) -> &mut Self`