### PR TITLE
feat: add trait_associated_type_default_removed lint

### DIFF
--- a/src/lints/trait_associated_type_default_removed.ron
+++ b/src/lints/trait_associated_type_default_removed.ron
@@ -1,0 +1,59 @@
+SemverQuery(
+    id: "trait_associated_type_default_removed",
+    human_readable_name: "non-sealed trait removed the default value for an associated type",
+    description: "A non-sealed trait associated type lost its default value, which breaks downstream implementations of the trait",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature"),
+    query: r#"
+    {
+        CrateDiff {
+            current {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        associated_type {
+                            associated_type: name @output @tag
+                            has_default @filter(op: "!=", value: ["$true"]) @output
+
+                            span_: span @optional {
+                               filename @output
+                               begin_line @output
+                            }
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        sealed @filter(op: "!=", value: ["$true"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        associated_type {
+                            name @filter(op: "=", value: ["%associated_type"])
+                            has_default @filter(op: "=", value: ["$true"])
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+    },
+    error_message: "A non-sealed trait associated type lost its default value, which breaks downstream implementations of the trait",
+    per_result_error_template: Some("trait type {{join \"::\" path}}::{{associated_type}} in file {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -837,6 +837,7 @@ add_lints!(
     trait_associated_const_default_removed,
     trait_associated_const_now_doc_hidden,
     trait_associated_type_added,
+    trait_associated_type_default_removed,
     trait_associated_type_now_doc_hidden,
     trait_default_impl_removed,
     trait_method_missing,

--- a/test_crates/trait_associated_type_default_removed/new/Cargo.toml
+++ b/test_crates/trait_associated_type_default_removed/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_associated_type_default_removed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_associated_type_default_removed/new/src/lib.rs
+++ b/test_crates/trait_associated_type_default_removed/new/src/lib.rs
@@ -1,0 +1,25 @@
+mod sealed {
+    pub(crate) trait Sealed {}
+}
+
+pub trait WillLoseDefault {
+    type Foo;
+}
+
+pub trait WillLoseDefaultSealed: sealed::Sealed {
+    type Foo;
+}
+
+pub trait Unchanged {
+    type Foo = bool;
+}
+pub trait UnchangedSealed: sealed::Sealed {
+    type Foo = bool;
+}
+
+pub trait UnchangedNoDefault {
+    type Foo;
+}
+pub trait UnchangedNoDefaultSealed: sealed::Sealed {
+    type Foo;
+}

--- a/test_crates/trait_associated_type_default_removed/new/src/lib.rs
+++ b/test_crates/trait_associated_type_default_removed/new/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(associated_type_defaults)]
+
 mod sealed {
     pub(crate) trait Sealed {}
 }

--- a/test_crates/trait_associated_type_default_removed/old/Cargo.toml
+++ b/test_crates/trait_associated_type_default_removed/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_associated_type_default_removed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_associated_type_default_removed/old/src/lib.rs
+++ b/test_crates/trait_associated_type_default_removed/old/src/lib.rs
@@ -1,0 +1,25 @@
+mod sealed {
+    pub(crate) trait Sealed {}
+}
+
+pub trait WillLoseDefault {
+    type Foo = bool;
+}
+
+pub trait WillLoseDefaultSealed: sealed::Sealed {
+    type Foo = bool;
+}
+
+pub trait Unchanged {
+    type Foo = bool;
+}
+pub trait UnchangedSealed: sealed::Sealed {
+    type Foo = bool;
+}
+
+pub trait UnchangedNoDefault {
+    type Foo;
+}
+pub trait UnchangedNoDefaultSealed: sealed::Sealed {
+    type Foo;
+}

--- a/test_crates/trait_associated_type_default_removed/old/src/lib.rs
+++ b/test_crates/trait_associated_type_default_removed/old/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(associated_type_defaults)]
+
 mod sealed {
     pub(crate) trait Sealed {}
 }

--- a/test_outputs/trait_associated_type_default_removed.output.ron
+++ b/test_outputs/trait_associated_type_default_removed.output.ron
@@ -1,5 +1,15 @@
 {
     "./test_crates/trait_associated_type_default_removed/": [
-        // TODO
-    ]
+        {
+            "associated_type": String("Foo"),
+            "has_default": Boolean(false),
+            "path": List([
+                String("trait_associated_type_default_removed"),
+                String("WillLoseDefault"),
+            ]),
+            "span_begin_line": Uint64(8),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+    ],
 }

--- a/test_outputs/trait_associated_type_default_removed.output.ron
+++ b/test_outputs/trait_associated_type_default_removed.output.ron
@@ -1,0 +1,5 @@
+{
+    "./test_crates/trait_associated_type_default_removed/": [
+        // TODO
+    ]
+}


### PR DESCRIPTION
Lint for "non-sealed trait removed the default value for an associated type"

See https://github.com/obi1kenobi/cargo-semver-checks/issues/870

It seems like "associated type defaults" are a nightly feature (see tracking issue https://github.com/rust-lang/rust/issues/29661). Does `cargo-semver-checks` support nightly features. Am I just wrong on what feature this lint should test?