### PR TITLE
Enable tests for async fn in traits

### DIFF
--- a/test_crates/async_impl_future_equivalence/new/src/lib.rs
+++ b/test_crates/async_impl_future_equivalence/new/src/lib.rs
@@ -19,11 +19,8 @@ impl S {
     pub async fn switches_to_async() {}
 }
 
-// TODO: https://github.com/obi1kenobi/cargo-semver-checks/issues/624
-// Uncomment once the project drops support for Rust < 1.75
-//
-// #[allow(async_fn_in_trait)]
-// pub trait Trait {
-//     fn switches_to_return_impl() -> impl Future;
-//     async fn switches_to_async();
-// }
+#[allow(async_fn_in_trait)]
+pub trait Trait {
+    fn switches_to_return_impl() -> impl Future;
+    async fn switches_to_async();
+}

--- a/test_crates/async_impl_future_equivalence/old/src/lib.rs
+++ b/test_crates/async_impl_future_equivalence/old/src/lib.rs
@@ -19,11 +19,8 @@ impl S {
     }
 }
 
-// TODO: https://github.com/obi1kenobi/cargo-semver-checks/issues/624
-// Uncomment once the project drops support for Rust < 1.75
-//
-// #[allow(async_fn_in_trait)]
-// pub trait Trait {
-//     async fn switches_to_return_impl();
-//     fn switches_to_async() -> impl Future;
-// }
+#[allow(async_fn_in_trait)]
+pub trait Trait {
+    async fn switches_to_return_impl();
+    fn switches_to_async() -> impl Future;
+}


### PR DESCRIPTION
Closes #624

#624 was waiting on Rust 1.75 and I saw #833 was merged bumping the minimum requirement to 1.77