### PR TITLE
Bugreport auto issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,7 @@ dependencies = [
  "toml",
  "trustfall",
  "trustfall_rustdoc",
+ "urlencoding",
 ]
 
 [[package]]
@@ -3354,6 +3355,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-config2"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83ce0be8bd1479e5de6202def660e6c7e27e4e0599bffa4fed05bd380ec2ede"
+dependencies = [
+ "home",
+ "serde",
+ "serde_derive",
+ "toml_edit",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +321,7 @@ dependencies = [
  "assert_cmd",
  "atty",
  "bugreport",
+ "cargo-config2",
  "cargo_metadata",
  "cargo_toml",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ rustc_version = "0.4.0"
 rayon = "1.8.0"
 anstyle = "1.0.6"
 anstream = "0.6.13"
+urlencoding = "2.1.3"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ rayon = "1.8.0"
 anstyle = "1.0.6"
 anstream = "0.6.13"
 urlencoding = "2.1.3"
+cargo-config2 = "0.1.26"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,6 @@ fn print_issue_url(config: &mut GlobalConfig) {
         }
     };
 
-
     writeln!(
         config.stdout(),
         "{bold_cyan}\

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 
 use std::{env, path::PathBuf};
 
-use anstyle::{Color, Reset, Style};
+use cargo_config2::Config;
 use cargo_semver_checks::{
     GlobalConfig, PackageSelection, ReleaseType, Rustdoc, ScopeSelection, SemverQuery,
 };
@@ -139,9 +139,7 @@ fn configure_color(cli_choice: Option<clap::ColorChoice>) {
 
 fn print_issue_url() {
     use bugreport::{bugreport, collector::*, format::Markdown};
-    let false_negative_url: &str = "https://github.com/obi1kenobi/cargo-semver-checks/issues/new?labels=A-lint%2CC-enhancement&template=2-false-negative.yml";
-    let false_positive_url: &str = "https://github.com/obi1kenobi/cargo-semver-checks/issues/new?labels=C-bug%2CA-lint&template=1-false-positive.yml";
-    let other_bug: &str = "https://github.com/obi1kenobi/cargo-semver-checks/issues/new?labels=C-bug&template=3-bug-report.yml";
+    let other_bug_url: &str = "https://github.com/obi1kenobi/cargo-semver-checks/issues/new?labels=C-bug&template=3-bug-report.yml";
 
     let bug_report = bugreport!()
         .info(SoftwareVersion::default())
@@ -152,24 +150,22 @@ fn print_issue_url() {
         .format::<Markdown>();
 
     let bug_report_url: String = urlencoding::encode(&bug_report).into_owned();
+    let cargo_config = match Config::load() {
+        Ok(c) => toml::to_string(&c).unwrap_or_else(|s| {
+            println!("Error serializing cargo build configuration: {}", s);
+            String::default()
+        }),
+        Err(e) => {
+            println!("Error loading cargo build configuration: {}", e);
+            String::default()
+        }
+    };
+
+    let cargo_config_url: String = urlencoding::encode(&cargo_config).into_owned();
 
     println!(
-        "{}",
-        format!(
-            "Please file a bug report at one of the following URLs:\n\n\
-            {}- False negative:{} {}sysinfo={bug_report_url}\n\
-            {}- False positive:{} {}sysinfo={bug_report_url}\n\
-            {}- Other bug:{} {}sysinfo={bug_report_url}\n\n",
-            Style::new().fg_color(Some(Color::Ansi(anstyle::AnsiColor::Cyan))),
-            Reset,
-            false_negative_url,
-            Style::new().fg_color(Some(Color::Ansi(anstyle::AnsiColor::Cyan))),
-            Reset,
-            false_positive_url,
-            Style::new().fg_color(Some(Color::Ansi(anstyle::AnsiColor::Cyan))),
-            Reset,
-            other_bug
-        )
+        "Please file a bug report:\n\n{}&sys-info={}&build-config={}",
+        other_bug_url, bug_report_url, cargo_config_url
     );
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 use std::{env, path::PathBuf};
 
+use anstyle::{AnsiColor, Color, Reset, Style};
 use cargo_config2::Config;
 use cargo_semver_checks::{
     GlobalConfig, PackageSelection, ReleaseType, Rustdoc, ScopeSelection, SemverQuery,
@@ -149,23 +150,41 @@ fn print_issue_url() {
         .info(CompileTimeInformation::default())
         .format::<Markdown>();
 
-    let bug_report_url: String = urlencoding::encode(&bug_report).into_owned();
+    println!(
+        "{}System information:{}\n--------------------------\n{bug_report}",
+        Style::new()
+            .bold()
+            .fg_color(Some(Color::Ansi(AnsiColor::Blue))),
+        Reset
+    );
+
+    let bug_report_url = urlencoding::encode(&bug_report);
+
     let cargo_config = match Config::load() {
         Ok(c) => toml::to_string(&c).unwrap_or_else(|s| {
-            println!("Error serializing cargo build configuration: {}", s);
+            eprintln!("Error serializing cargo build configuration: {}", s);
             String::default()
         }),
         Err(e) => {
-            println!("Error loading cargo build configuration: {}", e);
+            eprintln!("Error loading cargo build configuration: {}", e);
             String::default()
         }
     };
 
+    println!(
+        "{}Cargo build configuration:{}\n--------------------------\n{cargo_config}",
+        Style::new()
+            .bold()
+            .fg_color(Some(Color::Ansi(AnsiColor::Blue))),
+        Reset
+    );
+
     let cargo_config_url: String = urlencoding::encode(&cargo_config).into_owned();
 
     println!(
-        "Please file a bug report:\n\n{}&sys-info={}&build-config={}",
-        other_bug_url, bug_report_url, cargo_config_url
+        "{}Please file an Issue on github reporting your bug.\n\
+        Consider adding the diagnostic information above, either manually or automatically through the link below:{}\n\n{}&sys-info={}&build-config={}",
+        Style::new().bold(), Reset, other_bug_url, bug_report_url, cargo_config_url
     );
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,7 @@ fn print_issue_url(config: &mut GlobalConfig) {
         "{}System information:{}\n--------------------------\n{bug_report}",
         Style::new()
             .bold()
-            .fg_color(Some(Color::Ansi(AnsiColor::Blue))),
+            .fg_color(Some(Color::Ansi(AnsiColor::Cyan))),
         Reset
     )
     .expect("Failed to print bug report system information to stdout");
@@ -178,7 +178,7 @@ fn print_issue_url(config: &mut GlobalConfig) {
         "{}Cargo build configuration:{}\n--------------------------\n{cargo_config}",
         Style::new()
             .bold()
-            .fg_color(Some(Color::Ansi(AnsiColor::Blue))),
+            .fg_color(Some(Color::Ansi(AnsiColor::Cyan))),
         Reset
     )
     .expect("Failed to print bug report Cargo configuration to stdout");


### PR DESCRIPTION
This PR automates the process of creating an issue and copying the output from --bugreport by generating a github new issue URL. It also includes build cargo build configuration

2 dependencies were added: urlencoding urlencoding = "2.1.3" and cargo-config2 = "0.1.26"

Old report:
![image](https://github.com/user-attachments/assets/5a7694b2-5715-430a-bc88-6596ff3c8f3a)

New report:
![image](https://github.com/user-attachments/assets/9ee464c2-b38f-49ea-87a5-60547b1c68c5)
![image](https://github.com/user-attachments/assets/3b51a982-3049-483e-8fee-fc478c19a6c3)

New report with NO_COLOR env variable set
![image](https://github.com/user-attachments/assets/5d281ea2-0d2c-4140-8591-46ddd7522e08)

![image](https://github.com/user-attachments/assets/0bacaaa0-e35f-4cf3-818f-d8901253fded)




