### PR TITLE
Added lint trait_associated_const_now_doc_hidden

### DIFF
--- a/src/lints/trait_associated_const_now_doc_hidden.ron
+++ b/src/lints/trait_associated_const_now_doc_hidden.ron
@@ -1,0 +1,57 @@
+SemverQuery(
+    id: "trait_associated_const_now_doc_hidden",
+    human_readable_name: "trait associated const is now #[doc(hidden)]",
+    description: "A public trait associated const is now marked as #[doc(hidden)] and has thus been removed from the public API",
+    required_update: Major,
+    reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Trait {
+                        trait_name: name @output
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        associated_constant {
+                            associated_constant: name @output @tag
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        associated_constant {
+                            public_api_eligible @filter(op: "!=", value: ["$true"])
+                            name @filter(op: "=", value: ["%associated_constant"])
+                            span_: span @optional {
+                                filename @output
+                                begin_line @output
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true
+    },
+    error_message: "A const in a pub trait is now #[doc(hidden)], which removes it from the crate's public API",
+    per_result_error_template: Some("associated constant {{trait_name}}::{{associated_constant}} in {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -530,6 +530,7 @@ add_lints!(
     struct_pub_field_now_doc_hidden,
     struct_repr_transparent_removed,
     struct_with_pub_fields_changed_type,
+    trait_associated_const_now_doc_hidden,
     trait_associated_type_now_doc_hidden,
     trait_method_missing,
     trait_method_now_doc_hidden,

--- a/test_crates/trait_associated_const_now_doc_hidden/new/Cargo.toml
+++ b/test_crates/trait_associated_const_now_doc_hidden/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_associated_const_now_doc_hidden"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_associated_const_now_doc_hidden/new/src/lib.rs
+++ b/test_crates/trait_associated_const_now_doc_hidden/new/src/lib.rs
@@ -1,0 +1,38 @@
+// Basic test case
+pub trait PubTraitA {
+    #[doc(hidden)]
+    const CONST_A: u8 = 0;
+    // Should not flag already #[doc(hidden)] const
+    #[doc(hidden)]
+    const DOC_HIDDEN_CONST_A: u8 = 0;
+}
+
+// Trait is private so it should not trigger the lint
+trait TraitA {
+    #[doc(hidden)]
+    const CONST_B: u8 = 0;
+}
+
+// Trait is #[doc(hidden)] along with the const, only trait_now_doc_hidden should be triggered
+#[doc(hidden)]
+pub trait PubTraitB {
+    #[doc(hidden)]
+    const CONST_C: u8 = 0;
+}
+
+// Test cases when trait is #[doc(hidden)]
+#[doc(hidden)]
+pub trait DocHiddenTrait {
+    #[doc(hidden)]
+    const CONST_D: u8 = 0;
+    #[doc(hidden)]
+    const DOC_HIDDEN_CONST_B: u8 = 0;
+}
+
+// Test cases when #[doc(hidden)] from trait is removed
+pub trait PubTraitC {
+    #[doc(hidden)]
+    const CONST_E: u8 = 0;
+    #[doc(hidden)]
+    const DOC_HIDDEN_CONST_C: u8 = 0;
+}

--- a/test_crates/trait_associated_const_now_doc_hidden/old/Cargo.toml
+++ b/test_crates/trait_associated_const_now_doc_hidden/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_associated_const_now_doc_hidden"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_associated_const_now_doc_hidden/old/src/lib.rs
+++ b/test_crates/trait_associated_const_now_doc_hidden/old/src/lib.rs
@@ -1,0 +1,33 @@
+// Basic test case
+pub trait PubTraitA {
+    const CONST_A: u8 = 0;
+    // Should not flag already #[doc(hidden)] const
+    #[doc(hidden)]
+    const DOC_HIDDEN_CONST_A: u8 = 0;
+}
+
+// Trait is private so it should not trigger the lint
+trait TraitA {
+    const CONST_B: u8 = 0;
+}
+
+// Trait is #[doc(hidden)] along with the const, only trait_now_doc_hidden should be triggered
+pub trait PubTraitB {
+    const CONST_C: u8 = 0;
+}
+
+// Test cases when trait is #[doc(hidden)]
+#[doc(hidden)]
+pub trait DocHiddenTrait {
+    const CONST_D: u8 = 0;
+    #[doc(hidden)]
+    const DOC_HIDDEN_CONST_B: u8 = 0;
+}
+
+// Test cases when #[doc(hidden)] from trait is removed
+#[doc(hidden)]
+pub trait PubTraitC {
+    const CONST_E: u8 = 0;
+    #[doc(hidden)]
+    const DOC_HIDDEN_CONST_C: u8 = 0;
+}

--- a/test_outputs/trait_associated_const_now_doc_hidden.output.ron
+++ b/test_outputs/trait_associated_const_now_doc_hidden.output.ron
@@ -1,0 +1,14 @@
+{
+    "./test_crates/trait_associated_const_now_doc_hidden/": [
+        {
+            "associated_constant": String("CONST_A"),
+            "path": List([
+                String("trait_associated_const_now_doc_hidden"),
+                String("PubTraitA"),
+            ]),
+            "span_begin_line": Uint64(4),
+            "span_filename": String("src/lib.rs"),
+            "trait_name": String("PubTraitA"),
+        },
+    ]
+}

--- a/test_outputs/trait_now_doc_hidden.output.ron
+++ b/test_outputs/trait_now_doc_hidden.output.ron
@@ -1,4 +1,15 @@
 {
+    "./test_crates/trait_associated_const_now_doc_hidden/": [
+        {
+            "path": List([
+                String("trait_associated_const_now_doc_hidden"),
+                String("PubTraitB"),
+            ]),
+            "span_begin_line": Uint64(18),
+            "span_filename": String("src/lib.rs"),
+            "trait_name": String("PubTraitB"),
+        },
+    ],
     "./test_crates/trait_associated_type_now_doc_hidden/": [
         {
             "path": List([


### PR DESCRIPTION
Lint for when an associated const in a public trait is now marked as #[doc(hidden)]

Issue mentioned in https://github.com/obi1kenobi/cargo-semver-checks/issues/578