### PR TITLE
Add snapshot test for when a workspace member's baseline has a compile error.

### DIFF
--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -140,7 +140,7 @@ fn assert_integration_test(test_name: &str, invocation: &[&str]) {
     std::env::remove_var("RUST_BACKTRACE");
     // remove the cargo verbosity variable, which gets passed to `cargo doc`
     // and may create a nonreproducible environment.
-    std::env::remove_var("CARGO_TERM_VERBOSE");
+    std::env::set_var("CARGO_TERM_VERBOSE", "false");
 
     let stdout = StaticWriter::new();
     let stderr = StaticWriter::new();

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -303,3 +303,25 @@ fn workspace_publish_false_workspace_flag() {
         ],
     )
 }
+
+/// When a workspace has a crate with a compile error in the baseline version
+/// and the user request to semver-check the `--workspace`, which has other workspace
+/// members that do not have compile errors.
+///
+/// Currently, the workspace `semver-checks` all non-error workspace members but returns
+/// an error at the end.
+#[test]
+fn workspace_baseline_compile_error() {
+    assert_integration_test(
+        "workspace_baseline_compile_error",
+        &[
+            "cargo",
+            "semver-checks",
+            "--baseline-root",
+            "test_crates/manifest_tests/workspace_baseline_compile_error/old",
+            "--manifest-path",
+            "test_crates/manifest_tests/workspace_baseline_compile_error/new",
+            "--workspace",
+        ],
+    );
+}

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -141,6 +141,7 @@ fn assert_integration_test(test_name: &str, invocation: &[&str]) {
     // remove the cargo verbosity variable, which gets passed to `cargo doc`
     // and may create a nonreproducible environment.
     std::env::set_var("CARGO_TERM_VERBOSE", "false");
+    std::env::set_var("CARGO_TERM_QUIET", "true");
 
     let stdout = StaticWriter::new();
     let stderr = StaticWriter::new();

--- a/test_crates/manifest_tests/workspace_baseline_compile_error/new/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_baseline_compile_error/new/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+resolver = "2"
+members = ["error", "no-error"]

--- a/test_crates/manifest_tests/workspace_baseline_compile_error/new/error/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_baseline_compile_error/new/error/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "error"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/workspace_baseline_compile_error/new/error/src/lib.rs
+++ b/test_crates/manifest_tests/workspace_baseline_compile_error/new/error/src/lib.rs
@@ -1,0 +1,5 @@
+//! Has a compile error in the baseline version,
+//! so we can't generate the rustdoc JSON to
+//! run semver-checks on
+// in baseline:
+// compile_error!("This crate has a compiler error.");

--- a/test_crates/manifest_tests/workspace_baseline_compile_error/new/no-error/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_baseline_compile_error/new/no-error/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "no-error"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/workspace_baseline_compile_error/new/no-error/src/lib.rs
+++ b/test_crates/manifest_tests/workspace_baseline_compile_error/new/no-error/src/lib.rs
@@ -1,0 +1,4 @@
+//! This crate removes the function `my_fn` in the new version
+//! which is a `function_missing` major semver error.
+// removed in new version:
+// pub fn my_fn() {}

--- a/test_crates/manifest_tests/workspace_baseline_compile_error/old/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_baseline_compile_error/old/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+resolver = "2"
+members = ["error", "no-error"]

--- a/test_crates/manifest_tests/workspace_baseline_compile_error/old/error/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_baseline_compile_error/old/error/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "error"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/workspace_baseline_compile_error/old/error/src/lib.rs
+++ b/test_crates/manifest_tests/workspace_baseline_compile_error/old/error/src/lib.rs
@@ -1,0 +1,4 @@
+//! Has a compile error in the baseline version,
+//! so we can't generate the rustdoc JSON to
+//! run semver-checks on
+compile_error!("This crate has a compiler error.");

--- a/test_crates/manifest_tests/workspace_baseline_compile_error/old/no-error/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_baseline_compile_error/old/no-error/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "no-error"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/workspace_baseline_compile_error/old/no-error/src/lib.rs
+++ b/test_crates/manifest_tests/workspace_baseline_compile_error/old/no-error/src/lib.rs
@@ -1,0 +1,3 @@
+//! This crate removes the function `my_fn` in the new version
+//! which is a `function_missing` major semver error.
+pub fn my_fn() {}

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_baseline_compile_error-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_baseline_compile_error-input.snap
@@ -1,0 +1,30 @@
+---
+source: src/snapshot_tests.rs
+expression: check
+---
+Check(
+  scope: Scope(
+    mode: DenyList(PackageSelection(
+      selection: Workspace,
+      excluded_packages: [],
+    )),
+  ),
+  current: Rustdoc(
+    source: Root("test_crates/manifest_tests/workspace_baseline_compile_error/new"),
+  ),
+  baseline: Rustdoc(
+    source: Root("test_crates/manifest_tests/workspace_baseline_compile_error/old"),
+  ),
+  release_type: None,
+  current_feature_config: FeatureConfig(
+    features_group: Heuristic,
+    extra_features: [],
+    is_baseline: false,
+  ),
+  baseline_feature_config: FeatureConfig(
+    features_group: Heuristic,
+    extra_features: [],
+    is_baseline: true,
+  ),
+  build_target: None,
+)

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_baseline_compile_error-output.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_baseline_compile_error-output.snap
@@ -1,0 +1,6 @@
+---
+source: src/snapshot_tests.rs
+expression: result
+---
+--- error ---
+aborting due to failure to build rustdoc for crate error v0.1.0

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_baseline_compile_error-output.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_baseline_compile_error-output.snap
@@ -4,3 +4,51 @@ expression: result
 ---
 --- error ---
 aborting due to failure to build rustdoc for crate error v0.1.0
+--- stdout ---
+
+--- failure function_missing: pub fn removed or renamed ---
+
+Description:
+A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.34.0/src/lints/function_missing.ron
+
+Failed in:
+  function no_error::my_fn, previously in file [ROOT]/test_crates/manifest_tests/workspace_baseline_compile_error/old/no-error/src/lib.rs:3
+
+--- stderr ---
+     Parsing error v0.1.0 (current)
+      Parsed [TIME] (current)
+     Parsing error v0.1.0 (baseline)
+error: running cargo-doc on crate error failed with output:
+-----
+ Documenting error v0.1.0 ([ROOT]/test_crates/manifest_tests/workspace_baseline_compile_error/old/error)
+error: This crate has a compiler error.
+ --> [ROOT]/test_crates/manifest_tests/workspace_baseline_compile_error/old/error/src/lib.rs:4:1
+  |
+4 | compile_error!("This crate has a compiler error.");
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: could not document `error`
+
+-----
+
+error: failed to build rustdoc for crate error v0.1.0
+note: this is usually due to a compilation error in the crate,
+      and is unlikely to be a bug in cargo-semver-checks
+note: the following command can be used to reproduce the compilation error:
+      cargo new --lib example &&
+          cd example &&
+          echo '[workspace]' >> Cargo.toml &&
+          cargo add --path test_crates/manifest_tests/workspace_baseline_compile_error/old/error --no-default-features &&
+          cargo check
+
+     Parsing no-error v0.1.0 (current)
+      Parsed [TIME] (current)
+     Parsing no-error v0.1.0 (baseline)
+      Parsed [TIME] (baseline)
+    Checking no-error v0.1.0 -> v0.1.0 (no change)
+     Checked [TIME] [TOTAL] checks: [PASS] pass, 1 fail, 0 warn, 0 skip
+
+     Summary semver requires new major version: 1 major and 0 minor checks failed
+    Finished [TIME] no-error


### PR DESCRIPTION
When the user runs `cargo semver-checks --workspace` on a workspace that has a member with a baseline version with a compile error, but other non-error workspace members.

The current behavior is to semver-check the members it can, and then return an error at the end saying it couldn't compile the errored crate.

Potential other tests: 

- when the current version has a compile error
- when no crates in the workspace can be built because their current/baseline versions all have compile errors
