### PR TITLE
make specifying `workspace = false` a hard error

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -165,7 +165,7 @@ where
     match option {
         Some(true) => Ok(true),
         None => Ok(false),
-        Some(false) => Err(serde::de::Error::custom("`lints.workspace = false` is not valid configuration.  Either set `lints.workspace = true` or omit the key entirely.")),
+        Some(false) => Err(serde::de::Error::custom("`lints.workspace = false` is not valid configuration. Either set `lints.workspace = true` or omit the key entirely.")),
     }
 }
 


### PR DESCRIPTION
For [compatibility with cargo](https://rust-lang.zulipchat.com/#narrow/stream/421156-gsoc/topic/Project.3A.20Adding.20lint.20configuration.20to.20cargo-semver-checks/near/450316607).  This PR keeps the original API but validates that the user hasn't specified `workspace = false` while deserializing.
