### PR TITLE
Add explicit features for gix backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,16 +134,28 @@ jobs:
         with:
           workspaces: 'semver'
 
+      # Ensure we include all new non-default features here explicitly, except for
+      # pass-through mutually-exclusive features from our dependencies such as:
+      # https://github.com/obi1kenobi/cargo-semver-checks/pull/824
+      #
+      # Ideally, one day we'd be able to do something like "`--all-features` except feature X":
+      # https://github.com/rust-lang/cargo/issues/3126
       - name: cargo clippy
-        run: cargo clippy --manifest-path semver/Cargo.toml --workspace --all-features --all-targets --no-deps -- -D warnings --allow deprecated
+        run: cargo clippy --manifest-path semver/Cargo.toml --workspace --all-targets --no-deps -- -D warnings --allow deprecated
 
       - name: cargo fmt
         run: cargo fmt --manifest-path semver/Cargo.toml -- --check
 
+      # Ensure we include all new non-default features here explicitly, except for
+      # pass-through mutually-exclusive features from our dependencies such as:
+      # https://github.com/obi1kenobi/cargo-semver-checks/pull/824
+      #
+      # Ideally, one day we'd be able to do something like "`--all-features` except feature X":
+      # https://github.com/rust-lang/cargo/issues/3126
       - name: cargo doc
         env:
           RUSTDOCFLAGS: -D warnings
-        run: cargo doc --manifest-path semver/Cargo.toml --workspace --all-features --no-deps --document-private-items
+        run: cargo doc --manifest-path semver/Cargo.toml --workspace --no-deps --document-private-items
 
   rust-tests:
     name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e2161dd6eba090ff1594084e95fd67aeccf04382ffea77999ea94ed42ec67b6"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.73+curl-8.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "450ab250ecf17227c39afb9a2dd9261dc0035cb80f2612472fc0c4aac2dcb84d"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,6 +1502,7 @@ checksum = "eb0ffa5f869977f5b9566399154055902f05d7e85c787d5eacf551acdd0c4adf"
 dependencies = [
  "base64 0.22.1",
  "bstr",
+ "curl",
  "gix-command",
  "gix-credentials",
  "gix-features",
@@ -1887,6 +1918,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +2065,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2145,6 +2206,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,14 +2304,13 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+checksum = "25a78e6f726d84fcf960409f509ae354a32648f090c8d32a2ea8b1a1bc3bab14"
 dependencies = [
  "libc",
  "once_cell",
  "socket2",
- "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -2567,6 +2633,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,9 +2890,9 @@ dependencies = [
 
 [[package]]
 name = "tame-index"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9632d46ad4e0c6a07d4354fc43c6eae4654a09beef8e9e7c7c899f983185c45"
+checksum = "cbf60b994ded7946fbf1c3eea9aff178da624dfb101b14c7341db018ddaf483e"
 dependencies = [
  "camino",
  "crossbeam-channel",
@@ -3261,6 +3336,12 @@ checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ log = "0.4.17"
 # Note that `tame-index` and `gix` must be upgraded in lock-step to retain the same `gix`
 # minor version. Otherwise, one will compile `gix` two times in different minor versions.
 gix = { version = "0.63", default-features = false, features = ["max-performance", "revision"] }
-tame-index = { version = "0.12", features = ["git", "sparse"] }
+tame-index = { version = "0.12", features = ["sparse"] }
 
 human-panic = "1.0.3"
 bugreport = "0.5.0"
@@ -67,3 +67,13 @@ opt-level = 3
 debug-assertions = true
 overflow-checks = true
 codegen-units = 16
+
+[features]
+default = ["gix-reqwest"]
+
+# Gix has mutually exclusive features that are exposed through tame-index. Hard-coding either of
+# these features can lead to compile errors when another crate enables the other feature through
+# workspace feature unification. We therefore allow downstream users to choose which feature to
+# enable:
+gix-reqwest = ["tame-index/gix-reqwest"]
+gix-curl = ["tame-index/gix-curl"]


### PR DESCRIPTION
Update tame-index and integrate the latest change: https://github.com/EmbarkStudios/tame-index/pull/66

This merge request is adding two features to allow downstream developers to select which gix backend to use. Since Rust unifies the feature of a crate when building it, and gix has two *mutually exclusive* features, the only way here seems to propagate this oddity and expose it in the features of this crate as well.  

More concretely, this conflicts otherwise in our crate where we also pull in [cargo](https://github.com/rust-lang/cargo/blob/ea14e861c78cf5bb67e68ddeeea7ae9219a920a2/Cargo.toml#L49) which then always enables the curl backend.
