### PR TITLE
read package/workspace config from Cargo manifest

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,8 +486,8 @@ note: skipped the following crates since they have no library target: {skipped}"
                 }
 
                 let workspace_overrides =
-                    manifest::deserialize_lint_table(metadata.workspace_metadata.clone())
-                        .context("[workspace.metadata.cargo-semver-checks] table is incorrect")?
+                    manifest::deserialize_lint_table(&metadata.workspace_metadata)
+                        .context("[workspace.metadata.cargo-semver-checks] table is invalid")?
                         .map(Arc::new);
 
                 selected
@@ -513,11 +513,12 @@ note: skipped the following crates since they have no library target: {skipped}"
                             Ok((crate_name.clone(), None))
                         } else {
                             let package_overrides =
-                                manifest::deserialize_lint_table(selected.metadata.clone())
+                                manifest::deserialize_lint_table(&selected.metadata)
                                     .with_context(|| {
                                         format!(
-                                    "{} [package.metadata.cargo-semver-checks] table is incorrect",
-                                    selected.name
+                                    "package `{}`'s [package.metadata.cargo-semver-checks] table is invalid (at {})",
+                                    selected.name,
+                                    selected.manifest_path,
                                 )
                                     })?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use trustfall_rustdoc::{load_rustdoc, VersionedCrate};
 use rustdoc_cmd::RustdocCommand;
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Instant;
 
 pub use config::GlobalConfig;
@@ -484,6 +485,11 @@ note: skipped the following crates since they have no library target: {skipped}"
                     );
                 }
 
+                let workspace_overrides =
+                    manifest::deserialize_lint_table(metadata.workspace_metadata.clone())
+                        .context("[workspace.metadata.cargo-semver-checks] table is incorrect")?
+                        .map(Arc::new);
+
                 selected
                     .iter()
                     .map(|selected| {
@@ -506,6 +512,23 @@ note: skipped the following crates since they have no library target: {skipped}"
                             })?;
                             Ok((crate_name.clone(), None))
                         } else {
+                            let package_overrides =
+                                manifest::deserialize_lint_table(selected.metadata.clone())
+                                    .with_context(|| {
+                                        format!(
+                                    "{} [package.metadata.cargo-semver-checks] table is incorrect",
+                                    selected.name
+                                )
+                                    })?;
+
+                            let mut overrides = OverrideStack::new();
+                            if let Some(workspace) = &workspace_overrides {
+                                overrides.push(Arc::clone(workspace));
+                            }
+                            if let Some(package) = package_overrides {
+                                overrides.push(Arc::new(package));
+                            }
+
                             let start = std::time::Instant::now();
                             let (current_crate, baseline_crate) = generate_versioned_crates(
                                 config,

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -113,6 +113,16 @@ impl From<OverrideConfig> for QueryOverride {
     }
 }
 
+/// Helper function to deserialize an optional lint table from a [`serde_json::Value`]
+/// into a [`OverrideMap`].  Returns an `Err` if the `cargo-semver-checks` table is present
+/// but invalid.  Returns `Ok(None)` if the table is not present.
+pub(crate) fn deserialize_lint_table(
+    metadata: serde_json::Value,
+) -> anyhow::Result<Option<OverrideMap>> {
+    let table: Option<LintTable> = serde_json::from_value(metadata)?;
+    Ok(table.map(LintTable::into_overrides).flatten())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{manifest::OverrideConfig, QueryOverride};

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -117,9 +117,9 @@ impl From<OverrideConfig> for QueryOverride {
 /// into a [`OverrideMap`].  Returns an `Err` if the `cargo-semver-checks` table is present
 /// but invalid.  Returns `Ok(None)` if the table is not present.
 pub(crate) fn deserialize_lint_table(
-    metadata: serde_json::Value,
+    metadata: &serde_json::Value,
 ) -> anyhow::Result<Option<OverrideMap>> {
-    let table: Option<LintTable> = serde_json::from_value(metadata)?;
+    let table = Option::<LintTable>::deserialize(metadata)?;
     Ok(table.and_then(LintTable::into_overrides))
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -120,7 +120,7 @@ pub(crate) fn deserialize_lint_table(
     metadata: serde_json::Value,
 ) -> anyhow::Result<Option<OverrideMap>> {
     let table: Option<LintTable> = serde_json::from_value(metadata)?;
-    Ok(table.map(LintTable::into_overrides).flatten())
+    Ok(table.and_then(LintTable::into_overrides))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Deserializes lint table from the relevant `[workspace.metadata]` and `[package.metadata]` tables, if they exist.

Notes:
- this is only possible when we have access to the `Cargo.toml` manifest and run the `cargo metadata` command - that is, we won't be able to configure lint levels when the rustdoc source is `Rustdoc | Revision | VersionFromRegistry` as of current without something like CLI flags:
  - [here's](https://github.com/suaviloquence/cargo-semver-checks/commit/9628e96b12cdb105e3d328aa57722be85b3aa3be) a shim of how I plan to pass this to the `run_check_release` function. takeaway is that when we don't have the manifest to read the metadata, we just pass an empty `OverrideStack` as overrides
- it's hard to test that we are generating the correct overrides at this state without the proposed new API.  Once we actually *use* the overrides, we can test whether they are applied correctly by parsing the output
  - [here](https://github.com/obi1kenobi/cargo-semver-checks/commit/cb853e694f4ba0acb370fddb51cd22e858801b4b)'s the beginnings of a test crate, although I just printed the passed overrides for now:
    <details>
    <summary>test output</summary>
    run with `cargo r -- semver-checks --baseline-root test_crates/workspace-overrides/baseline --manifest-path test_crates/workspace-overrides/current/pkg/Cargo.toml  -vvv`


    `overrides: OverrideStack([{"function_missing": QueryOverride { required_update: Some(Minor), lint_level: Some(Warn) }, "module_missing": QueryOverride { required_update: None, lint_level: Some(Allow) }}, {"function_missing": QueryOverride { required_update: None, lint_level: Some(Deny) }, "module_missing": QueryOverride { required_update: None, lint_level: Some(Warn) }}])`
       </details>