### PR TITLE
add test for `allow` lint level

### DIFF
--- a/test_crates/manifest_tests/allow/new/Cargo.toml
+++ b/test_crates/manifest_tests/allow/new/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "allow"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.cargo-semver-checks.lints]
+module_missing = "allow"

--- a/test_crates/manifest_tests/allow/new/src/lib.rs
+++ b/test_crates/manifest_tests/allow/new/src/lib.rs
@@ -1,0 +1,3 @@
+// this is removed in the new version, triggering the module_missing
+// lint, but this is configured to allow, so `semver-checks` should pass
+// pub mod module_missing {}

--- a/test_crates/manifest_tests/allow/old/Cargo.toml
+++ b/test_crates/manifest_tests/allow/old/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "allow"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/allow/old/src/lib.rs
+++ b/test_crates/manifest_tests/allow/old/src/lib.rs
@@ -1,0 +1,3 @@
+// this is removed in the new version, triggering the module_missing
+// lint, but this is configured to allow, so `semver-checks` should pass
+pub mod module_missing {}


### PR DESCRIPTION
Tests that checks configured as `allow` are not run
and don't require a new semver update.
