### PR TITLE
Test that config is only read from new (i.e., current) manifest

### DIFF
--- a/test_crates/manifest_tests/only_read_new_manifest/new/Cargo.toml
+++ b/test_crates/manifest_tests/only_read_new_manifest/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "only-read-new-manifest"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/only_read_new_manifest/new/src/lib.rs
+++ b/test_crates/manifest_tests/only_read_new_manifest/new/src/lib.rs
@@ -1,0 +1,6 @@
+// This will be removed in the `new` version to trigger the `struct_missing` lint.
+// This is configured to `allow` in `old/Cargo.toml` (the baseline version),
+// but this should not affect the lint level as the configuration should only be
+// read from the `new` (current) manifest, so the `struct_missing` lint should
+// still trigger.
+// pub struct StructMissing;

--- a/test_crates/manifest_tests/only_read_new_manifest/old/Cargo.toml
+++ b/test_crates/manifest_tests/only_read_new_manifest/old/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+publish = false
+name = "only-read-new-manifest"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.cargo-semver-checks.lints]
+struct_missing = "allow"

--- a/test_crates/manifest_tests/only_read_new_manifest/old/src/lib.rs
+++ b/test_crates/manifest_tests/only_read_new_manifest/old/src/lib.rs
@@ -1,0 +1,6 @@
+// This will be removed in the `new` version to trigger the `struct_missing` lint.
+// This is configured to `allow` in `old/Cargo.toml` (the baseline version),
+// but this should not affect the lint level as the configuration should only be
+// read from the `new` (current) manifest, so the `struct_missing` lint should
+// still trigger.
+pub struct StructMissing;

--- a/tests/lint_config.rs
+++ b/tests/lint_config.rs
@@ -128,3 +128,15 @@ fn test_workspace_key_cargo_true() {
 fn test_workspace_key_both_missing() {
     test_workspace_key_overrided("both_missing", false);
 }
+
+/// Tests that config overrides are only read from the new/current
+/// manifest and not the old/baseline manifest.  In `old/Cargo.toml`,
+/// `struct_missing` is configured to allow, but this should not apply
+/// and the lint should still be triggered.
+#[test]
+fn test_only_read_config_from_new_manifest() {
+    let assert = command_for_crate("only_read_new_manifest").assert();
+    assert
+        .stderr(predicates::str::is_match("FAIL(.*)struct_missing").expect("regex should be valid"))
+        .failure();
+}


### PR DESCRIPTION
Tests that config is only read from the new (current) manifest and not the old (baseline) manifest.
