### PR TITLE
refactoring to add lint levels on queries

### DIFF
--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -68,7 +68,7 @@ fn classify_semver_version_change(
 fn print_failed_lint(
     config: &mut GlobalConfig,
     semver_query: &SemverQuery,
-    results: &[BTreeMap<Arc<str>, FieldValue>],
+    results: Vec<BTreeMap<Arc<str>, FieldValue>>,
 ) -> anyhow::Result<()> {
     if let Some(ref_link) = semver_query.reference_link.as_deref() {
         config.log_info(|config| {
@@ -320,7 +320,7 @@ pub(super) fn run_check_release(
                 Ok(())
             })?;
 
-            print_failed_lint(config, semver_query, &results)?;
+            print_failed_lint(config, semver_query, results)?;
         }
 
         let required_bump = if required_versions.contains(&RequiredSemverUpdate::Major) {

--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -68,7 +68,7 @@ fn classify_semver_version_change(
 fn print_failed_lint(
     config: &mut GlobalConfig,
     semver_query: &SemverQuery,
-    results: Vec<BTreeMap<Arc<str>, FieldValue>>,
+    results: &[BTreeMap<Arc<str>, FieldValue>],
 ) -> anyhow::Result<()> {
     if let Some(ref_link) = semver_query.reference_link.as_deref() {
         config.log_info(|config| {
@@ -320,7 +320,7 @@ pub(super) fn run_check_release(
                 Ok(())
             })?;
 
-            print_failed_lint(config, semver_query, results)?;
+            print_failed_lint(config, semver_query, &results)?;
         }
 
         let required_bump = if required_versions.contains(&RequiredSemverUpdate::Major) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,6 +149,10 @@ impl GlobalConfig {
         self.shell_print("warning", message, Color::Ansi(AnsiColor::Yellow), false)
     }
 
+    pub fn shell_error(&mut self, message: impl std::fmt::Display) -> anyhow::Result<()> {
+        self.shell_print("error", message, Color::Ansi(AnsiColor::Red), false)
+    }
+
     /// Gets the color-supporting `stdout` that the crate will use.
     ///
     /// See [`GlobalConfig::set_stdout`] and [`GlobalConfig::set_out_color_choice`] to

--- a/src/lints/auto_trait_impl_removed.ron
+++ b/src/lints/auto_trait_impl_removed.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "auto trait no longer implemented",
     description: "A type has stopped implementing one or more auto traits.",
     required_update: Major,
+    lint_level: Deny,
     // TODO: Add a better reference link once the cargo semver reference has a section on auto traits.
     reference_link: Some("https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits"),
     query: r#"

--- a/src/lints/constructible_struct_adds_field.ron
+++ b/src/lints/constructible_struct_adds_field.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "externally-constructible struct adds field",
     description: "A struct constructible with a struct literal added a new pub field.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/reference/expressions/struct-expr.html"),
     query: r#"
     {

--- a/src/lints/constructible_struct_adds_private_field.ron
+++ b/src/lints/constructible_struct_adds_private_field.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "struct no longer constructible due to new private field",
     description: "A struct is no longer constructible with a struct literal due to a new private field.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/reference/expressions/struct-expr.html"),
     query: r#"
     {

--- a/src/lints/constructible_struct_changed_type.ron
+++ b/src/lints/constructible_struct_changed_type.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "struct constructible with literal became an enum or union",
     description: "A struct was converted into an enum or union, breaking struct literals.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://github.com/obi1kenobi/cargo-semver-checks/issues/297#issuecomment-1399099659"),
     reference: Some(
         r#"\

--- a/src/lints/derive_trait_impl_removed.ron
+++ b/src/lints/derive_trait_impl_removed.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "built-in derived trait no longer implemented",
     description: "A type has stopped implementing a built-in trait that used to be derived.",
     required_update: Major,
+    lint_level: Deny,
     // TODO: Find a better reference than the definition of #[derive(...)].
     //       The cargo semver reference doesn't say that no longer deriving a pub trait is breaking.
     reference_link: Some("https://doc.rust-lang.org/reference/attributes/derive.html#derive"),

--- a/src/lints/enum_marked_non_exhaustive.ron
+++ b/src/lints/enum_marked_non_exhaustive.ron
@@ -4,6 +4,7 @@ SemverQuery(
     description: "An exhaustive enum has been marked #[non_exhaustive].",
     reference: Some("An exhaustive enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile."),
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive"),
     query: r#"
     {

--- a/src/lints/enum_missing.ron
+++ b/src/lints/enum_missing.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub enum removed or renamed",
     description: "An enum can no longer be imported by its prior path.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/enum_must_use_added.ron
+++ b/src/lints/enum_must_use_added.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "enum #[must_use] added",
     description: "An enum has been marked with #[must_use].",
     required_update: Minor,
+    lint_level: Deny,
 
     // TODO: Change the reference link to point to the cargo semver reference
     //       once it has a section on attribute #[must_use].

--- a/src/lints/enum_now_doc_hidden.ron
+++ b/src/lints/enum_now_doc_hidden.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub enum is now #[doc(hidden)]",
     description: "A pub enum is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
     query: r#"
     {

--- a/src/lints/enum_repr_int_changed.ron
+++ b/src/lints/enum_repr_int_changed.ron
@@ -4,6 +4,7 @@ SemverQuery(
     description: "An enum's repr attribute changed integer types.",
     reference: Some("The repr(u*) or repr(i*) attribute on an enum was changed to another integer type. This can cause its memory representation to change, breaking FFI use cases."),
     required_update: Major,
+    lint_level: Deny,
 
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#repr-int-enum-change"),
     query: r#"

--- a/src/lints/enum_repr_int_removed.ron
+++ b/src/lints/enum_repr_int_removed.ron
@@ -4,6 +4,7 @@ SemverQuery(
     description: "An enum's repr attribute was removed.",
     reference: Some("The repr(u*) or repr(i*) attribute was removed from an enum. This can cause its memory representation to change, breaking FFI use cases."),
     required_update: Major,
+    lint_level: Deny,
 
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#repr-int-enum-remove"),
     query: r#"

--- a/src/lints/enum_repr_transparent_removed.ron
+++ b/src/lints/enum_repr_transparent_removed.ron
@@ -23,6 +23,7 @@ To avoid false-positives, this query is restricted to checking only enums that i
 - which has at most one non-PhantomData field
 "#),
     required_update: Major,
+    lint_level: Deny,
 
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#repr-transparent-remove"),
     query: r#"

--- a/src/lints/enum_struct_variant_field_added.ron
+++ b/src/lints/enum_struct_variant_field_added.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub enum struct variant field added",
     description: "An enum's exhaustive struct variant has a new field.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute"),
     query: r#"
     {

--- a/src/lints/enum_struct_variant_field_missing.ron
+++ b/src/lints/enum_struct_variant_field_missing.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub enum struct variant's field removed or renamed" ,
     description: "An enum's struct variant has a field that is no longer available under its prior name.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/enum_struct_variant_field_now_doc_hidden.ron
+++ b/src/lints/enum_struct_variant_field_now_doc_hidden.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub enum struct variant's field is now #[doc(hidden)]",
     description: "An enum's struct variant has a field that is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
     query: r#"
     {

--- a/src/lints/enum_tuple_variant_field_added.ron
+++ b/src/lints/enum_tuple_variant_field_added.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub enum tuple variant field added",
     description: "An enum's exhaustive tuple variant has a new field.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute"),
     query: r#"
     {

--- a/src/lints/enum_tuple_variant_field_missing.ron
+++ b/src/lints/enum_tuple_variant_field_missing.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub enum tuple variant's field removed",
     description: "A field has been removed from an enum's tuple variant.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/enum_tuple_variant_field_now_doc_hidden.ron
+++ b/src/lints/enum_tuple_variant_field_now_doc_hidden.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub enum tuple variant field is now #[doc(hidden)]",
     description: "A pub enum tuple variant field is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
     query: r#"
     {

--- a/src/lints/enum_variant_added.ron
+++ b/src/lints/enum_variant_added.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "enum variant added on exhaustive enum",
     description: "An exhaustive enum has a new variant.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new"),
     query: r#"
     {

--- a/src/lints/enum_variant_missing.ron
+++ b/src/lints/enum_variant_missing.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub enum variant removed or renamed",
     description: "An enum variant is no longer available under its prior name.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/exported_function_changed_abi.ron
+++ b/src/lints/exported_function_changed_abi.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "exported function changed ABI",
     description: "A function marked `#[no_mangle]` or assigned an explicit `#[export_name]` changed its external ABI.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/reference/items/external-blocks.html#abi"),
     query: r#"{
     CrateDiff {

--- a/src/lints/function_abi_no_longer_unwind.ron
+++ b/src/lints/function_abi_no_longer_unwind.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "function abi no longer unwind",
     description: "A pub fn changed from an unwind-capable ABI to the same-named ABI without unwind. If that function causes an unwind (e.g. by panicking), its behavior is now undefined.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://rust-lang.github.io/rfcs/2945-c-unwind-abi.html"),
     query: r#"
     {

--- a/src/lints/function_changed_abi.ron
+++ b/src/lints/function_changed_abi.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub function changed ABI",
     description: "A public function changed its external ABI.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/reference/items/external-blocks.html#abi"),
     query: r#"
     {

--- a/src/lints/function_const_removed.ron
+++ b/src/lints/function_const_removed.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub fn is no longer const",
     description: "A function can no longer be called in a const context.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/reference/const_eval.html"),
     query: r#"
     {

--- a/src/lints/function_export_name_changed.ron
+++ b/src/lints/function_export_name_changed.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "function's export name has changed or been removed",
     description: "A function's ABI name with #[no_mangle] or #[export_name = \"name\"] has changed or been removed",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/reference/abi.html#the-no_mangle-attribute"),
     query: r#"
     {

--- a/src/lints/function_missing.ron
+++ b/src/lints/function_missing.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub fn removed or renamed",
     description: "A function can no longer be imported by its prior path.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/function_must_use_added.ron
+++ b/src/lints/function_must_use_added.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "function #[must_use] added",
     description: "A function has been marked with #[must_use].",
     required_update: Minor,
+    lint_level: Deny,
 
     // TODO: Change the reference link to point to the cargo semver reference
     //       once it has a section on attribute #[must_use].

--- a/src/lints/function_now_doc_hidden.ron
+++ b/src/lints/function_now_doc_hidden.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub function is now #[doc(hidden)]",
     description: "A pub function is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
     query: r#"
     {

--- a/src/lints/function_parameter_count_changed.ron
+++ b/src/lints/function_parameter_count_changed.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub fn parameter count changed",
     description: "Parameter count of a function has changed.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity"),
     query: r#"
     {

--- a/src/lints/function_unsafe_added.ron
+++ b/src/lints/function_unsafe_added.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub fn became unsafe",
     description: "A function became unsafe to call.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#calling-an-unsafe-function-or-method"),
     query: r#"
     {

--- a/src/lints/inherent_associated_pub_const_missing.ron
+++ b/src/lints/inherent_associated_pub_const_missing.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "inherent impl's associated pub const removed",
     description: "An inherent impl's associated public const removed or renamed",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/inherent_method_const_removed.ron
+++ b/src/lints/inherent_method_const_removed.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub method is no longer const",
     description: "A method or associated fn can no longer be called in a const context.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/reference/const_eval.html"),
     query: r#"
     {

--- a/src/lints/inherent_method_missing.ron
+++ b/src/lints/inherent_method_missing.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub method removed or renamed",
     description: "A method or associated fn is no longer available under its prior name.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/inherent_method_must_use_added.ron
+++ b/src/lints/inherent_method_must_use_added.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "inherent method #[must_use] added",
     description: "An inherent method or associated fn has been marked #[must_use].",
     required_update: Minor,
+    lint_level: Deny,
 
     // TODO: Change the reference link to point to the cargo semver reference
     //       once it has a section on attribute #[must_use].

--- a/src/lints/inherent_method_unsafe_added.ron
+++ b/src/lints/inherent_method_unsafe_added.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub method became unsafe",
     description: "A method or associated fn became unsafe to call.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#calling-an-unsafe-function-or-method"),
     query: r#"
     {

--- a/src/lints/method_parameter_count_changed.ron
+++ b/src/lints/method_parameter_count_changed.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub method parameter count changed",
     description: "Parameter count of a method has changed.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity"),
     query: r#"
     {

--- a/src/lints/module_missing.ron
+++ b/src/lints/module_missing.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub module removed or renamed",
     description: "A module can no longer be imported by its prior path",
     required_update: Major,
+    lint_level: Deny,
     reference_link:  Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/pub_module_level_const_missing.ron
+++ b/src/lints/pub_module_level_const_missing.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub module-level const is missing",
     description: "A pub const is missing, renamed, or changed to static.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/pub_module_level_const_now_doc_hidden.ron
+++ b/src/lints/pub_module_level_const_now_doc_hidden.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub module-level const is now #[doc(hidden)]",
     description: "A pub const is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
     query: r#"
     {

--- a/src/lints/pub_static_missing.ron
+++ b/src/lints/pub_static_missing.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub static is missing",
     description: "A pub static is missing, renamed, or made private",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/pub_static_mut_now_immutable.ron
+++ b/src/lints/pub_static_mut_now_immutable.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub static mut is now immutable",
     description: "A mutable static became immutable and thus can no longer be assigned to",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/reference/items/static-items.html"),
     query: r#"
     {

--- a/src/lints/pub_static_now_doc_hidden.ron
+++ b/src/lints/pub_static_now_doc_hidden.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub static is now #[doc(hidden)]",
     description: "A pub static is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
     query: r#"
     {

--- a/src/lints/repr_c_removed.ron
+++ b/src/lints/repr_c_removed.ron
@@ -4,6 +4,7 @@ SemverQuery(
     description: "A type that used to be repr(C) is no longer repr(C).",
     reference: Some("A type that used to be repr(C) is no longer repr(C). This can cause its memory layout to change, breaking FFI use cases."),
     required_update: Major,
+    lint_level: Deny,
 
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#repr-c-remove"),
     query: r#"

--- a/src/lints/repr_packed_added.ron
+++ b/src/lints/repr_packed_added.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "repr(packed) added",
     description: "A struct or union has been marked with #[repr(packed)].",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#repr-packed-add"),
     query: r#"
     {

--- a/src/lints/repr_packed_removed.ron
+++ b/src/lints/repr_packed_removed.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "repr(packed) removed",
     description: "A struct or union that used to be #[repr(packed)] is no longer #[repr(packed)].",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#repr-packed-remove"),
     query: r#"
     {

--- a/src/lints/sized_impl_removed.ron
+++ b/src/lints/sized_impl_removed.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "Sized no longer implemented",
     description: "A type is no longer `Sized`.",
     required_update: Major,
+    lint_level: Deny,
     // TODO: Add a better reference link once the cargo semver reference has a section on Sized.
     reference_link: Some("https://doc.rust-lang.org/reference/special-types-and-traits.html#sized"),
     query: r#"

--- a/src/lints/struct_marked_non_exhaustive.ron
+++ b/src/lints/struct_marked_non_exhaustive.ron
@@ -4,6 +4,7 @@ SemverQuery(
     description: "An exhaustive struct has been marked #[non_exhaustive].",
     reference: Some("An exhaustive struct has been marked #[non_exhaustive] making it no longer constructible using a struct literal outside its crate."),
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive"),
     query: r#"
     {

--- a/src/lints/struct_missing.ron
+++ b/src/lints/struct_missing.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub struct removed or renamed",
     description: "A struct can no longer be imported by its prior path.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/struct_must_use_added.ron
+++ b/src/lints/struct_must_use_added.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "struct #[must_use] added",
     description: "A struct has been marked with #[must_use].",
     required_update: Minor,
+    lint_level: Deny,
 
     // TODO: Change the reference link to point to the cargo semver reference
     //       once it has a section on attribute #[must_use].

--- a/src/lints/struct_now_doc_hidden.ron
+++ b/src/lints/struct_now_doc_hidden.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub struct is now #[doc(hidden)]",
     description: "A pub struct is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
     query: r#"
     {

--- a/src/lints/struct_pub_field_missing.ron
+++ b/src/lints/struct_pub_field_missing.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub struct's pub field removed or renamed",
     description: "A struct field is no longer available under its prior name.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/struct_pub_field_now_doc_hidden.ron
+++ b/src/lints/struct_pub_field_now_doc_hidden.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub struct field is now #[doc(hidden)]",
     description: "A pub struct field is now marked #[doc(hidden)] and is no longer part of the public API.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
     query: r#"
     {

--- a/src/lints/struct_repr_transparent_removed.ron
+++ b/src/lints/struct_repr_transparent_removed.ron
@@ -26,6 +26,7 @@ To avoid false-positives, this query is restricted to checking only structs that
 - that one field is public.
 "#),
     required_update: Major,
+    lint_level: Deny,
 
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#repr-transparent-remove"),
     query: r#"

--- a/src/lints/struct_with_pub_fields_changed_type.ron
+++ b/src/lints/struct_with_pub_fields_changed_type.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "struct with pub fields became an enum or union",
     description: "A struct was converted into an enum or union, breaking accesses to its fields.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://github.com/obi1kenobi/cargo-semver-checks/issues/297#issuecomment-1399099659"),
     reference: Some(
         r#"\

--- a/src/lints/trait_associated_const_now_doc_hidden.ron
+++ b/src/lints/trait_associated_const_now_doc_hidden.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "trait associated const is now #[doc(hidden)]",
     description: "A public trait associated const is now marked as #[doc(hidden)] and has thus been removed from the public API",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
     query: r#"
     {

--- a/src/lints/trait_associated_type_now_doc_hidden.ron
+++ b/src/lints/trait_associated_type_now_doc_hidden.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "trait associated type is now #[doc(hidden)]",
     description: "A public trait associated type is now marked as #[doc(hidden)] and has thus been removed from the public API",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
     query: r#"
     {

--- a/src/lints/trait_method_missing.ron
+++ b/src/lints/trait_method_missing.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub trait method removed or renamed",
     description: "A trait method can no longer be called by its prior path.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures"),
     query: r#"
     {

--- a/src/lints/trait_method_now_doc_hidden.ron
+++ b/src/lints/trait_method_now_doc_hidden.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub trait method is now #[doc(hidden)]",
     description: "A public trait method is now marked as #[doc(hidden)] and has thus been removed from the public API",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
     query: r#"
     {

--- a/src/lints/trait_method_unsafe_added.ron
+++ b/src/lints/trait_method_unsafe_added.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub trait method became unsafe",
     description: "A method in a public trait became unsafe",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#calling-an-unsafe-function-or-method"),
     query: r#"
     {

--- a/src/lints/trait_method_unsafe_removed.ron
+++ b/src/lints/trait_method_unsafe_removed.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub trait method became safe",
     description: "A method in a public trait became safe",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/stable/reference/unsafe-keyword.html#unsafe-functions-unsafe-fn"),
     query: r#"
     {

--- a/src/lints/trait_missing.ron
+++ b/src/lints/trait_missing.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub trait removed or renamed",
     description: "A trait can no longer be imported by its prior path.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/trait_must_use_added.ron
+++ b/src/lints/trait_must_use_added.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "trait #[must_use] added",
     description: "A trait has been marked with #[must_use].",
     required_update: Minor,
+    lint_level: Deny,
 
     // TODO: Change the reference link to point to the cargo semver reference
     //       once it has a section on attribute #[must_use].

--- a/src/lints/trait_no_longer_object_safe.ron
+++ b/src/lints/trait_no_longer_object_safe.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "trait no longer object safe",
     description: "A trait is no longer object safe, meaning it can no longer be used as `dyn Trait`.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/stable/reference/items/traits.html#object-safety"),
     query: r#"
     {

--- a/src/lints/trait_now_doc_hidden.ron
+++ b/src/lints/trait_now_doc_hidden.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub trait is now #[doc(hidden)]",
     description: "A pub trait is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
     query: r#"
     {

--- a/src/lints/trait_removed_associated_constant.ron
+++ b/src/lints/trait_removed_associated_constant.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "trait's associated constant was removed",
     description: "A trait's associated constant was removed or renamed",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/trait_removed_associated_type.ron
+++ b/src/lints/trait_removed_associated_type.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "trait's associated type was removed",
     description: "A trait's associated type was removed or renamed.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/trait_removed_supertrait.ron
+++ b/src/lints/trait_removed_supertrait.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "supertrait removed or renamed",
     description: "Removing a supertrait bound is a breaking change, since users of the trait can no longer assume it can also be used like its supertrait.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/reference/items/traits.html#supertraits"),
     query: r#"
     {

--- a/src/lints/trait_unsafe_added.ron
+++ b/src/lints/trait_unsafe_added.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub trait became unsafe",
     description: "A public trait became unsafe.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#implementing-an-unsafe-trait"),
     query: r#"
     {

--- a/src/lints/trait_unsafe_removed.ron
+++ b/src/lints/trait_unsafe_removed.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub unsafe trait became safe",
     description: "A public unsafe trait became safe.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#implementing-an-unsafe-trait"),
     query: r#"
     {

--- a/src/lints/tuple_struct_to_plain_struct.ron
+++ b/src/lints/tuple_struct_to_plain_struct.ron
@@ -7,6 +7,7 @@ This is breaking even if the fields have the same names, because tuple struct pa
 Source: Rust for Rustaceans, Chapter 3, "Type Modifications", page 51
 "#),
     required_update: Major,
+    lint_level: Deny,
     reference_link: None,
     query: r#"
     {

--- a/src/lints/type_marked_deprecated.ron
+++ b/src/lints/type_marked_deprecated.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "#[deprecated] added on type",
     description: "A type has been newly marked with #[deprecated].",
     required_update: Minor,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute"),
     query: r#"
     {

--- a/src/lints/union_field_missing.ron
+++ b/src/lints/union_field_missing.ron
@@ -2,7 +2,8 @@ SemverQuery(
     id: "union_field_missing",
     human_readable_name: "pub union pub field is removed or renamed",
     description: "pub union pub field is removed or renamed. No longer present under it's previous name, by whatever cause.",
-    required_update: Major, 
+    required_update: Major,
+    lint_level: Deny, 
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/union_missing.ron
+++ b/src/lints/union_missing.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub union removed or renamed",
     description: "A union can no longer be imported by its prior path.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"
     {

--- a/src/lints/union_now_doc_hidden.ron
+++ b/src/lints/union_now_doc_hidden.ron
@@ -3,6 +3,7 @@ SemverQuery(
     human_readable_name: "pub union is now #[doc(hidden)]",
     description: "A pub union is now marked #[doc(hidden)] and is thus no longer part of the public API.",
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden"),
     query: r#"
     {

--- a/src/lints/unit_struct_changed_kind.ron
+++ b/src/lints/unit_struct_changed_kind.ron
@@ -4,6 +4,7 @@ SemverQuery(
     description: "A struct changed from a unit struct to a plain struct.",
     reference: Some("A public struct that was previously a unit struct is now a plain struct. The unit struct was not marked #[non_exhaustive], so it could be constructed outside of the defining crate. Plain structs cannot be constructed using the syntax allowed for unit structs, so this is a major breaking change for code that depends on it."),
     required_update: Major,
+    lint_level: Deny,
 
     // TODO: Change the reference link once this cargo docs PR merges:
     // https://github.com/rust-lang/cargo/pull/10871

--- a/src/lints/variant_marked_non_exhaustive.ron
+++ b/src/lints/variant_marked_non_exhaustive.ron
@@ -4,6 +4,7 @@ SemverQuery(
     description: "An exhaustive enum variant has been marked #[non_exhaustive].",
     reference: Some("An exhaustive enum variant has been marked #[non_exhaustive], preventing it from being constructed using a literal from outside its own crate."),
     required_update: Major,
+    lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive"),
     query: r#"
     {

--- a/src/query.rs
+++ b/src/query.rs
@@ -30,6 +30,27 @@ impl From<RequiredSemverUpdate> for ReleaseType {
     }
 }
 
+/// The level of intensity of the error when a lint occurs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum LintLevel {
+    /// If this lint occurs, do nothing.
+    Allow,
+    /// If this lint occurs, print a warning.
+    Warn,
+    /// If this lint occurs, raise an error.
+    Deny,
+}
+
+impl LintLevel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LintLevel::Allow => "allow",
+            LintLevel::Warn => "warn",
+            LintLevel::Deny => "deny",
+        }
+    }
+}
+
 /// Kind of semver update.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ActualSemverUpdate {
@@ -72,6 +93,9 @@ pub struct SemverQuery {
     pub description: String,
 
     pub required_update: RequiredSemverUpdate,
+
+    /// The default lint level for when this lint occurs.
+    pub lint_level: LintLevel,
 
     #[serde(default)]
     pub reference: Option<String>,


### PR DESCRIPTION
* split part of `check_release::run_check_release` into a helper function `print_lint_error`
* add `LintLevel` struct in `query` and add it as a field to `SemverQuery`
* add default `Deny` field to all existing lints in `lints/`
* add `shell_error` function in `GlobalConfig`