### PR TITLE
Add lint for trait default impl removed

### DIFF
--- a/scripts/regenerate_test_rustdocs.sh
+++ b/scripts/regenerate_test_rustdocs.sh
@@ -23,8 +23,7 @@ RUSTDOC_OUTPUT_DIR="$CARGO_TARGET_DIR/doc"
 # - Otherwise, navigate up relative to this script's path.
 #   This latter option is useful when building cargo-semver-checks for distribution with NixOS:
 #   https://github.com/obi1kenobi/cargo-semver-checks/issues/855
-# TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || { cd -- "$(dirname -- "${BASH_SOURCE[0]}" )" &>/dev/null && cd -- .. &>/dev/null && pwd; })"
-TOPLEVEL="/home/david/oss/cargo-semver-checks"
+TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || { cd -- "$(dirname -- "${BASH_SOURCE[0]}" )" &>/dev/null && cd -- .. &>/dev/null && pwd; })"
 TARGET_DIR="$TOPLEVEL/localdata/test_data"
 TOOLCHAIN=
 

--- a/scripts/regenerate_test_rustdocs.sh
+++ b/scripts/regenerate_test_rustdocs.sh
@@ -23,7 +23,8 @@ RUSTDOC_OUTPUT_DIR="$CARGO_TARGET_DIR/doc"
 # - Otherwise, navigate up relative to this script's path.
 #   This latter option is useful when building cargo-semver-checks for distribution with NixOS:
 #   https://github.com/obi1kenobi/cargo-semver-checks/issues/855
-TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || { cd -- "$(dirname -- "${BASH_SOURCE[0]}" )" &>/dev/null && cd -- .. &>/dev/null && pwd; })"
+# TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || { cd -- "$(dirname -- "${BASH_SOURCE[0]}" )" &>/dev/null && cd -- .. &>/dev/null && pwd; })"
+TOPLEVEL="/home/david/oss/cargo-semver-checks"
 TARGET_DIR="$TOPLEVEL/localdata/test_data"
 TOOLCHAIN=
 

--- a/src/lints/trait_default_impl_removed.ron
+++ b/src/lints/trait_default_impl_removed.ron
@@ -1,0 +1,61 @@
+SemverQuery(
+    id: "trait_default_impl_removed",
+    human_readable_name: "pub trait default method impl removed",
+    description: "A non-sealed public trait default method impl was removed.",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/book/ch10-02-traits.html#default-implementations"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        sealed @filter(op: "!=", value: ["$true"])
+                        name @output
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+                        method {
+                            method_name: name @output @tag
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+                            has_body @filter(op: "=", value: ["$true"])
+
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        sealed @filter(op: "!=", value: ["$true"])
+                        object_safe @filter(op: "=", value: ["$true"])
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+                        method {
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+                            name @filter(op: "=", value: ["%method_name"])
+                            has_body @filter(op: "!=", value: ["$true"])
+                            span_: span @optional {
+                                filename @output
+                                begin_line @output
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "true": true,
+        "public": "public",
+    },
+    error_message: "A trait's method default impl was removed, breaking users relying on the default impl",
+    per_result_error_template: Some("trait method <{{join \"::\" path}}>::{{method_name}} in file {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/lints/trait_default_impl_removed.ron
+++ b/src/lints/trait_default_impl_removed.ron
@@ -58,5 +58,5 @@ SemverQuery(
         "public": "public",
     },
     error_message: "A method's default impl in an unsealed trait has been removed, breaking trait implementations that relied on that default",
-    per_result_error_template: Some("trait method <{{join \"::\" path}}>::{{method_name}} in file {{span_filename}}:{{span_begin_line}}"),
+    per_result_error_template: Some("trait method {{join \"::\" path}}::{{method_name}} in file {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/lints/trait_default_impl_removed.ron
+++ b/src/lints/trait_default_impl_removed.ron
@@ -32,7 +32,6 @@ SemverQuery(
                 item {
                     ... on Trait {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        sealed @filter(op: "!=", value: ["$true"])
 
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
@@ -43,6 +42,7 @@ SemverQuery(
                             public_api_eligible @filter(op: "=", value: ["$true"])
                             name @filter(op: "=", value: ["%method_name"])
                             has_body @filter(op: "!=", value: ["$true"])
+
                             span_: span @optional {
                                 filename @output
                                 begin_line @output
@@ -57,6 +57,6 @@ SemverQuery(
         "true": true,
         "public": "public",
     },
-    error_message: "A trait's method default impl was removed, breaking users relying on the default impl",
+    error_message: "A method's default impl in an unsealed trait has been removed, breaking trait implementations that relied on that default",
     per_result_error_template: Some("trait method <{{join \"::\" path}}>::{{method_name}} in file {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/lints/trait_default_impl_removed.ron
+++ b/src/lints/trait_default_impl_removed.ron
@@ -1,7 +1,7 @@
 SemverQuery(
     id: "trait_default_impl_removed",
     human_readable_name: "pub trait default method impl removed",
-    description: "A non-sealed public trait default method impl was removed.",
+    description: "A non-sealed public trait default method impl was removed",
     required_update: Major,
     lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/book/ch10-02-traits.html#default-implementations"),
@@ -19,11 +19,11 @@ SemverQuery(
                             path @output @tag
                             public_api @filter(op: "=", value: ["$true"])
                         }
+
                         method {
                             method_name: name @output @tag
                             public_api_eligible @filter(op: "=", value: ["$true"])
                             has_body @filter(op: "=", value: ["$true"])
-
                         }
                     }
                 }
@@ -33,11 +33,12 @@ SemverQuery(
                     ... on Trait {
                         visibility_limit @filter(op: "=", value: ["$public"])
                         sealed @filter(op: "!=", value: ["$true"])
-                        object_safe @filter(op: "=", value: ["$true"])
+
                         importable_path {
                             path @filter(op: "=", value: ["%path"])
                             public_api @filter(op: "=", value: ["$true"])
                         }
+
                         method {
                             public_api_eligible @filter(op: "=", value: ["$true"])
                             name @filter(op: "=", value: ["%method_name"])

--- a/src/query.rs
+++ b/src/query.rs
@@ -835,6 +835,7 @@ add_lints!(
     struct_with_pub_fields_changed_type,
     trait_associated_const_now_doc_hidden,
     trait_associated_type_now_doc_hidden,
+    trait_default_impl_removed,
     trait_method_missing,
     trait_method_now_doc_hidden,
     trait_method_unsafe_added,

--- a/test_crates/trait_default_impl_removed/new/Cargo.toml
+++ b/test_crates/trait_default_impl_removed/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_default_impl_removed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_default_impl_removed/new/src/lib.rs
+++ b/test_crates/trait_default_impl_removed/new/src/lib.rs
@@ -3,7 +3,7 @@ pub trait TraitA {
     fn method_default_impl_removed(&self);
 }
 
-// Default trait method becomes  removed completely, should not be reported as it becomes
+// Default trait method becomes removed completely, should not be reported as it becomes
 // missing instead
 pub trait TraitB {}
 

--- a/test_crates/trait_default_impl_removed/new/src/lib.rs
+++ b/test_crates/trait_default_impl_removed/new/src/lib.rs
@@ -1,0 +1,13 @@
+// Default trait method impl is removed, should be reported
+pub trait TraitA {
+    fn method_default_impl_removed(&self);
+}
+
+// Default trait method becomes  removed completely, should not be reported as it becomes
+// missing instead.
+pub trait TraitB {}
+
+//Default trait method impl is removed, but its private, shouldnt be repoted
+trait TraitC {
+    fn method_default_impl_removed(&self);
+}

--- a/test_crates/trait_default_impl_removed/new/src/lib.rs
+++ b/test_crates/trait_default_impl_removed/new/src/lib.rs
@@ -1,3 +1,8 @@
+mod private {
+    pub trait Sealed {}
+    pub struct Token;
+}
+
 // Default trait method impl is removed, should be reported
 pub trait TraitA {
     fn method_default_impl_removed(&self);
@@ -7,12 +12,29 @@ pub trait TraitA {
 // missing instead
 pub trait TraitB {}
 
-//Default trait method impl is removed, but its private, shouldnt be reported
+// Default trait method impl is removed, but it's private, shouldn't be reported
 trait TraitC {
     fn method_default_impl_removed(&self);
 }
 
-// Non-object safe trait has its default impl removed, should be reported
+// Default trait method impl is removed, and becomes non-object-safe, should be reported
 pub trait TraitD {
-    fn method_becomes_non_obj_safe(&self) -> Self;
+    fn method_default_impl_removed_and_becomes_non_obj_safe(&self) -> Self;
+}
+
+// Default trait method impl is removed, and becomes sealed, should be reported
+pub trait TraitE {
+    fn method_default_impl_removed_and_becomes_sealed(&self, _: private::Token);
+}
+
+// Default trait method impl is removed, and it's partially sealed, should be reported
+pub trait TraitF {
+    fn method_partially_sealed_has_default_impl_removed(&self, _: private::Token);
+}
+
+// Default trait method impl is removed, but it's sealed. The fact that it's sealed dominates,
+// thus having its default impl removed is not a problem since it was never possible to
+// implement it, should not be reported
+pub trait TraitG: private::Sealed {
+    fn method_sealed_has_default_impl_removed(&self);
 }

--- a/test_crates/trait_default_impl_removed/new/src/lib.rs
+++ b/test_crates/trait_default_impl_removed/new/src/lib.rs
@@ -4,10 +4,15 @@ pub trait TraitA {
 }
 
 // Default trait method becomes  removed completely, should not be reported as it becomes
-// missing instead.
+// missing instead
 pub trait TraitB {}
 
-//Default trait method impl is removed, but its private, shouldnt be repoted
+//Default trait method impl is removed, but its private, shouldnt be reported
 trait TraitC {
     fn method_default_impl_removed(&self);
+}
+
+// Non-object safe trait has its default impl removed, should be reported
+pub trait TraitD {
+    fn method_becomes_non_obj_safe(&self) -> Self;
 }

--- a/test_crates/trait_default_impl_removed/old/Cargo.toml
+++ b/test_crates/trait_default_impl_removed/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_default_impl_removed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_default_impl_removed/old/src/lib.rs
+++ b/test_crates/trait_default_impl_removed/old/src/lib.rs
@@ -3,13 +3,18 @@ pub trait TraitA {
     fn method_default_impl_removed(&self) {}
 }
 
-// Default trait method becomes  removed completely, should not be reported as it becomes
-// missing instead.
+// Default trait method becomes removed completely, should not be reported as it becomes
+// missing instead
 pub trait TraitB {
     fn method_becomes_removed(&self) {}
 }
 
-//Default trait method impl is removed, but its private, shouldnt be repoted
+//Default trait method impl is removed, but its private, shouldnt be reported
 trait TraitC {
     fn method_default_impl_removed(&self) {}
+}
+
+// Non-object safe trait has its default impl removed, should be reported
+pub trait TraitD {
+    fn method_becomes_non_obj_safe(&self) {}
 }

--- a/test_crates/trait_default_impl_removed/old/src/lib.rs
+++ b/test_crates/trait_default_impl_removed/old/src/lib.rs
@@ -1,3 +1,8 @@
+mod private {
+    pub trait Sealed {}
+    pub struct Token;
+}
+
 // Default trait method impl is removed, should be reported
 pub trait TraitA {
     fn method_default_impl_removed(&self) {}
@@ -9,12 +14,29 @@ pub trait TraitB {
     fn method_becomes_removed(&self) {}
 }
 
-//Default trait method impl is removed, but its private, shouldnt be reported
+// Default trait method impl is removed, but it's private, shouldn't be reported
 trait TraitC {
     fn method_default_impl_removed(&self) {}
 }
 
-// Non-object safe trait has its default impl removed, should be reported
+// Default trait method impl is removed, and becomes non-object-safe, should be reported
 pub trait TraitD {
-    fn method_becomes_non_obj_safe(&self) {}
+    fn method_default_impl_removed_and_becomes_non_obj_safe(&self) {}
+}
+
+// Default trait method impl is removed, and becomes sealed, should be reported
+pub trait TraitE {
+    fn method_default_impl_removed_and_becomes_sealed(&self) {}
+}
+
+// Default trait method impl is removed, and it's partially sealed, should be reported
+pub trait TraitF {
+    fn method_partially_sealed_has_default_impl_removed(&self, _: private::Token) {}
+}
+
+// Default trait method impl is removed, but it's sealed. The fact that it's sealed dominates,
+// thus having its default impl removed is not a problem since it was never possible to
+// implement it, should not be reported
+pub trait TraitG: private::Sealed {
+    fn method_sealed_has_default_impl_removed(&self) {}
 }

--- a/test_crates/trait_default_impl_removed/old/src/lib.rs
+++ b/test_crates/trait_default_impl_removed/old/src/lib.rs
@@ -1,0 +1,15 @@
+// Default trait method impl is removed, should be reported
+pub trait TraitA {
+    fn method_default_impl_removed(&self) {}
+}
+
+// Default trait method becomes  removed completely, should not be reported as it becomes
+// missing instead.
+pub trait TraitB {
+    fn method_becomes_removed(&self) {}
+}
+
+//Default trait method impl is removed, but its private, shouldnt be repoted
+trait TraitC {
+    fn method_default_impl_removed(&self) {}
+}

--- a/test_outputs/trait_default_impl_removed.output.ron
+++ b/test_outputs/trait_default_impl_removed.output.ron
@@ -1,0 +1,15 @@
+{
+    "./test_crates/trait_default_impl_removed/": [
+        {
+            "method_name": String("method_default_impl_removed"),
+            "name": String("TraitA"),
+            "path": List([
+                String("trait_default_impl_removed"),
+                String("TraitA"),
+            ]),
+            "span_begin_line": Uint64(3),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+    ],
+}

--- a/test_outputs/trait_default_impl_removed.output.ron
+++ b/test_outputs/trait_default_impl_removed.output.ron
@@ -7,21 +7,43 @@
                 String("trait_default_impl_removed"),
                 String("TraitA"),
             ]),
-            "span_begin_line": Uint64(3),
+            "span_begin_line": Uint64(8),
             "span_filename": String("src/lib.rs"),
             "visibility_limit": String("public"),
         },
         {
-            "method_name": String("method_becomes_non_obj_safe"),
+            "method_name": String("method_default_impl_removed_and_becomes_non_obj_safe"),
             "name": String("TraitD"),
             "path": List([
                 String("trait_default_impl_removed"),
                 String("TraitD"),
             ]),
-            "span_begin_line": Uint64(17),
+            "span_begin_line": Uint64(22),
             "span_filename": String("src/lib.rs"),
             "visibility_limit": String("public"),
         },
+        {
+            "method_name": String("method_default_impl_removed_and_becomes_sealed"),
+            "name": String("TraitE"),
+            "path": List([
+                String("trait_default_impl_removed"),
+                String("TraitE"),
+            ]),
+            "span_begin_line": Uint64(27),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "method_name": String("method_partially_sealed_has_default_impl_removed"),
+            "name": String("TraitF"),
+            "path": List([
+                String("trait_default_impl_removed"),
+                String("TraitF"),
+            ]),
+            "span_begin_line": Uint64(32),
+             "span_filename": String("src/lib.rs"),
+             "visibility_limit": String("public"),
+         },
     ],
     "./test_crates/trait_no_longer_object_safe/": [
         {

--- a/test_outputs/trait_default_impl_removed.output.ron
+++ b/test_outputs/trait_default_impl_removed.output.ron
@@ -11,5 +11,29 @@
             "span_filename": String("src/lib.rs"),
             "visibility_limit": String("public"),
         },
+        {
+            "method_name": String("method_becomes_non_obj_safe"),
+            "name": String("TraitD"),
+            "path": List([
+                String("trait_default_impl_removed"),
+                String("TraitD"),
+            ]),
+            "span_begin_line": Uint64(17),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+    ],
+    "./test_crates/trait_no_longer_object_safe/": [
+        {
+            "method_name": String("by_ref"),
+            "name": String("RefTrait"),
+            "path": List([
+                String("trait_no_longer_object_safe"),
+                String("RefTrait"),
+            ]),
+            "span_begin_line": Uint64(3),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
     ],
 }

--- a/test_outputs/trait_method_missing.output.ron
+++ b/test_outputs/trait_method_missing.output.ron
@@ -7,7 +7,7 @@
                 String("trait_default_impl_removed"),
                 String("TraitB"),
             ]),
-            "span_begin_line": Uint64(9),
+            "span_begin_line": Uint64(14),
             "span_filename": String("src/lib.rs"),
             "visibility_limit": String("public"),
         },

--- a/test_outputs/trait_method_missing.output.ron
+++ b/test_outputs/trait_method_missing.output.ron
@@ -1,4 +1,17 @@
 {
+     "./test_crates/trait_default_impl_removed/": [
+        {
+            "method_name": String("method_becomes_removed"),
+            "name": String("TraitB"),
+            "path": List([
+                String("trait_default_impl_removed"),
+                String("TraitB"),
+            ]),
+            "span_begin_line": Uint64(9),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+    ],
     "./test_crates/trait_method_missing/": [
         {
             "method_name": String("fooA"),

--- a/test_outputs/trait_newly_sealed.output.ron
+++ b/test_outputs/trait_newly_sealed.output.ron
@@ -33,5 +33,27 @@
             "visibility_limit": String("public"),
         },
     ],
+    "./test_crates/trait_default_impl_removed/": [
+        {
+            "name": String("TraitE"),
+            "path": List([
+                String("trait_default_impl_removed"),
+                String("TraitE"),
+            ]),
+            "span_begin_line": Uint64(26),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("TraitF"),
+            "path": List([
+                String("trait_default_impl_removed"),
+                String("TraitF"),
+            ]),
+            "span_begin_line": Uint64(31),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+    ],
 }
 

--- a/test_outputs/trait_no_longer_object_safe.output.ron
+++ b/test_outputs/trait_no_longer_object_safe.output.ron
@@ -28,7 +28,7 @@
                 String("trait_default_impl_removed"),
                 String("TraitD"),
             ]),
-            "span_begin_line": Uint64(16),
+            "span_begin_line": Uint64(21),
             "span_filename": String("src/lib.rs"),
             "visibility_limit": String("public"),
         },

--- a/test_outputs/trait_no_longer_object_safe.output.ron
+++ b/test_outputs/trait_no_longer_object_safe.output.ron
@@ -21,6 +21,18 @@
             "visibility_limit": String("public"),
         },
     ],
+    "./test_crates/trait_default_impl_removed/": [
+        {
+            "name": String("TraitD"),
+            "path": List([
+                String("trait_default_impl_removed"),
+                String("TraitD"),
+            ]),
+            "span_begin_line": Uint64(16),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+    ],
     "./test_crates/trait_no_longer_object_safe/": [
         {
             "name": String("RefTrait"),


### PR DESCRIPTION
Should add another lint for #870, particularly `non-sealed trait removed a default impl for a trait method`. Fixes #294.

I am not sure if the `object_safe @filter(op: "=", value: ["$true"])` line is needed, since otherwise it would raise another lint. I thought that it could be a `False Positive`, since at least if i try it locally, I only get the `warning` if it returns `Self`, like so:

```rust
struct Test;
pub trait Trait {
    // fn method(&self) -> Self; #cargo complains about trait obj safety
    fn method(&self); # cargo is fine with it
}
impl Trait for Test {}
```

Anyways, otherwise any feedback happy to change. Thanks!
