### PR TITLE
Add handling of ambiguous package definitions within the same dir.

### DIFF
--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -336,3 +336,29 @@ fn workspace_baseline_compile_error() {
         ],
     );
 }
+
+/// Pin down the behavior when running `cargo-semver-checks` on a project that
+/// for some reason contains multiple definitions of the same package name
+/// in different workspaces in the same directory.
+///
+/// The current behavior *is not* necessarily preferable in the long term, and may change.
+/// It looks through all `Cargo.toml` files in the directory and accumulates everything they define.
+///
+/// In the long run, we may want to use something like `cargo locate-project` to determine
+/// which workspace we're currently "inside" and only load its manifests.
+/// This approach is described here:
+/// <https://github.com/obi1kenobi/cargo-semver-checks/issues/462#issuecomment-1569413532>
+#[test]
+fn multiple_ambiguous_package_name_definitions() {
+    assert_integration_test(
+        "multiple_ambiguous_package_name_definitions",
+        &[
+            "cargo",
+            "semver-checks",
+            "--baseline-root",
+            "test_crates/manifest_tests/multiple_ambiguous_package_name_definitions",
+            "--manifest-path",
+            "test_crates/manifest_tests/multiple_ambiguous_package_name_definitions",
+        ],
+    );
+}

--- a/test_crates/manifest_tests/multiple_ambiguous_package_name_definitions/Cargo.toml
+++ b/test_crates/manifest_tests/multiple_ambiguous_package_name_definitions/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+resolver = "2"
+
+[package]
+name = "example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/multiple_ambiguous_package_name_definitions/nested/Cargo.toml
+++ b/test_crates/manifest_tests/multiple_ambiguous_package_name_definitions/nested/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+resolver = "2"
+
+[package]
+name = "example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/multiple_ambiguous_package_name_definitions/nested/src/lib.rs
+++ b/test_crates/manifest_tests/multiple_ambiguous_package_name_definitions/nested/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/test_crates/manifest_tests/multiple_ambiguous_package_name_definitions/src/lib.rs
+++ b/test_crates/manifest_tests/multiple_ambiguous_package_name_definitions/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__multiple_ambiguous_package_name_definitions-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__multiple_ambiguous_package_name_definitions-input.snap
@@ -1,0 +1,30 @@
+---
+source: src/snapshot_tests.rs
+expression: check
+---
+Check(
+  scope: Scope(
+    mode: DenyList(PackageSelection(
+      selection: DefaultMembers,
+      excluded_packages: [],
+    )),
+  ),
+  current: Rustdoc(
+    source: Root("test_crates/manifest_tests/multiple_ambiguous_package_name_definitions"),
+  ),
+  baseline: Rustdoc(
+    source: Root("test_crates/manifest_tests/multiple_ambiguous_package_name_definitions"),
+  ),
+  release_type: None,
+  current_feature_config: FeatureConfig(
+    features_group: Heuristic,
+    extra_features: [],
+    is_baseline: false,
+  ),
+  baseline_feature_config: FeatureConfig(
+    features_group: Heuristic,
+    extra_features: [],
+    is_baseline: true,
+  ),
+  build_target: None,
+)

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__multiple_ambiguous_package_name_definitions-output.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__multiple_ambiguous_package_name_definitions-output.snap
@@ -1,0 +1,13 @@
+---
+source: src/snapshot_tests.rs
+expression: result
+---
+--- error ---
+package `example` is ambiguous: it is defined by in multiple manifests within the root path test_crates/manifest_tests/multiple_ambiguous_package_name_definitions
+
+defined in:
+  test_crates/manifest_tests/multiple_ambiguous_package_name_definitions/Cargo.toml
+  test_crates/manifest_tests/multiple_ambiguous_package_name_definitions/nested/Cargo.toml
+--- stdout ---
+
+--- stderr ---


### PR DESCRIPTION
Instead of corrupting our data and possibly raising an unrelated error, `cargo-semver-checks` now explicitly checks if any of the package names in the same directory tree are defined by more than one manifest, and raises an appropriate error:

```
error: package `example` is ambiguous: it is defined by in multiple manifests within the root path .

defined in:
  ./Cargo.toml
  ./nested/Cargo.toml
```