### PR TITLE
deserialize [package.metadata] and [workspace.metadata] tables

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,9 +1,14 @@
+use std::collections::BTreeMap;
+
 use anyhow::Context;
+use serde::Deserialize;
+
+use crate::{LintLevel, OverrideMap, QueryOverride, RequiredSemverUpdate};
 
 #[derive(Debug, Clone)]
 pub(crate) struct Manifest {
     pub(crate) path: std::path::PathBuf,
-    pub(crate) parsed: cargo_toml::Manifest,
+    pub(crate) parsed: cargo_toml::Manifest<LintTable>,
 }
 
 impl Manifest {
@@ -11,7 +16,7 @@ impl Manifest {
         // Parsing via `cargo_toml::Manifest::from_path()` is preferable to parsing from a string,
         // because inspection of surrounding files is sometimes necessary to determine
         // the existence of lib targets and ensure proper handling of workspace inheritance.
-        let parsed = cargo_toml::Manifest::from_path(&path)
+        let parsed = cargo_toml::Manifest::from_path_with_metadata(&path)
             .with_context(|| format!("failed when reading {}", path.display()))?;
 
         Ok(Self { path, parsed })
@@ -56,4 +61,144 @@ pub(crate) fn get_project_dir_from_manifest_path(
         .parent()
         .context("manifest path doesn't have a parent")?;
     Ok(dir_path.to_path_buf())
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct LintTable {
+    #[serde(rename = "cargo-semver-checks")]
+    pub(crate) config: BTreeMap<String, OverrideConfig>,
+}
+
+impl From<LintTable> for OverrideMap {
+    fn from(value: LintTable) -> Self {
+        value
+            .config
+            .into_iter()
+            .map(|(k, v)| (k, v.into()))
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged, rename_all = "kebab-case")]
+pub(crate) enum OverrideConfig {
+    Structure(QueryOverride),
+    LintLevel(LintLevel),
+    RequiredUpdate(RequiredSemverUpdate),
+}
+
+impl From<OverrideConfig> for QueryOverride {
+    fn from(value: OverrideConfig) -> Self {
+        match value {
+            OverrideConfig::Structure(x) => x,
+            OverrideConfig::LintLevel(lint_level) => Self {
+                lint_level: Some(lint_level),
+                required_update: None,
+            },
+            OverrideConfig::RequiredUpdate(required_update) => Self {
+                lint_level: None,
+                required_update: Some(required_update),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{manifest::OverrideConfig, QueryOverride};
+
+    use super::LintTable;
+
+    #[test]
+    fn test_deserialize_config() {
+        use crate::LintLevel::*;
+        use crate::RequiredSemverUpdate::*;
+        use OverrideConfig::*;
+        let manifest = r#"[package]
+            name = "cargo-semver-checks"
+            version = "1.2.3"
+            edition = "2021"
+
+            [package.metadata.cargo-semver-checks]
+            one = "major"
+            two = "deny"
+            three = { lint-level = "warn" }
+            four = { required-update = "major" }
+            five = { required-update = "minor", lint-level = "allow" }
+
+            [workspace.metadata.cargo-semver-checks]
+            six = "allow"
+            "#;
+
+        let parsed = cargo_toml::Manifest::from_slice_with_metadata(manifest.as_bytes())
+            .expect("Cargo.toml should be valid");
+        let package_metadata: LintTable = parsed
+            .package
+            .expect("Cargo.toml should contain a package")
+            .metadata
+            .expect("Package metadata should be present");
+
+        let workspace_metadata = parsed
+            .workspace
+            .expect("Cargo.toml should contain a workspace")
+            .metadata
+            .expect("Workspace metadata should be present");
+
+        let pkg = package_metadata.config;
+        let wks = workspace_metadata.config;
+        assert!(
+            matches!(pkg.get("one"), Some(&RequiredUpdate(Major))),
+            "got {:?}",
+            pkg.get("one")
+        );
+
+        assert!(
+            matches!(pkg.get("two"), Some(&LintLevel(Deny))),
+            "got {:?}",
+            pkg.get("two")
+        );
+
+        assert!(
+            matches!(
+                pkg.get("three"),
+                Some(&Structure(QueryOverride {
+                    required_update: None,
+                    lint_level: Some(Warn)
+                }))
+            ),
+            "got {:?}",
+            pkg.get("three")
+        );
+
+        assert!(
+            matches!(
+                pkg.get("four"),
+                Some(&Structure(QueryOverride {
+                    required_update: Some(Major),
+                    lint_level: None,
+                }))
+            ),
+            "got {:?}",
+            pkg.get("four")
+        );
+
+        //
+        assert!(
+            matches!(
+                pkg.get("five"),
+                Some(&Structure(QueryOverride {
+                    required_update: Some(Minor),
+                    lint_level: Some(Allow)
+                }))
+            ),
+            "got {:?}",
+            pkg.get("five")
+        );
+
+        assert!(
+            matches!(wks.get("six"), Some(&LintLevel(Allow))),
+            "got {:?}",
+            wks.get("six")
+        );
+    }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -63,6 +63,8 @@ pub(crate) fn get_project_dir_from_manifest_path(
     Ok(dir_path.to_path_buf())
 }
 
+/// A [package.metadata] or [workspace.metadata] table with
+/// `cargo-semver-checks` lint entries stored in `config`
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct LintTable {
     #[serde(rename = "cargo-semver-checks")]
@@ -79,11 +81,21 @@ impl From<LintTable> for OverrideMap {
     }
 }
 
+/// Different valid representations of a [`QueryOverride`] in the Cargo.toml configuration table
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged, rename_all = "kebab-case")]
 pub(crate) enum OverrideConfig {
+    /// Specify members by name, e.g.
+    /// `lint_name = { lint-level = "deny", required-update = "major" }
+    /// Any omitted members will default to `None`
     Structure(QueryOverride),
+    /// Shorthand for specifying just a lint level and leaving
+    /// the other members as default: e.g.,
+    /// `lint_name = "deny"`
     LintLevel(LintLevel),
+    /// Shorthand for specifying just a required version bump and leaving
+    /// the other members as default: e.g.,
+    /// `lint_name = "allow"`
     RequiredUpdate(RequiredSemverUpdate),
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -93,7 +93,7 @@ pub(crate) enum OverrideConfig {
     LintLevel(LintLevel),
     /// Shorthand for specifying just a required version bump and leaving
     /// the other members as default: e.g.,
-    /// `lint_name = "allow"`
+    /// `lint_name = "minor"`
     RequiredUpdate(RequiredSemverUpdate),
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -8,7 +8,9 @@ use crate::ReleaseType;
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RequiredSemverUpdate {
+    #[serde(alias = "major")]
     Major,
+    #[serde(alias = "minor")]
     Minor,
 }
 
@@ -34,10 +36,13 @@ impl From<RequiredSemverUpdate> for ReleaseType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum LintLevel {
     /// If this lint occurs, do nothing.
+    #[serde(alias = "allow")]
     Allow,
     /// If this lint occurs, print a warning.
+    #[serde(alias = "warn")]
     Warn,
     /// If this lint occurs, raise an error.
+    #[serde(alias = "deny")]
     Deny,
 }
 
@@ -142,18 +147,21 @@ Failed to parse a query: {e}
 }
 
 /// Configured values for a [`SemverQuery`] that differ from the lint's defaults.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct QueryOverride {
     /// The required version bump for this lint; see [`SemverQuery`].`required_update`.
     ///
     /// If this is `None`, use the query's default `required_update` when calculating
     /// the effective required version bump.
+    #[serde(default)]
     pub required_update: Option<RequiredSemverUpdate>,
 
     /// The lint level for this lint; see [`SemverQuery`].`lint_level`.
     ///
     /// If this is `None`, use the query's default `lint_level` when calculating
     /// the effective lint level.
+    #[serde(default)]
     pub lint_level: Option<LintLevel>,
 }
 


### PR DESCRIPTION
Uses the `cargo_toml` metadata tables to enable getting workspace and package metadata.

Current specification:
```toml
[package.metadata.cargo-semver-checks] 
one = "major"  # override lint "one"'s required semver update to `major`, keeping the lint level default
two = "deny"  # override "two"'s lint level to `deny`, leaving the required semver update default
three = { lint-level = "warn" }  # more verbose syntax to override lint level while leaving update default
four = { required-update = "major" }  # more verbose syntax to override required version update
five = { required-update = "minor", lint-level = "allow" }  # override both required semver update and lint level

[workspace.metadata.cargo-semver-checks]
six = "major" # same syntax as above but workspace-level overrides
```

Considerations:

- When we start reading these as config, we will read the configuration from the current-version crate (i.e., `--manifest-path`).  This makes sense e.g. for running `cargo semver-checks` before a release, might complicate CI pipelines where you can't edit the manifest file? I'm not sure.
- for the `Deserialize` implementations for `RequiredSemverUpdate` and `LintLevel` enums, I added the `#[serde(alias = "$name as kebab-case")]` instead of doing `#[serde(rename_all = "kebab-case")]`.  This is because we are also deserializing them in the query .ron files, where we use rust enum PascalCasing to specify the enum variant.  This means that e.g., `lint = { lint-level = "Deny" }` would be valid syntax.
- To think about: do we want to specify lint names in the metadata table as Cargo.toml kebab-case or as they currently are in snake_case?

For reviewing: I tried to make a smaller PR - most of the length comes from an added test, starting from line 118 in `manifest.rs`