### PR TITLE
Use a GitHub personal auth token to push new tagged versions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1778,6 +1778,7 @@ jobs:
       publish-tag: ${{ needs.should-publish.outputs.publish-tag }}
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      TAGGER_GITHUB_TOKEN: ${{ secrets.TAGGER_GITHUB_TOKEN }}
 
   should-publish:
     name: Check if version changed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
     secrets:
       CARGO_REGISTRY_TOKEN:
         required: true
+      TAGGER_GITHUB_TOKEN:
+        required: true
 
 concurrency:
   group: release
@@ -39,6 +41,8 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Tag the version
+        env:
+          GITHUB_TOKEN: ${{ secrets.TAGGER_GITHUB_TOKEN }}
         run: |
           git tag "${{ inputs.publish-tag }}"
           git push origin "${{ inputs.publish-tag }}"


### PR DESCRIPTION
Fixes #836.