### PR TITLE
Add snapshot testing with `insta`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
  "handlebars",
  "human-panic",
  "ignore",
- "insta",
+ "insta-cmd",
  "itertools 0.13.0",
  "log",
  "predicates",
@@ -1843,6 +1843,17 @@ dependencies = [
  "linked-hash-map",
  "serde",
  "similar",
+]
+
+[[package]]
+name = "insta-cmd"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffeeefa927925cced49ccb01bf3e57c9d4cd132df21e576eb9415baeab2d3de6"
+dependencies = [
+ "insta",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -319,12 +325,12 @@ dependencies = [
  "handlebars",
  "human-panic",
  "ignore",
- "insta-cmd",
+ "insta",
  "itertools 0.13.0",
  "log",
  "predicates",
  "rayon",
- "ron",
+ "ron 0.8.1",
  "rustc_version",
  "semver",
  "serde",
@@ -1841,19 +1847,9 @@ dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
+ "ron 0.7.1",
  "serde",
  "similar",
-]
-
-[[package]]
-name = "insta-cmd"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffeeefa927925cced49ccb01bf3e57c9d4cd132df21e576eb9415baeab2d3de6"
-dependencies = [
- "insta",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2521,6 +2517,17 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ron"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags 1.3.2",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,7 @@ dependencies = [
  "handlebars",
  "human-panic",
  "ignore",
+ "insta",
  "itertools 0.13.0",
  "log",
  "predicates",
@@ -1832,6 +1833,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "serde",
+ "similar",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,6 +1953,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ anstream = "0.6.13"
 assert_cmd = "2.0"
 similar-asserts = { version = "1.5.0", features = ["serde"] }
 predicates = "3.1.0"
+insta = { version = "1.39.0", features = ["yaml"] }
+serde = { version = "1.0.185", features = ["derive"] }
 
 # In dev and test profiles, compile all dependencies with optimizations enabled,
 # but still checking debug assertions and overflows.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,7 @@ anstream = "0.6.13"
 assert_cmd = "2.0"
 similar-asserts = { version = "1.5.0", features = ["serde"] }
 predicates = "3.1.0"
-insta = { version = "1.39.0", features = ["yaml"] }
-serde = { version = "1.0.185", features = ["derive"] }
+insta-cmd = "0.6.0"
 
 # In dev and test profiles, compile all dependencies with optimizations enabled,
 # but still checking debug assertions and overflows.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ anstream = "0.6.13"
 assert_cmd = "2.0"
 similar-asserts = { version = "1.5.0", features = ["serde"] }
 predicates = "3.1.0"
-insta-cmd = "0.6.0"
+insta = { version = "1.39.0", features = ["ron"] }
 
 # In dev and test profiles, compile all dependencies with optimizations enabled,
 # but still checking debug assertions and overflows.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@ mod rustdoc_gen;
 mod templating;
 mod util;
 
+#[cfg(test)]
+mod snapshot_tests;
+
 use anyhow::Context;
 use cargo_metadata::PackageId;
 use clap::ValueEnum;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,6 @@ mod rustdoc_gen;
 mod templating;
 mod util;
 
-#[cfg(test)]
-mod snapshot_tests;
-
 use anyhow::Context;
 use cargo_metadata::PackageId;
 use clap::ValueEnum;
@@ -20,6 +17,7 @@ use itertools::Itertools;
 
 use check_release::run_check_release;
 use rustdoc_gen::CrateDataForRustdoc;
+use serde::Serialize;
 use trustfall_rustdoc::{load_rustdoc, VersionedCrate};
 
 use rustdoc_cmd::RustdocCommand;
@@ -36,7 +34,7 @@ pub use query::{
 
 /// Test a release for semver violations.
 #[non_exhaustive]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct Check {
     /// Which packages to analyze.
     scope: Scope,
@@ -54,7 +52,7 @@ pub struct Check {
 /// Affects which lints are executed.
 /// Non-exhaustive in case we want to add "pre-release" as an option in the future.
 #[non_exhaustive]
-#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ReleaseType {
     Major,
     Minor,
@@ -62,7 +60,7 @@ pub enum ReleaseType {
 }
 
 #[non_exhaustive]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct Rustdoc {
     source: RustdocSource,
 }
@@ -112,7 +110,7 @@ impl Rustdoc {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 enum RustdocSource {
     /// Path to the Rustdoc json file.
     /// Use this option when you have already generated the rustdoc file.
@@ -130,12 +128,12 @@ enum RustdocSource {
 }
 
 /// Which packages to analyze.
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Default, Debug, PartialEq, Eq, Serialize)]
 struct Scope {
     mode: ScopeMode,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 enum ScopeMode {
     /// All packages except the excluded ones.
     DenyList(PackageSelection),
@@ -150,7 +148,7 @@ impl Default for ScopeMode {
 }
 
 #[non_exhaustive]
-#[derive(Default, Clone, Debug, PartialEq, Eq)]
+#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct PackageSelection {
     selection: ScopeSelection,
     excluded_packages: Vec<String>,
@@ -171,7 +169,7 @@ impl PackageSelection {
 }
 
 #[non_exhaustive]
-#[derive(Default, Debug, PartialEq, Eq, Clone)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Serialize)]
 pub enum ScopeSelection {
     /// All packages in the workspace. Equivalent to `--workspace`.
     Workspace,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,9 @@ use cargo_semver_checks::{
 };
 use clap::{Args, Parser, Subcommand};
 
+#[cfg(test)]
+mod snapshot_tests;
+
 fn main() {
     human_panic::setup_panic!();
 

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -131,7 +131,7 @@ impl fmt::Display for CommandResult {
 #[allow(dead_code)] // TODO
 fn assert_integration_test(test_name: &str, invocation: &[&str]) {
     // remove the backtrace environment variable, as this may cause non-
-    // reproducable snapshots.
+    // reproducible snapshots.
     std::env::remove_var("RUST_BACKTRACE");
 
     let stdout = StaticWriter::new();
@@ -149,6 +149,9 @@ fn assert_integration_test(test_name: &str, invocation: &[&str]) {
 
     let mut settings = insta::Settings::clone_current();
     settings.set_snapshot_path("../test_outputs/snapshot_tests");
+    // The `settings` are applied to the current thread as long as the returned
+    //  drop guard  `_grd` is alive, so we use a `let` binding to keep it alive 
+    // for the scope of the function.
     let _grd = settings.bind_to_scope();
 
     insta::assert_ron_snapshot!(format!("{test_name}-input"), check);

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(test)]
 //! Snapshot tests of `cargo semver-checks` runs to ensure
 //! that we define how we handle edge cases.
 //!
@@ -12,38 +13,156 @@
 //!
 //! If the changes are intended, to update the test, accept the new output
 //! in the `cargo insta review` CLI.  Make sure to commit the
-//! `tests/snapshots/{name}.snap` file in your PR.
+//! `test_outputs/snapshot_tests/{name}.snap` file in your PR.
 //!
 //! Alternatively, if you can't use `cargo-insta`, review the changed files
-//! in the `tests/snapshots/ directory by moving `{name}.snap.new` to
+//! in the `test_outputs/snapshot_test/ directory by moving `{name}.snap.new` to
 //! `{name}.snap` to update the snapshot.  To update all changed tests,
 //! run `INSTA_UPDATE=always cargo test --lib snapshot_tests`
 //!
 //! # Adding a new test
 //!
-//! To add a new test, typically you will want to use `create_command`
-//! and add arguments (especially `--manifest-path` and `--baseline-root`).
-//! Then, call [`assert_cmd_snapshot!`] with the command.
+//! To add a new test, typically you will want to use the [`integration_test`] helper function
+//! with a string invocation of `cargo semver-checks ...` (typically including the `--manifest-path`
+//! and `--baseline-root` arguments to specify the location of the current/baseline test crate path,
+//! usually in the `test_crates/manifest_tests` directory).  Add a new function marked `#[test]` that
+//! calls this function with the prefix (usually the function name) and the arguments.
 //!
-//! Then run `cargo test --test snapshot_tests`.  The new test should fail, as
+//! Then run `cargo test --bin cargo_semver_checks snapshot_tests`.  The new test should fail, as
 //! there is no snapshot to compare to.  Review the output with `cargo insta review`,
 //! and accept it when the captured behavior is correct. (see above if you can't use
 //! `cargo-insta`)
-use std::process::Command;
 
-#[allow(unused_imports)] // TODO
-use insta_cmd::assert_cmd_snapshot;
+use std::{
+    cell::RefCell,
+    fmt,
+    io::{Cursor, Write},
+    rc::Rc,
+};
 
-/// Helper function to create a [`Command`] to run `cargo-semver-checks`
-/// for snapshot testing with `assert_cmd_snapshot!`
+use cargo_semver_checks::{Check, GlobalConfig};
+use clap::Parser as _;
+
+use crate::Cargo;
+
+/// Helper struct to implement [`Write + 'static`] on a shared buffer.  Single-threaded
+/// only, perform write actions then call `StaticWriter::try_into_buffer()` to read.
+#[derive(Debug, Default, Clone)]
+struct StaticWriter(Rc<RefCell<Cursor<Vec<u8>>>>);
+
+impl StaticWriter {
+    #[inline]
+    #[must_use]
+    fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the buffer if there are no other references to it, otherwise
+    /// returns the original [`Rc`]-backed `self`.
+    fn try_into_inner(self) -> Result<Vec<u8>, Self> {
+        match Rc::try_unwrap(self.0) {
+            Ok(b) => Ok(b.into_inner().into_inner()),
+            Err(rc) => Err(Self(rc)),
+        }
+    }
+}
+
+impl Write for StaticWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.borrow_mut().write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.borrow_mut().flush()
+    }
+}
+
+/// Struct for printing the result of an invocation of `cargo-semver-checks`
+#[derive(Debug)]
+struct CommandOutput {
+    /// Whether the invocation of `cargo-semver-checks` was successful (i.e., there are no semver-breaking changes),
+    /// from [`Report::success`](cargo_semver_checks::Report::success).
+    success: bool,
+    /// The stderr of the invocation.
+    stderr: String,
+    /// The stdout of the invocation.
+    stdout: String,
+}
+
+impl fmt::Display for CommandOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "success: {}", self.success)?;
+        writeln!(f, "--- stdout ---\n{}", self.stdout)?;
+        writeln!(f, "--- stderr ---\n{}", self.stderr)?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct CommandResult(anyhow::Result<CommandOutput>);
+
+impl fmt::Display for CommandResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            Ok(d) => write!(f, "{d}"),
+            Err(e) => writeln!(f, "--- error ---\n{e}"),
+        }
+    }
+}
+
+/// Helper function to assert snapshots of (1) correctly parsed start state
+/// and (2) their outputs.  See the module-level documentation for instructions
+/// on how to create the tests.
+///
+/// # Arguments
+///
+/// - `test_name` is the file prefix for snapshot tests to be saved in as
+/// `test_outputs/snapshot_tests/{test_name}-{"args" | "output"}.snap
+/// - `invocation` is a list of arguments of the command line invocation,
+/// starting with `["cargo", "semver-checks"]`.
 #[allow(dead_code)] // TODO
-fn create_command() -> Command {
-    let mut cmd = Command::new(insta_cmd::get_cargo_bin("cargo-semver-checks"));
+fn assert_integration_test(test_name: &str, invocation: &[&str]) {
+    // remove the backtrace environment variable, as this may cause non-
+    // reproducable snapshots.
+    std::env::remove_var("RUST_BACKTRACE");
 
-    cmd.arg("semver-checks");
-    // We don't want backtraces in our snapshot, as those may change the
-    // output but not affect the behavior of the program.
-    cmd.env("RUST_BACKTRACE", "0");
+    let stdout = StaticWriter::new();
+    let stderr = StaticWriter::new();
 
-    cmd
+    let Cargo::SemverChecks(arguments) = Cargo::parse_from(invocation.into_iter());
+
+    let mut config = GlobalConfig::new();
+
+    config.set_stdout(Box::new(stdout.clone()));
+    config.set_stderr(Box::new(stderr.clone()));
+    config.set_color_choice(false);
+
+    let check = Check::from(arguments.check_release);
+
+    let mut settings = insta::Settings::clone_current();
+    settings.set_snapshot_path("../test_outputs/snapshot_tests");
+    let _grd = settings.bind_to_scope();
+
+    insta::assert_ron_snapshot!(format!("{test_name}-input"), check);
+
+    let result = check.check_release(&mut config);
+
+    // drop other references to stdout/err
+    drop(config);
+
+    let stdout = stdout
+        .try_into_inner()
+        .expect("failed to get unique reference to stdout");
+    let stderr = stderr
+        .try_into_inner()
+        .expect("failed to get unique reference to stderr");
+
+    let result = CommandResult(result.map(|report| CommandOutput {
+        success: report.success(),
+        stdout: String::from_utf8(stdout).expect("failed to convert to UTF-8"),
+        stderr: String::from_utf8(stderr).expect("failed to convert to UTF-8"),
+    }));
+
+    insta::assert_snapshot!(format!("{test_name}-output"), result);
 }

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -15,20 +15,28 @@
 //! in the `cargo insta review` CLI.  Make sure to commit the
 //! `test_outputs/snapshot_tests/{name}.snap` file in your PR.
 //!
+//! We check **multiple stages** of the `cargo-semver-checks` execution of a given command
+//! (currently two: the parsed input [`Check`](cargo_semver_checks::Check) and the output
+//! of running [`check_release`](cargo_semver_checks::Check::check_release)).  This means
+//! you may have to run `cargo test` and `cargo insta review` multiple times when adding or
+//! updating a new test if both the input and output change.
+//!
 //! Alternatively, if you can't use `cargo-insta`, review the changed files
 //! in the `test_outputs/snapshot_test/ directory by moving `{name}.snap.new` to
 //! `{name}.snap` to update the snapshot.  To update all changed tests,
-//! run `INSTA_UPDATE=always cargo test --lib snapshot_tests`
+//! run `INSTA_UPDATE=always cargo test --bin cargo-semver-checks snapshot_tests`
 //!
 //! # Adding a new test
 //!
-//! To add a new test, typically you will want to use the [`integration_test`] helper function
+//! To add a new test, typically you will want to use the [`assert_integration_test`] helper function
 //! with a string invocation of `cargo semver-checks ...` (typically including the `--manifest-path`
-//! and `--baseline-root` arguments to specify the location of the current/baseline test crate path,
-//! usually in the `test_crates/manifest_tests` directory).  Add a new function marked `#[test]` that
-//! calls this function with the prefix (usually the function name) and the arguments.
+//! and `--baseline-root` arguments to specify the location of the current/baseline test crate path:
+//! in the `test_crates` directory if the test can use cached generated rustdoc files, or in the
+//! `test_crates/manifest_tests` directory if the test relies on `Cargo.toml` manifest files).
+//! Add a new function marked `#[test]` that calls [`assert_integration_test`] with
+//! the prefix (usually the function name) and the arguments to `cargo semver-checks`
 //!
-//! Then run `cargo test --bin cargo_semver_checks snapshot_tests`.  The new test should fail, as
+//! Then run `cargo test --bin cargo-semver-checks snapshot_tests`.  The new test should fail, as
 //! there is no snapshot to compare to.  Review the output with `cargo insta review`,
 //! and accept it when the captured behavior is correct. (see above if you can't use
 //! `cargo-insta`)

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -1,4 +1,3 @@
-#![cfg(test)]
 //! Snapshot tests of `cargo semver-checks` runs to ensure
 //! that we define how we handle edge cases.
 //!
@@ -126,9 +125,9 @@ impl fmt::Display for CommandResult {
 /// # Arguments
 ///
 /// - `test_name` is the file prefix for snapshot tests to be saved in as
-/// `test_outputs/snapshot_tests/{test_name}-{"args" | "output"}.snap
+///   `test_outputs/snapshot_tests/{test_name}-{"args" | "output"}.snap
 /// - `invocation` is a list of arguments of the command line invocation,
-/// starting with `["cargo", "semver-checks"]`.
+///   starting with `["cargo", "semver-checks"]`.
 #[allow(dead_code)] // TODO
 fn assert_integration_test(test_name: &str, invocation: &[&str]) {
     // remove the backtrace environment variable, as this may cause non-
@@ -138,7 +137,7 @@ fn assert_integration_test(test_name: &str, invocation: &[&str]) {
     let stdout = StaticWriter::new();
     let stderr = StaticWriter::new();
 
-    let Cargo::SemverChecks(arguments) = Cargo::parse_from(invocation.into_iter());
+    let Cargo::SemverChecks(arguments) = Cargo::parse_from(invocation);
 
     let mut config = GlobalConfig::new();
 

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -150,7 +150,7 @@ fn assert_integration_test(test_name: &str, invocation: &[&str]) {
     let mut settings = insta::Settings::clone_current();
     settings.set_snapshot_path("../test_outputs/snapshot_tests");
     // The `settings` are applied to the current thread as long as the returned
-    //  drop guard  `_grd` is alive, so we use a `let` binding to keep it alive 
+    // drop guard  `_grd` is alive, so we use a `let` binding to keep it alive
     // for the scope of the function.
     let _grd = settings.bind_to_scope();
 

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -17,7 +17,7 @@
 //! Alternatively, if you can't use `cargo-insta`, review the changed files
 //! in the `tests/snapshots/ directory by moving `{name}.snap.new` to
 //! `{name}.snap` to update the snapshot.  To update all changed tests,
-//! run `INSTA_UPDATE=always cargo test --test snapshot_tests`
+//! run `INSTA_UPDATE=always cargo test --lib snapshot_tests`
 //!
 //! # Adding a new test
 //!

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -1,0 +1,70 @@
+//! Snapshot tests of `cargo semver-checks` runs to ensure
+//! that we define how we handle edge cases.
+//!
+//! # Updating test output
+//!
+//! If you introduce changes into `cargo-semver-checks` that modify its behavior
+//! so that these tests fail, the snapshot may need to be updated.  After you've
+//! determined that the new behavior is not a regression and the test should
+//! be updated, run the following:
+//!
+//! `$ cargo insta review` (you may need to `cargo install cargo-insta`)
+//!
+//! If the changes are intended, to update the test, accept the new output
+//! in the `cargo insta review` CLI.  Make sure to commit the
+//! `tests/snapshots/{name}.snap` file in your PR.
+//!
+//! Alternatively, if you can't use `cargo-insta`, review the changed files
+//! in the `tests/snapshots/ directory by moving `{name}.snap.new` to
+//! `{name}.snap` to update the snapshot.  To update all changed tests,
+//! run `INSTA_UPDATE=always cargo test --test snapshot_tests`
+//!
+//! # Adding a new test
+//!
+//! To add a new test, typically you will want to use `CommandOutput::new` with
+//! a `builder` that adds arguments (especially `--manifest-path` and `--baseline-root`).
+//! Then, call [`insta::assert_yaml_snapshot!`] with the `output`.
+//!
+//! Then run `cargo test --test snapshot_tests`.  The new test should fail, as
+//! there is no snapshot to compare to.  Review the output with `cargo insta review`,
+//! and accept it when the captured behavior is correct. (see above if you can't use
+//! `cargo-insta`)
+use std::process::Command;
+
+use assert_cmd::cargo::CommandCargoExt;
+use serde::Serialize;
+
+/// Structure to serialize the result of running `cargo-semver-checks`
+/// to be tested with insta.
+///
+/// Typical workflow: run `CommandOutput::new` with a `builder` that adds
+/// args to the command, use `insta::assert_yaml_snapshot!(&output)`.
+#[derive(Debug, Serialize)]
+struct CommandOutput {
+    exit_code: Option<i32>,
+    stderr: String,
+    stdout: String,
+}
+
+impl CommandOutput {
+    /// Creates a new `CommandOutput` instance by running `cargo semver-checks`.
+    ///
+    /// Use the `builder` parameter to customize the command (e.g., to add
+    /// arguments to the invocation of the command)
+    #[must_use]
+    fn new(builder: impl FnOnce(&mut Command) -> &mut Command) -> Self {
+        let mut cmd = Command::cargo_bin("cargo-semver-checks")
+            .expect("cargo semver-checks binary not found");
+
+        cmd.arg("semver-checks");
+
+        builder(&mut cmd);
+
+        let output = cmd.output().expect("executing command failed");
+        Self {
+            exit_code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        }
+    }
+}

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -59,6 +59,9 @@ impl CommandOutput {
             .expect("cargo semver-checks binary not found");
 
         cmd.arg("semver-checks");
+        // We don't want backtraces in our snapshot, as those may change the
+        // output but not affect the behavior of the program.
+        cmd.env("RUST_BACKTRACE", "0");
 
         builder(&mut cmd);
 

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -39,6 +39,7 @@ use serde::Serialize;
 ///
 /// Typical workflow: run `CommandOutput::new` with a `builder` that adds
 /// args to the command, use `insta::assert_yaml_snapshot!(&output)`.
+#[allow(dead_code)] // TODO
 #[derive(Debug, Serialize)]
 struct CommandOutput {
     exit_code: Option<i32>,
@@ -51,6 +52,7 @@ impl CommandOutput {
     ///
     /// Use the `builder` parameter to customize the command (e.g., to add
     /// arguments to the invocation of the command)
+    #[allow(dead_code)] // TODO
     #[must_use]
     fn new(builder: impl FnOnce(&mut Command) -> &mut Command) -> Self {
         let mut cmd = Command::cargo_bin("cargo-semver-checks")


### PR DESCRIPTION
Sets up infrastructure for snapshot testing with `insta`. Example coming in subsequent PR.
