### PR TITLE
fix: regenerate script toplevel resolution

### DIFF
--- a/scripts/regenerate_test_rustdocs.sh
+++ b/scripts/regenerate_test_rustdocs.sh
@@ -23,7 +23,7 @@ RUSTDOC_OUTPUT_DIR="$CARGO_TARGET_DIR/doc"
 # - Otherwise, navigate up relative to this script's path.
 #   This latter option is useful when building cargo-semver-checks for distribution with NixOS:
 #   https://github.com/obi1kenobi/cargo-semver-checks/issues/855
-TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || cd -- "$(dirname -- "${BASH_SOURCE[0]}" )" &>/dev/null && cd -- .. &>/dev/null && pwd)"
+TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || { cd -- "$(dirname -- "${BASH_SOURCE[0]}" )" &>/dev/null && cd -- .. &>/dev/null && pwd; })"
 TARGET_DIR="$TOPLEVEL/localdata/test_data"
 TOOLCHAIN=
 


### PR DESCRIPTION
Hi 👋🏻,

I wanted to check on #870. (EDIT: sorry for linking the issue without a real connection)

When loading the `regenerate_test_rustdocs.sh` script, it would just output `Generating rustdoc with: cargo 1.80.1 (376290515 2024-07-16)` and then exit promptly. Upon closer examination, the [`TOPLEVEL` variable](https://github.com/obi1kenobi/cargo-semver-checks/blob/661fcedaf8b1700959a61306433807f08edf457f/scripts/regenerate_test_rustdocs.sh#L26) would end up having two values, thus silently crashing the rest of the program.

Though my bash knowledge is limited, I think this is what is happening:

```bash
git rev-parse --show-toplevel 2>/dev/null || cd -- "$(dirname -- "${BASH_SOURCE[0]}" )" &>/dev/null && cd -- .. &>/dev/null && pwd
# is either (in git repo)
true || true && true && true # execs both git and pwd
false || true && true && true # execs only pwd
```

Wrapping the second part of the logical `OR` resolves the issue.

It seems that #856, introduced this and was recently committed. 