### PR TITLE
Fix typo in features_simple/old test crate

### DIFF
--- a/test_crates/features_simple/old/src/lib.rs
+++ b/test_crates/features_simple/old/src/lib.rs
@@ -9,6 +9,6 @@ pub fn feature_dependent_function() {}
     feature = "__foo",
     feature = "unstable-foo",
     feature = "unstable_foo",
-    feat8re = "_bar"
+    feature = "_bar"
 ))]
 pub fn unstable_function() {}


### PR DESCRIPTION
Got a warning while running `regenerate_test_rustdocs`