### PR TITLE
fix: #735

### DIFF
--- a/src/lints/auto_trait_impl_removed.ron
+++ b/src/lints/auto_trait_impl_removed.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "auto_trait_impl_removed",
     human_readable_name: "auto trait no longer implemented",
     description: "A type has stopped implementing one or more auto traits.",
     required_update: Major,

--- a/src/lints/constructible_struct_adds_field.ron
+++ b/src/lints/constructible_struct_adds_field.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "constructible_struct_adds_field",
     human_readable_name: "externally-constructible struct adds field",
     description: "A struct constructible with a struct literal added a new pub field.",
     required_update: Major,

--- a/src/lints/constructible_struct_adds_private_field.ron
+++ b/src/lints/constructible_struct_adds_private_field.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "constructible_struct_adds_private_field",
     human_readable_name: "struct no longer constructible due to new private field",
     description: "A struct is no longer constructible with a struct literal due to a new private field.",
     required_update: Major,

--- a/src/lints/constructible_struct_changed_type.ron
+++ b/src/lints/constructible_struct_changed_type.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "constructible_struct_changed_type",
     human_readable_name: "struct constructible with literal became an enum or union",
     description: "A struct was converted into an enum or union, breaking struct literals.",
     required_update: Major,

--- a/src/lints/derive_trait_impl_removed.ron
+++ b/src/lints/derive_trait_impl_removed.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "derive_trait_impl_removed",
     human_readable_name: "built-in derived trait no longer implemented",
     description: "A type has stopped implementing a built-in trait that used to be derived.",
     required_update: Major,

--- a/src/lints/enum_marked_non_exhaustive.ron
+++ b/src/lints/enum_marked_non_exhaustive.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "enum_marked_non_exhaustive",
     human_readable_name: "enum marked #[non_exhaustive]",
     description: "An exhaustive enum has been marked #[non_exhaustive].",
     reference: Some("An exhaustive enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile."),

--- a/src/lints/enum_missing.ron
+++ b/src/lints/enum_missing.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "enum_missing",
     human_readable_name: "pub enum removed or renamed",
     description: "An enum can no longer be imported by its prior path.",
     required_update: Major,

--- a/src/lints/enum_must_use_added.ron
+++ b/src/lints/enum_must_use_added.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "enum_must_use_added",
     human_readable_name: "enum #[must_use] added",
     description: "An enum has been marked with #[must_use].",
     required_update: Minor,

--- a/src/lints/enum_now_doc_hidden.ron
+++ b/src/lints/enum_now_doc_hidden.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "enum_now_doc_hidden",
     human_readable_name: "pub enum is now #[doc(hidden)]",
     description: "A pub enum is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,

--- a/src/lints/enum_repr_int_changed.ron
+++ b/src/lints/enum_repr_int_changed.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "enum_repr_int_changed",
     human_readable_name: "enum repr(u*)/repr(i*) changed",
     description: "An enum's repr attribute changed integer types.",
     reference: Some("The repr(u*) or repr(i*) attribute on an enum was changed to another integer type. This can cause its memory representation to change, breaking FFI use cases."),

--- a/src/lints/enum_repr_int_removed.ron
+++ b/src/lints/enum_repr_int_removed.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "enum_repr_int_removed",
     human_readable_name: "enum repr(u*)/repr(i*) removed",
     description: "An enum's repr attribute was removed.",
     reference: Some("The repr(u*) or repr(i*) attribute was removed from an enum. This can cause its memory representation to change, breaking FFI use cases."),

--- a/src/lints/enum_repr_transparent_removed.ron
+++ b/src/lints/enum_repr_transparent_removed.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "enum_repr_transparent_removed",
     human_readable_name: "enum repr(transparent) removed",
     description: "A enum is no longer repr(transparent).",
     reference: Some(r#"

--- a/src/lints/enum_struct_variant_field_added.ron
+++ b/src/lints/enum_struct_variant_field_added.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "enum_struct_variant_field_added",
     human_readable_name: "pub enum struct variant field added",
     description: "An enum's exhaustive struct variant has a new field.",
     required_update: Major,

--- a/src/lints/enum_struct_variant_field_missing.ron
+++ b/src/lints/enum_struct_variant_field_missing.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "enum_struct_variant_field_missing",
     human_readable_name: "pub enum struct variant's field removed or renamed" ,
     description: "An enum's struct variant has a field that is no longer available under its prior name.",
     required_update: Major,

--- a/src/lints/enum_struct_variant_field_now_doc_hidden.ron
+++ b/src/lints/enum_struct_variant_field_now_doc_hidden.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "enum_struct_variant_field_now_doc_hidden",
     human_readable_name: "pub enum struct variant's field is now #[doc(hidden)]",
     description: "An enum's struct variant has a field that is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,

--- a/src/lints/enum_tuple_variant_field_added.ron
+++ b/src/lints/enum_tuple_variant_field_added.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "enum_tuple_variant_field_added",
     human_readable_name: "pub enum tuple variant field added",
     description: "An enum's exhaustive tuple variant has a new field.",
     required_update: Major,

--- a/src/lints/enum_tuple_variant_field_missing.ron
+++ b/src/lints/enum_tuple_variant_field_missing.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "enum_tuple_variant_field_missing",
     human_readable_name: "pub enum tuple variant's field removed",
     description: "A field has been removed from an enum's tuple variant.",
     required_update: Major,

--- a/src/lints/enum_tuple_variant_field_now_doc_hidden.ron
+++ b/src/lints/enum_tuple_variant_field_now_doc_hidden.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "enum_tuple_variant_field_now_doc_hidden",
     human_readable_name: "pub enum tuple variant field is now #[doc(hidden)]",
     description: "A pub enum tuple variant field is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,

--- a/src/lints/enum_variant_added.ron
+++ b/src/lints/enum_variant_added.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "enum_variant_added",
     human_readable_name: "enum variant added on exhaustive enum",
     description: "An exhaustive enum has a new variant.",
     required_update: Major,

--- a/src/lints/enum_variant_missing.ron
+++ b/src/lints/enum_variant_missing.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "enum_variant_missing",
     human_readable_name: "pub enum variant removed or renamed",
     description: "An enum variant is no longer available under its prior name.",
     required_update: Major,

--- a/src/lints/exported_function_changed_abi.ron
+++ b/src/lints/exported_function_changed_abi.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "exported_function_changed_abi",
     human_readable_name: "exported function changed ABI",
     description: "A function marked `#[no_mangle]` or assigned an explicit `#[export_name]` changed its external ABI.",
     required_update: Major,

--- a/src/lints/function_abi_no_longer_unwind.ron
+++ b/src/lints/function_abi_no_longer_unwind.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "function_abi_no_longer_unwind",
     human_readable_name: "function abi no longer unwind",
     description: "A pub fn changed from an unwind-capable ABI to the same-named ABI without unwind. If that function causes an unwind (e.g. by panicking), its behavior is now undefined.",
     required_update: Major,

--- a/src/lints/function_changed_abi.ron
+++ b/src/lints/function_changed_abi.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "function_changed_abi",
     human_readable_name: "pub function changed ABI",
     description: "A public function changed its external ABI.",
     required_update: Major,

--- a/src/lints/function_const_removed.ron
+++ b/src/lints/function_const_removed.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "function_const_removed",
     human_readable_name: "pub fn is no longer const",
     description: "A function can no longer be called in a const context.",
     required_update: Major,

--- a/src/lints/function_export_name_changed.ron
+++ b/src/lints/function_export_name_changed.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "function_export_name_changed",
     human_readable_name: "function's export name has changed or been removed",
     description: "A function's ABI name with #[no_mangle] or #[export_name = \"name\"] has changed or been removed",
     required_update: Major,

--- a/src/lints/function_missing.ron
+++ b/src/lints/function_missing.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "function_missing",
     human_readable_name: "pub fn removed or renamed",
     description: "A function can no longer be imported by its prior path.",
     required_update: Major,

--- a/src/lints/function_must_use_added.ron
+++ b/src/lints/function_must_use_added.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "function_must_use_added",
     human_readable_name: "function #[must_use] added",
     description: "A function has been marked with #[must_use].",
     required_update: Minor,

--- a/src/lints/function_now_doc_hidden.ron
+++ b/src/lints/function_now_doc_hidden.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "function_now_doc_hidden",
     human_readable_name: "pub function is now #[doc(hidden)]",
     description: "A pub function is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,

--- a/src/lints/function_parameter_count_changed.ron
+++ b/src/lints/function_parameter_count_changed.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "function_parameter_count_changed",
     human_readable_name: "pub fn parameter count changed",
     description: "Parameter count of a function has changed.",
     required_update: Major,

--- a/src/lints/function_unsafe_added.ron
+++ b/src/lints/function_unsafe_added.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "function_unsafe_added",
     human_readable_name: "pub fn became unsafe",
     description: "A function became unsafe to call.",
     required_update: Major,

--- a/src/lints/inherent_associated_pub_const_missing.ron
+++ b/src/lints/inherent_associated_pub_const_missing.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "inherent_associated_pub_const_missing",
     human_readable_name: "inherent impl's associated pub const removed",
     description: "An inherent impl's associated public const removed or renamed",
     required_update: Major,

--- a/src/lints/inherent_method_const_removed.ron
+++ b/src/lints/inherent_method_const_removed.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "inherent_method_const_removed",
     human_readable_name: "pub method is no longer const",
     description: "A method or associated fn can no longer be called in a const context.",
     required_update: Major,

--- a/src/lints/inherent_method_missing.ron
+++ b/src/lints/inherent_method_missing.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "inherent_method_missing",
     human_readable_name: "pub method removed or renamed",
     description: "A method or associated fn is no longer available under its prior name.",
     required_update: Major,

--- a/src/lints/inherent_method_must_use_added.ron
+++ b/src/lints/inherent_method_must_use_added.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "inherent_method_must_use_added",
     human_readable_name: "inherent method #[must_use] added",
     description: "An inherent method or associated fn has been marked #[must_use].",
     required_update: Minor,

--- a/src/lints/inherent_method_unsafe_added.ron
+++ b/src/lints/inherent_method_unsafe_added.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "inherent_method_unsafe_added",
     human_readable_name: "pub method became unsafe",
     description: "A method or associated fn became unsafe to call.",
     required_update: Major,

--- a/src/lints/method_parameter_count_changed.ron
+++ b/src/lints/method_parameter_count_changed.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "method_parameter_count_changed",
     human_readable_name: "pub method parameter count changed",
     description: "Parameter count of a method has changed.",
     required_update: Major,

--- a/src/lints/module_missing.ron
+++ b/src/lints/module_missing.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "module_missing",
     human_readable_name: "pub module removed or renamed",
     description: "A module can no longer be imported by its prior path",
     required_update: Major,

--- a/src/lints/pub_module_level_const_missing.ron
+++ b/src/lints/pub_module_level_const_missing.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "pub_module_level_const_missing",
     human_readable_name: "pub module-level const is missing",
     description: "A pub const is missing, renamed, or changed to static.",
     required_update: Major,

--- a/src/lints/pub_module_level_const_now_doc_hidden.ron
+++ b/src/lints/pub_module_level_const_now_doc_hidden.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "pub_module_level_const_now_doc_hidden",
     human_readable_name: "pub module-level const is now #[doc(hidden)]",
     description: "A pub const is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,

--- a/src/lints/pub_static_missing.ron
+++ b/src/lints/pub_static_missing.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "pub_static_missing",
     human_readable_name: "pub static is missing",
     description: "A pub static is missing, renamed, or made private",
     required_update: Major,

--- a/src/lints/pub_static_mut_now_immutable.ron
+++ b/src/lints/pub_static_mut_now_immutable.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "pub_static_mut_now_immutable",
     human_readable_name: "pub static mut is now immutable",
     description: "A mutable static became immutable and thus can no longer be assigned to",
     required_update: Major,

--- a/src/lints/pub_static_now_doc_hidden.ron
+++ b/src/lints/pub_static_now_doc_hidden.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "pub_static_now_doc_hidden",
     human_readable_name: "pub static is now #[doc(hidden)]",
     description: "A pub static is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,

--- a/src/lints/repr_c_removed.ron
+++ b/src/lints/repr_c_removed.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "repr_c_removed",
     human_readable_name: "repr(C) removed",
     description: "A type that used to be repr(C) is no longer repr(C).",
     reference: Some("A type that used to be repr(C) is no longer repr(C). This can cause its memory layout to change, breaking FFI use cases."),

--- a/src/lints/repr_packed_added.ron
+++ b/src/lints/repr_packed_added.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "repr_packed_added",
     human_readable_name: "repr(packed) added",
     description: "A struct or union has been marked with #[repr(packed)].",
     required_update: Major,

--- a/src/lints/repr_packed_removed.ron
+++ b/src/lints/repr_packed_removed.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "repr_packed_removed",
     human_readable_name: "repr(packed) removed",
     description: "A struct or union that used to be #[repr(packed)] is no longer #[repr(packed)].",
     required_update: Major,

--- a/src/lints/sized_impl_removed.ron
+++ b/src/lints/sized_impl_removed.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "sized_impl_removed",
     human_readable_name: "Sized no longer implemented",
     description: "A type is no longer `Sized`.",
     required_update: Major,

--- a/src/lints/struct_marked_non_exhaustive.ron
+++ b/src/lints/struct_marked_non_exhaustive.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "struct_marked_non_exhaustive",
     human_readable_name: "struct marked #[non_exhaustive]",
     description: "An exhaustive struct has been marked #[non_exhaustive].",
     reference: Some("An exhaustive struct has been marked #[non_exhaustive] making it no longer constructible using a struct literal outside its crate."),

--- a/src/lints/struct_missing.ron
+++ b/src/lints/struct_missing.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "struct_missing",
     human_readable_name: "pub struct removed or renamed",
     description: "A struct can no longer be imported by its prior path.",
     required_update: Major,

--- a/src/lints/struct_must_use_added.ron
+++ b/src/lints/struct_must_use_added.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "struct_must_use_added",
     human_readable_name: "struct #[must_use] added",
     description: "A struct has been marked with #[must_use].",
     required_update: Minor,

--- a/src/lints/struct_now_doc_hidden.ron
+++ b/src/lints/struct_now_doc_hidden.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "struct_now_doc_hidden",
     human_readable_name: "pub struct is now #[doc(hidden)]",
     description: "A pub struct is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,

--- a/src/lints/struct_pub_field_missing.ron
+++ b/src/lints/struct_pub_field_missing.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "struct_pub_field_missing",
     human_readable_name: "pub struct's pub field removed or renamed",
     description: "A struct field is no longer available under its prior name.",
     required_update: Major,

--- a/src/lints/struct_pub_field_now_doc_hidden.ron
+++ b/src/lints/struct_pub_field_now_doc_hidden.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "struct_pub_field_now_doc_hidden",
     human_readable_name: "pub struct field is now #[doc(hidden)]",
     description: "A pub struct field is now marked #[doc(hidden)] and is no longer part of the public API.",
     required_update: Major,

--- a/src/lints/struct_repr_transparent_removed.ron
+++ b/src/lints/struct_repr_transparent_removed.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "struct_repr_transparent_removed",
     human_readable_name: "struct repr(transparent) removed",
     description: "A struct is no longer repr(transparent).",
     reference: Some(r#"

--- a/src/lints/struct_with_pub_fields_changed_type.ron
+++ b/src/lints/struct_with_pub_fields_changed_type.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "struct_with_pub_fields_changed_type",
     human_readable_name: "struct with pub fields became an enum or union",
     description: "A struct was converted into an enum or union, breaking accesses to its fields.",
     required_update: Major,

--- a/src/lints/trait_associated_const_now_doc_hidden.ron
+++ b/src/lints/trait_associated_const_now_doc_hidden.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "trait_associated_const_now_doc_hidden",
     human_readable_name: "trait associated const is now #[doc(hidden)]",
     description: "A public trait associated const is now marked as #[doc(hidden)] and has thus been removed from the public API",
     required_update: Major,

--- a/src/lints/trait_associated_type_now_doc_hidden.ron
+++ b/src/lints/trait_associated_type_now_doc_hidden.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "trait_associated_type_now_doc_hidden",
     human_readable_name: "trait associated type is now #[doc(hidden)]",
     description: "A public trait associated type is now marked as #[doc(hidden)] and has thus been removed from the public API",
     required_update: Major,

--- a/src/lints/trait_method_missing.ron
+++ b/src/lints/trait_method_missing.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "trait_method_missing",
     human_readable_name: "pub trait method removed or renamed",
     description: "A trait method can no longer be called by its prior path.",
     required_update: Major,

--- a/src/lints/trait_method_now_doc_hidden.ron
+++ b/src/lints/trait_method_now_doc_hidden.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "trait_method_now_doc_hidden",
     human_readable_name: "pub trait method is now #[doc(hidden)]",
     description: "A public trait method is now marked as #[doc(hidden)] and has thus been removed from the public API",
     required_update: Major,

--- a/src/lints/trait_method_unsafe_added.ron
+++ b/src/lints/trait_method_unsafe_added.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "trait_method_unsafe_added",
     human_readable_name: "pub trait method became unsafe",
     description: "A method in a public trait became unsafe",
     required_update: Major,

--- a/src/lints/trait_method_unsafe_removed.ron
+++ b/src/lints/trait_method_unsafe_removed.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "trait_method_unsafe_removed",
     human_readable_name: "pub trait method became safe",
     description: "A method in a public trait became safe",
     required_update: Major,

--- a/src/lints/trait_missing.ron
+++ b/src/lints/trait_missing.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "trait_missing",
     human_readable_name: "pub trait removed or renamed",
     description: "A trait can no longer be imported by its prior path.",
     required_update: Major,

--- a/src/lints/trait_must_use_added.ron
+++ b/src/lints/trait_must_use_added.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "trait_must_use_added",
     human_readable_name: "trait #[must_use] added",
     description: "A trait has been marked with #[must_use].",
     required_update: Minor,

--- a/src/lints/trait_no_longer_object_safe.ron
+++ b/src/lints/trait_no_longer_object_safe.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "trait_no_longer_object_safe",
     human_readable_name: "trait no longer object safe",
     description: "A trait is no longer object safe, meaning it can no longer be used as `dyn Trait`.",
     required_update: Major,

--- a/src/lints/trait_now_doc_hidden.ron
+++ b/src/lints/trait_now_doc_hidden.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "trait_now_doc_hidden",
     human_readable_name: "pub trait is now #[doc(hidden)]",
     description: "A pub trait is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,

--- a/src/lints/trait_removed_associated_constant.ron
+++ b/src/lints/trait_removed_associated_constant.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "trait_removed_associated_constant",
     human_readable_name: "trait's associated constant was removed",
     description: "A trait's associated constant was removed or renamed",
     required_update: Major,

--- a/src/lints/trait_removed_associated_type.ron
+++ b/src/lints/trait_removed_associated_type.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "trait_removed_associated_type",
     human_readable_name: "trait's associated type was removed",
     description: "A trait's associated type was removed or renamed.",
     required_update: Major,

--- a/src/lints/trait_removed_supertrait.ron
+++ b/src/lints/trait_removed_supertrait.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "trait_removed_supertrait",
     human_readable_name: "supertrait removed or renamed",
     description: "Removing a supertrait bound is a breaking change, since users of the trait can no longer assume it can also be used like its supertrait.",
     required_update: Major,

--- a/src/lints/trait_unsafe_added.ron
+++ b/src/lints/trait_unsafe_added.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "trait_unsafe_added",
     human_readable_name: "pub trait became unsafe",
     description: "A public trait became unsafe.",
     required_update: Major,

--- a/src/lints/trait_unsafe_removed.ron
+++ b/src/lints/trait_unsafe_removed.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "trait_unsafe_removed",
     human_readable_name: "pub unsafe trait became safe",
     description: "A public unsafe trait became safe.",
     required_update: Major,

--- a/src/lints/tuple_struct_to_plain_struct.ron
+++ b/src/lints/tuple_struct_to_plain_struct.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "tuple_struct_to_plain_struct",
     human_readable_name: "tuple struct changed to plain struct",
     description: "A struct changed from a tuple struct to plain struct",
     reference: Some(r#"

--- a/src/lints/type_marked_deprecated.ron
+++ b/src/lints/type_marked_deprecated.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "type_marked_deprecated",
     human_readable_name: "#[deprecated] added on type",
     description: "A type has been newly marked with #[deprecated].",
     required_update: Minor,

--- a/src/lints/union_field_missing.ron
+++ b/src/lints/union_field_missing.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "union_field_missing",
     human_readable_name: "pub union pub field is removed or renamed",
     description: "pub union pub field is removed or renamed. No longer present under it's previous name, by whatever cause.",
     required_update: Major, 

--- a/src/lints/union_missing.ron
+++ b/src/lints/union_missing.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "union_missing",
     human_readable_name: "pub union removed or renamed",
     description: "A union can no longer be imported by its prior path.",
     required_update: Major,

--- a/src/lints/union_now_doc_hidden.ron
+++ b/src/lints/union_now_doc_hidden.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "union_now_doc_hidden",
     human_readable_name: "pub union is now #[doc(hidden)]",
     description: "A pub union is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,

--- a/src/lints/unit_struct_changed_kind.ron
+++ b/src/lints/unit_struct_changed_kind.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "unit_struct_changed_kind",
     human_readable_name: "unit struct changed kind",
     description: "A struct changed from a unit struct to a plain struct.",
     reference: Some("A public struct that was previously a unit struct is now a plain struct. The unit struct was not marked #[non_exhaustive], so it could be constructed outside of the defining crate. Plain structs cannot be constructed using the syntax allowed for unit structs, so this is a major breaking change for code that depends on it."),

--- a/src/lints/variant_marked_non_exhaustive.ron
+++ b/src/lints/variant_marked_non_exhaustive.ron
@@ -1,5 +1,4 @@
 SemverQuery(
-    id: "variant_marked_non_exhaustive",
     human_readable_name: "enum variant marked #[non_exhaustive]",
     description: "An exhaustive enum variant has been marked #[non_exhaustive].",
     reference: Some("An exhaustive enum variant has been marked #[non_exhaustive], preventing it from being constructed using a literal from outside its own crate."),


### PR DESCRIPTION
Remove id field from lint .ron's and set id based on file name passed to add_lints! macro instead.

Same idea as the original PR #739, just with the missing piece to set the id again.