### PR TITLE
Improve function_abi_no_longer_unwind performance by reordering current, baseline

### DIFF
--- a/src/lints/function_abi_no_longer_unwind.ron
+++ b/src/lints/function_abi_no_longer_unwind.ron
@@ -7,19 +7,6 @@ SemverQuery(
     query: r#"
     {
         CrateDiff {
-            baseline {
-                item {
-                    ... on Function {
-                        visibility_limit @filter(op: "=", value: ["$public"])
-
-                        abi_: abi {
-                            name @tag
-                            raw_name @output
-                            unwind @filter(op: "=", value: ["$true"])
-                        }
-                    }
-                }
-            }
             current {
                 item {
                     ... on Function {
@@ -28,7 +15,7 @@ SemverQuery(
                         name @output
 
                         new_abi_: abi {
-                            name @filter(op: "=", value: ["%name"])
+                            name @tag
                             raw_name @output
                             unwind @filter(op: "!=", value: ["$true"])
                         }
@@ -36,6 +23,19 @@ SemverQuery(
                         span_: span @optional {
                             filename @output
                             begin_line @output
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on Function {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        abi_: abi {
+                            name @filter(op: "=", value: ["%name"])
+                            raw_name @output
+                            unwind @filter(op: "=", value: ["$true"])
                         }
                     }
                 }


### PR DESCRIPTION
Partially addresses #767

Comparing 0.29.1 to 0.30.0, it seems likely the largest performance issue is due to a new lint introduced in 0.30.0, `function_abi_no_longer_unwind`, which took 5 hours on my machine to check the aws ec2 crate using the command from the issue report. I ran every c-s-c release from 0.25.0 to 0.28.0 as well and did not see any other performance issues.

```text
     Parsing aws-sdk-ec2 v1.41.0 (current)
      Parsed [ 128.600s] (current)
     Parsing aws-sdk-ec2 v1.41.0 (baseline)
      Parsed [  87.512s] (baseline)
    Checking aws-sdk-ec2 v1.41.0 -> v1.41.0 (assume minor change)
    Starting 61 checks, 6 unnecessary on 4 threads
...
        PASS [17804.320s]       major        function_abi_no_longer_unwind
...
     Checked [17812.879s] 61 checks; 61 passed, 6 unnecessary
    Finished [18041.203s] aws-sdk-ec2
```

I am not very knowledgeable about ABI's but if I understood things correctly from a cursory investigation, the default "Rust" ABI (i.e. the most common kind) is considered unwind-able. After [reordering](https://github.com/obi1kenobi/cargo-semver-checks/pull/666#discussion_r1493542698) the current and baseline branches of the query to look for non-unwind-able functions first, the `function_abi_no_longer_unwind` lint runs in under a second:

```text
     Parsing aws-sdk-ec2 v1.41.0 (current)
             Features: behavior-version-latest,default,rt-tokio,rustls,test-util
      Parsed [ 144.442s] (current)
     Parsing aws-sdk-ec2 v1.41.0 (baseline)
             Features: behavior-version-latest,default,rt-tokio,rustls,test-util
      Parsed [ 102.323s] (baseline)
    Checking aws-sdk-ec2 v1.41.0 -> v1.41.0 (assume minor change)
    Starting 67 checks, 6 unnecessary on 4 threads
...
        PASS [   0.605s]       major        function_abi_no_longer_unwind
...
     Checked [  21.817s] 67 checks; 67 passed, 6 unnecessary
    Finished [ 285.853s] aws-sdk-ec2
```
