### PR TITLE
Forward verbosity and filter time out of snapshot tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,6 +1857,7 @@ dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
+ "regex",
  "ron 0.7.1",
  "serde",
  "similar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ anstream = "0.6.13"
 assert_cmd = "2.0"
 similar-asserts = { version = "1.5.0", features = ["serde"] }
 predicates = "3.1.0"
-insta = { version = "1.39.0", features = ["ron"] }
+insta = { version = "1.39.0", features = ["ron", "filters"] }
 fs-err = "2.11.0"
 
 # In dev and test profiles, compile all dependencies with optimizations enabled,

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -143,11 +143,15 @@ fn assert_integration_test(test_name: &str, invocation: &[&str]) {
     config.set_stdout(Box::new(stdout.clone()));
     config.set_stderr(Box::new(stderr.clone()));
     config.set_color_choice(false);
+    config.set_log_level(arguments.check_release.verbosity.log_level());
 
     let check = Check::from(arguments.check_release);
 
     let mut settings = insta::Settings::clone_current();
     settings.set_snapshot_path("../test_outputs/snapshot_tests");
+    // Turn dynamic time strings like [  0.123s] into [TIME] for reproducibility.
+    settings.add_filter(r"\[\s*[\d\.]+s\]", "[TIME]");
+
     // The `settings` are applied to the current thread as long as the returned
     // drop guard  `_grd` is alive, so we use a `let` binding to keep it alive
     // for the scope of the function.


### PR DESCRIPTION
Improvements/fixes for the stdout/stderr of a snapshot test.

1. Forward verbosity argument from clap args into `GlobalConfig`
2. Filter `[   x.xxxs]` time strings from stdout and stderr for reproducible snapshots

<details>

<summary> Example output run on the `only_warnings` test crate </summary>

```
---
source: src/snapshot_tests.rs
expression: result
---
success: true
--- stdout ---

--- warning function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.34.0/src/lints/function_missing.ron

Failed in:
  function only_warnings::function_missing, previously in file /home/m/dev/cargo-semver-checks/test_crates/manifest_tests/only_warnings/old/src/lib.rs:4

--- stderr ---
     Parsing only-warnings v0.1.0 (current)
      Parsed [TIME] (current)
     Parsing only-warnings v0.1.0 (baseline)
      Parsed [TIME] (baseline)
    Checking only-warnings v0.1.0 -> v0.1.0 (no change)
     Checked [TIME] 80 checks: 79 pass, 0 fail, 1 warn, 0 skip

     Summary no semver update required
     Warning produced 1 major and 0 minor level warnings
             produced warnings suggest new major version
    Finished [TIME] only-warnings
```

</details>

This is technically two changes in a PR - I can break it up if you'd like, but both changes are very small.