### PR TITLE
Re-enable the `trait_no_longer_object_safe` lint.

### DIFF
--- a/src/lints/trait_no_longer_object_safe.ron
+++ b/src/lints/trait_no_longer_object_safe.ron
@@ -46,5 +46,5 @@ SemverQuery(
         "true": true,
     },
     error_message: "Trait is no longer object safe, which breaks `dyn Trait` usage.",
-    per_result_error_template: Some("trait {{trait_name}} in file {{span_filename}}:{{span_begin_line}}"),
+    per_result_error_template: Some("trait {{name}} in file {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/query.rs
+++ b/src/query.rs
@@ -171,7 +171,7 @@ pub type OverrideMap = BTreeMap<String, QueryOverride>;
 /// Stores a stack of [`OverrideMap`] references such that items towards the top of
 /// the stack (later in the backing `Vec`) have *higher* precedence and override items lower in the stack.
 /// That is, when an override is set and not `None` for a given lint in multiple maps in the stack, the value
-/// at the top of the stack will be used to calculate the effective lint level or required version update.  
+/// at the top of the stack will be used to calculate the effective lint level or required version update.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct OverrideStack(Vec<Arc<OverrideMap>>);
 
@@ -791,6 +791,7 @@ add_lints!(
     trait_method_unsafe_removed,
     trait_missing,
     trait_must_use_added,
+    trait_no_longer_object_safe,
     trait_now_doc_hidden,
     trait_removed_associated_constant,
     trait_removed_associated_type,

--- a/test_outputs/trait_no_longer_object_safe.output.ron
+++ b/test_outputs/trait_no_longer_object_safe.output.ron
@@ -1,4 +1,26 @@
 {
+    "./test_crates/inherent_associated_pub_const_missing/": [
+        {
+            "name": String("TraitA"),
+            "path": List([
+                String("inherent_associated_pub_const_missing"),
+                String("TraitA"),
+            ]),
+            "span_begin_line": Uint64(59),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("TraitB"),
+            "path": List([
+                String("inherent_associated_pub_const_missing"),
+                String("TraitB"),
+            ]),
+            "span_begin_line": Uint64(68),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+    ],
     "./test_crates/trait_no_longer_object_safe/": [
         {
             "name": String("RefTrait"),


### PR DESCRIPTION
It appears to have been erroneously left out from the list of lints to run.
