### PR TITLE
Implement opt-in workspace overrides

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -524,9 +524,18 @@ note: skipped the following crates since they have no library target: {skipped}"
                                     })?;
 
                             let mut overrides = OverrideStack::new();
-                            if let Some(workspace) = &workspace_overrides {
-                                overrides.push(Arc::clone(workspace));
+
+                            let selected_manifest = manifest::Manifest::parse(selected.manifest_path.clone().into_std_path_buf())?;
+                            // the key `lints.workspace` for the Cargo lints table
+                            let lint_workspace_key = selected_manifest.parsed.lints.is_some_and(|x| x.workspace);
+                            let metadata_workspace_key = package_overrides.as_ref().is_some_and(|x| x.workspace);
+
+                            if lint_workspace_key || metadata_workspace_key {
+                                if let Some(workspace) = &workspace_overrides {
+                                    overrides.push(Arc::clone(workspace));
+                                }
                             }
+
                             if let Some(package) = package_overrides {
                                 overrides.push(Arc::new(package.inner));
                             }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -96,7 +96,6 @@ pub(crate) struct LintTable {
     /// `[workspace.metadata.*]` for now, this could be the case.  If either this
     /// field is true or `lints.workspace` is set, we should read the workspace
     /// lint config.
-    #[allow(dead_code)]
     #[serde(default)]
     pub(crate) workspace: bool,
     /// individual `lint_name = ...` entries

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -96,6 +96,7 @@ pub(crate) struct LintTable {
     /// `[workspace.metadata.*]` for now, this could be the case.  If either this
     /// field is true or `lints.workspace` is set, we should read the workspace
     /// lint config.
+    #[allow(dead_code)]
     #[serde(default)]
     pub(crate) workspace: bool,
     /// individual `lint_name = ...` entries

--- a/test_crates/manifest_tests/workspace_key_override/new/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_key_override/new/Cargo.toml
@@ -1,0 +1,8 @@
+[workspace]
+resolver = "2"
+members = ["metadata_true", "cargo_true", "both_missing"]
+
+[workspace.metadata.cargo-semver-checks.lints]
+struct_missing = { lint-level = "allow" }
+
+[workspace.lints]

--- a/test_crates/manifest_tests/workspace_key_override/new/both_missing/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_key_override/new/both_missing/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "both_missing"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/workspace_key_override/new/both_missing/src/lib.rs
+++ b/test_crates/manifest_tests/workspace_key_override/new/both_missing/src/lib.rs
@@ -1,0 +1,6 @@
+// This is removed in the new version to trigger the `struct_missing` lint
+// This is set to allow in `[workspace.metadata.cargo-semver-checks.lints]`,
+// and since this *package* is missing the `lints.workspace` key, _and_ the
+// `package.metadata.cargo-semver-cheks.lints.workspace = true`, this override
+// should not be applied.
+// pub struct StructMissing;

--- a/test_crates/manifest_tests/workspace_key_override/new/cargo_true/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_key_override/new/cargo_true/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "cargo_true"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/test_crates/manifest_tests/workspace_key_override/new/cargo_true/src/lib.rs
+++ b/test_crates/manifest_tests/workspace_key_override/new/cargo_true/src/lib.rs
@@ -1,0 +1,5 @@
+// This is removed in the new version to trigger the `struct_missing` lint
+// This is set to allow in `[workspace.metadata.cargo-semver-checks.lints]`,
+// and since this *package* has the `lints.workspace = true` key, this override
+// should be applied.
+// pub struct StructMissing;

--- a/test_crates/manifest_tests/workspace_key_override/new/metadata_true/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_key_override/new/metadata_true/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "metadata_true"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.cargo-semver-checks.lints]
+workspace = true

--- a/test_crates/manifest_tests/workspace_key_override/new/metadata_true/src/lib.rs
+++ b/test_crates/manifest_tests/workspace_key_override/new/metadata_true/src/lib.rs
@@ -1,0 +1,6 @@
+// This is removed in the new version to trigger the `struct_missing` lint
+// This is set to allow in `[workspace.metadata.cargo-semver-checks.lints]`,
+// and since this *package* has the
+// `package.metadata.cargo-semver-checks.lints.workspace = true`
+// key, this override should be applied.
+// pub struct StructMissing;

--- a/test_crates/manifest_tests/workspace_key_override/old/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_key_override/old/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+resolver = "2"
+members = ["metadata_true", "cargo_true", "both_missing"]

--- a/test_crates/manifest_tests/workspace_key_override/old/both_missing/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_key_override/old/both_missing/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "both_missing"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/workspace_key_override/old/both_missing/src/lib.rs
+++ b/test_crates/manifest_tests/workspace_key_override/old/both_missing/src/lib.rs
@@ -1,0 +1,6 @@
+// This is removed in the new version to trigger the `struct_missing` lint
+// This is set to allow in `[workspace.metadata.cargo-semver-checks.lints]`,
+// and since this *package* is missing the `lints.workspace` key, _and_ the
+// `package.metadata.cargo-semver-cheks.lints.workspace = true`, this override
+// should not be applied.
+pub struct StructMissing;

--- a/test_crates/manifest_tests/workspace_key_override/old/cargo_true/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_key_override/old/cargo_true/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "cargo_true"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/workspace_key_override/old/cargo_true/src/lib.rs
+++ b/test_crates/manifest_tests/workspace_key_override/old/cargo_true/src/lib.rs
@@ -1,0 +1,5 @@
+// This is removed in the new version to trigger the `struct_missing` lint
+// This is set to allow in `[workspace.metadata.cargo-semver-checks.lints]`,
+// and since this *package* has the `lints.workspace = true` key, this override
+// should be applied.
+pub struct StructMissing;

--- a/test_crates/manifest_tests/workspace_key_override/old/metadata_true/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_key_override/old/metadata_true/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "metadata_true"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/workspace_key_override/old/metadata_true/src/lib.rs
+++ b/test_crates/manifest_tests/workspace_key_override/old/metadata_true/src/lib.rs
@@ -1,0 +1,6 @@
+// This is removed in the new version to trigger the `struct_missing` lint
+// This is set to allow in `[workspace.metadata.cargo-semver-checks.lints]`,
+// and since this *package* has the
+// `package.metadata.cargo-semver-checks.lints.workspace = true`
+// key, this override should be applied.
+pub struct StructMissing;

--- a/test_crates/manifest_tests/workspace_overrides/new/pkg/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_overrides/new/pkg/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 
 [package.metadata.cargo-semver-checks.lints]
+workspace = true
 # overrides workspace
 function_missing = "deny"
 module_missing = { required-update = "major", lint-level = "warn" }


### PR DESCRIPTION
Now workspace overrides only apply when either the `lints.workspace = true` or `package.metadata.cargo-semver-checks.lints.workspace = true` key is set, matching the cargo `[lints]` table behavior.  Also adds a test to ensure this behavior stays this way.