### PR TITLE
Make lint table entries compatible with cargo `[lints]`

### DIFF
--- a/test_crates/manifest_tests/workspace_key_override/new/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_key_override/new/Cargo.toml
@@ -3,6 +3,6 @@ resolver = "2"
 members = ["metadata_true", "cargo_true", "both_missing"]
 
 [workspace.metadata.cargo-semver-checks.lints]
-struct_missing = { lint-level = "allow" }
+struct_missing = { level = "allow" }
 
 [workspace.lints]

--- a/test_crates/manifest_tests/workspace_overrides/new/pkg/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_overrides/new/pkg/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 workspace = true
 # overrides workspace
 function_missing = "deny"
-module_missing = { required-update = "major", lint-level = "warn" }
+module_missing = { required-update = "major", level = "warn" }


### PR DESCRIPTION
Removes `lint_name = "required-update"` shorthand and renames `lint-level` key to `level` in struct entry.

In cargo's `[lints]` table, the `level` key is required (for now).  We don't (in case someone wants to specify the required update and keep the default lint level), but this could cause problems if, eventually, we integrate with the lints table and cargo still keeps this behavior.  Do we want to make our `level` key required and then relax it later?

[context from zulip](https://rust-lang.zulipchat.com/#narrow/stream/421156-gsoc/topic/Project.3A.20Adding.20lint.20configuration.20to.20cargo-semver-checks/near/450027921)
