### PR TITLE
feat: add trait_associated_const_default_removed lint

### DIFF
--- a/src/lints/trait_associated_const_default_removed.ron
+++ b/src/lints/trait_associated_const_default_removed.ron
@@ -1,0 +1,60 @@
+SemverQuery(
+    id: "trait_associated_const_default_removed",
+    human_readable_name: "non-sealed trait removed the default value for an associated constant",
+    description: "A non-sealed trait associated constant lost its default value, which breaks downstream implementations of the trait",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: None, // TODO
+    query: r#"
+    {
+        CrateDiff {
+            current {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        associated_constant {
+                            associated_constant: name @output @tag
+                            default @filter(op: "is_null") @output
+
+                            span_: span @optional {
+                               filename @output
+                               begin_line @output
+                            }
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        sealed @filter(op: "!=", value: ["$true"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        associated_constant @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            name @filter(op: "=", value: ["%associated_constant"])
+                            default @filter(op: "is_not_null")
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+        "zero": 0,
+    },
+    error_message: "TODO",
+    per_result_error_template: Some("TODO"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -834,6 +834,7 @@ add_lints!(
     struct_repr_transparent_removed,
     struct_with_pub_fields_changed_type,
     trait_associated_const_added,
+    trait_associated_const_default_removed,
     trait_associated_const_now_doc_hidden,
     trait_associated_type_now_doc_hidden,
     trait_default_impl_removed,

--- a/test_crates/trait_associated_const_default_removed/new/Cargo.toml
+++ b/test_crates/trait_associated_const_default_removed/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_associated_const_default_removed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_associated_const_default_removed/new/src/lib.rs
+++ b/test_crates/trait_associated_const_default_removed/new/src/lib.rs
@@ -1,0 +1,55 @@
+mod sealed {
+    pub(crate) trait Sealed {}
+}
+
+pub trait WillLoseDefault {
+    const ONE: bool;
+    fn make_me_non_object_safe() -> Self;
+}
+
+pub trait WillLoseDefaultSealed: sealed::Sealed {
+    const ONE: bool;
+
+    fn make_me_non_object_safe() -> Self;
+}
+// pub trait WillLostDefaultAndGainSeal {
+//     fn make_me_non_object_safe() -> Self;
+// }
+
+pub trait Unchanged {
+    const ONE: bool = true;
+
+    fn make_me_non_object_safe() -> Self;
+}
+pub trait UnchangedSealed: sealed::Sealed {
+    const ONE: bool = true;
+
+    fn make_me_non_object_safe() -> Self;
+}
+
+pub trait UnchangedNoDefault {
+    const ONE: bool;
+
+    fn make_me_non_object_safe() -> Self;
+}
+pub trait UnchangedNoDefaultSealed: sealed::Sealed {
+    const ONE: bool;
+
+    fn make_me_non_object_safe() -> Self;
+}
+
+// pub trait WillGainADocHiddenConst {
+//     fn make_me_non_object_safe() -> Self;
+// }
+
+// pub trait ConstWithoutDefaultUnchanged {
+//     const BAR: bool;
+
+//     fn make_me_non_object_safe() -> Self;
+// }
+// pub trait ConstDocHidden {
+//     #[doc(hidden)]
+//     const BAR: bool = true;
+
+//     fn make_me_non_object_safe() -> Self;
+// }

--- a/test_crates/trait_associated_const_default_removed/old/Cargo.toml
+++ b/test_crates/trait_associated_const_default_removed/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_associated_const_default_removed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_associated_const_default_removed/old/src/lib.rs
+++ b/test_crates/trait_associated_const_default_removed/old/src/lib.rs
@@ -1,0 +1,56 @@
+mod sealed {
+    pub(crate) trait Sealed {}
+}
+
+pub trait WillLoseDefault {
+    const ONE: bool = true;
+
+    fn make_me_non_object_safe() -> Self;
+}
+
+pub trait WillLoseDefaultSealed: sealed::Sealed {
+    const ONE: bool = true;
+
+    fn make_me_non_object_safe() -> Self;
+}
+// pub trait WillLostDefaultAndGainSeal {
+//     fn make_me_non_object_safe() -> Self;
+// }
+
+pub trait Unchanged {
+    const ONE: bool = true;
+
+    fn make_me_non_object_safe() -> Self;
+}
+pub trait UnchangedSealed: sealed::Sealed {
+    const ONE: bool = true;
+
+    fn make_me_non_object_safe() -> Self;
+}
+
+pub trait UnchangedNoDefault {
+    const ONE: bool;
+
+    fn make_me_non_object_safe() -> Self;
+}
+pub trait UnchangedNoDefaultSealed: sealed::Sealed {
+    const ONE: bool;
+
+    fn make_me_non_object_safe() -> Self;
+}
+
+// pub trait WillGainADocHiddenConst {
+//     fn make_me_non_object_safe() -> Self;
+// }
+
+// pub trait ConstWithoutDefaultUnchanged {
+//     const BAR: bool;
+
+//     fn make_me_non_object_safe() -> Self;
+// }
+// pub trait ConstDocHidden {
+//     #[doc(hidden)]
+//     const BAR: bool = true;
+
+//     fn make_me_non_object_safe() -> Self;
+// }

--- a/test_outputs/trait_associated_const_default_removed.output.ron
+++ b/test_outputs/trait_associated_const_default_removed.output.ron
@@ -1,0 +1,5 @@
+{
+    "./test_crates/trait_associated_const_default_removed/": [
+        // TODO
+    ]
+}


### PR DESCRIPTION
Lint for "non-sealed trait removed the default value for an associated constant"

See https://github.com/obi1kenobi/cargo-semver-checks/issues/870

I still haven't fully made myself of a mental model of how to create queries. Here's a starting point. The query I made matches another test with incoherent results.