### PR TITLE
feat: add `trait_added_supertrait`

### DIFF
--- a/src/lints/trait_added_supertrait.ron
+++ b/src/lints/trait_added_supertrait.ron
@@ -1,0 +1,58 @@
+SemverQuery(
+    id: "trait_added_supertrait",
+    human_readable_name: "non-sealed trait added new supertraits",
+    description: "A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: None, // TODO
+    query: r#"
+    {
+        CrateDiff {
+            current {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        supertrait {
+                            supertrait: name @output @tag
+                        }
+
+                        span_: span @optional {
+                           filename @output
+                           begin_line @output
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        sealed @filter(op: "!=", value: ["$true"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        supertrait @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            name @filter(op: "=", value: ["%supertrait"])
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+        "zero": 0,
+    },
+    error_message: "A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait",
+    per_result_error_template: Some("trait {{join \"::\" path}} has gained {{supertrait}} in file {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/lints/trait_added_supertrait.ron
+++ b/src/lints/trait_added_supertrait.ron
@@ -4,7 +4,7 @@ SemverQuery(
     description: "A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait",
     required_update: Major,
     lint_level: Deny,
-    reference_link: Some("doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten"),
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten"),
     query: r#"
     {
         CrateDiff {

--- a/src/lints/trait_added_supertrait.ron
+++ b/src/lints/trait_added_supertrait.ron
@@ -4,7 +4,7 @@ SemverQuery(
     description: "A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait",
     required_update: Major,
     lint_level: Deny,
-    reference_link: None, // TODO
+    reference_link: Some("doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten"),
     query: r#"
     {
         CrateDiff {
@@ -54,5 +54,5 @@ SemverQuery(
         "zero": 0,
     },
     error_message: "A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait",
-    per_result_error_template: Some("trait {{join \"::\" path}} has gained {{supertrait}} in file {{span_filename}}:{{span_begin_line}}"),
+    per_result_error_template: Some("trait {{join \"::\" path}} gained {{supertrait}} in file {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/query.rs
+++ b/src/query.rs
@@ -1077,6 +1077,7 @@ add_lints!(
     struct_pub_field_now_doc_hidden,
     struct_repr_transparent_removed,
     struct_with_pub_fields_changed_type,
+    trait_added_supertrait,
     trait_associated_const_added,
     trait_associated_const_default_removed,
     trait_associated_const_now_doc_hidden,

--- a/test_crates/trait_added_supertrait/new/Cargo.toml
+++ b/test_crates/trait_added_supertrait/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_added_supertrait"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_added_supertrait/new/src/lib.rs
+++ b/test_crates/trait_added_supertrait/new/src/lib.rs
@@ -19,3 +19,5 @@ pub trait WillGainStdTwo: core::fmt::Debug {}
 pub trait WillGainStdThree: PartialEq {
     fn make_me_non_object_safe() -> Self;
 }
+
+pub trait WillChangeStdToCore: core::fmt::Debug {}

--- a/test_crates/trait_added_supertrait/new/src/lib.rs
+++ b/test_crates/trait_added_supertrait/new/src/lib.rs
@@ -1,15 +1,21 @@
+pub trait TraitOne {}
+pub trait TraitTwo {}
+
 mod sealed {
     pub trait Sealed {}
 }
 
-pub trait TraitOne {}
-pub trait TraitTwo {}
-
 pub trait Unchanged {}
 pub trait UnchangedSealed: sealed::Sealed {}
 
-pub trait WillGailOne: TraitOne {}
-pub trait WillGailOneSealed: TraitOne + sealed::Sealed {}
+pub trait WillGainOne: TraitOne {}
+pub trait WillGainOneSealed: TraitOne + sealed::Sealed {}
 
-pub trait WillGailAnotherOne: TraitOne + TraitTwo {}
-pub trait WillGailAnotherOneSealed: TraitOne + TraitTwo + sealed::Sealed {}
+pub trait WillGainAnotherOne: TraitOne + TraitTwo {}
+pub trait WillGainAnotherOneSealed: TraitOne + TraitTwo + sealed::Sealed {}
+
+pub trait WillGainStdOne: Sync {}
+pub trait WillGainStdTwo: core::fmt::Debug {}
+pub trait WillGainStdThree: PartialEq {
+    fn make_me_non_object_safe() -> Self;
+}

--- a/test_crates/trait_added_supertrait/new/src/lib.rs
+++ b/test_crates/trait_added_supertrait/new/src/lib.rs
@@ -1,0 +1,15 @@
+mod sealed {
+    pub trait Sealed {}
+}
+
+pub trait TraitOne {}
+pub trait TraitTwo {}
+
+pub trait Unchanged {}
+pub trait UnchangedSealed: sealed::Sealed {}
+
+pub trait WillGailOne: TraitOne {}
+pub trait WillGailOneSealed: TraitOne + sealed::Sealed {}
+
+pub trait WillGailAnotherOne: TraitOne + TraitTwo {}
+pub trait WillGailAnotherOneSealed: TraitOne + TraitTwo + sealed::Sealed {}

--- a/test_crates/trait_added_supertrait/old/Cargo.toml
+++ b/test_crates/trait_added_supertrait/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_added_supertrait"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_added_supertrait/old/src/lib.rs
+++ b/test_crates/trait_added_supertrait/old/src/lib.rs
@@ -1,15 +1,21 @@
+pub trait TraitOne {}
+pub trait TraitTwo {}
+
 mod sealed {
     pub trait Sealed {}
 }
 
-pub trait TraitOne {}
-pub trait TraitTwo {}
-
 pub trait Unchanged {}
 pub trait UnchangedSealed: sealed::Sealed {}
 
-pub trait WillGailOne {}
-pub trait WillGailOneSealed: sealed::Sealed {}
+pub trait WillGainOne {}
+pub trait WillGainOneSealed: sealed::Sealed {}
 
-pub trait WillGailAnotherOne: TraitOne {}
-pub trait WillGailAnotherOneSealed: TraitOne + sealed::Sealed {}
+pub trait WillGainAnotherOne: TraitOne {}
+pub trait WillGainAnotherOneSealed: TraitOne + sealed::Sealed {}
+
+pub trait WillGainStdOne {}
+pub trait WillGainStdTwo {}
+pub trait WillGainStdThree {
+    fn make_me_non_object_safe() -> Self;
+}

--- a/test_crates/trait_added_supertrait/old/src/lib.rs
+++ b/test_crates/trait_added_supertrait/old/src/lib.rs
@@ -19,3 +19,5 @@ pub trait WillGainStdTwo {}
 pub trait WillGainStdThree {
     fn make_me_non_object_safe() -> Self;
 }
+
+pub trait WillChangeStdToCore: std::fmt::Debug {}

--- a/test_crates/trait_added_supertrait/old/src/lib.rs
+++ b/test_crates/trait_added_supertrait/old/src/lib.rs
@@ -1,0 +1,15 @@
+mod sealed {
+    pub trait Sealed {}
+}
+
+pub trait TraitOne {}
+pub trait TraitTwo {}
+
+pub trait Unchanged {}
+pub trait UnchangedSealed: sealed::Sealed {}
+
+pub trait WillGailOne {}
+pub trait WillGailOneSealed: sealed::Sealed {}
+
+pub trait WillGailAnotherOne: TraitOne {}
+pub trait WillGailAnotherOneSealed: TraitOne + sealed::Sealed {}

--- a/test_outputs/trait_added_supertrait.output.ron
+++ b/test_outputs/trait_added_supertrait.output.ron
@@ -20,6 +20,36 @@
             "supertrait": String("TraitTwo"),
             "visibility_limit": String("public"),
         },
+        {
+            "path": List([
+                String("trait_added_supertrait"),
+                String("WillGainStdOne"),
+            ]),
+            "span_begin_line": Uint64(17),
+            "span_filename": String("src/lib.rs"),
+            "supertrait": String("Sync"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "path": List([
+                String("trait_added_supertrait"),
+                String("WillGainStdTwo"),
+            ]),
+            "span_begin_line": Uint64(18),
+            "span_filename": String("src/lib.rs"),
+            "supertrait": String("Debug"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "path": List([
+                String("trait_added_supertrait"),
+                String("WillGainStdThree"),
+            ]),
+            "span_begin_line": Uint64(19),
+            "span_filename": String("src/lib.rs"),
+            "supertrait": String("PartialEq"),
+            "visibility_limit": String("public"),
+        },
     ],
     "./test_crates/trait_associated_const_added/": [
         {
@@ -29,7 +59,7 @@
             ]),
             "span_begin_line": Uint64(16),
             "span_filename": String("src/lib.rs"),
-            "supertrait": String("sealed::Sealed"),
+            "supertrait": String("Sealed"),
             "visibility_limit": String("public"),
         },
     ],
@@ -41,7 +71,19 @@
             ]),
             "span_begin_line": Uint64(19),
             "span_filename": String("src/lib.rs"),
-            "supertrait": String("sealed::Sealed"),
+            "supertrait": String("Sealed"),
+            "visibility_limit": String("public"),
+        },
+    ],
+    "./test_crates/trait_method_added/": [
+        {
+            "path": List([
+                String("trait_method_added"),
+                String("WillGainMethodWithoutDefaultAndSeal"),
+            ]),
+            "span_begin_line": Uint64(20),
+            "span_filename": String("src/lib.rs"),
+            "supertrait": String("Sealed"),
             "visibility_limit": String("public"),
         },
     ],
@@ -53,7 +95,7 @@
             ]),
             "span_begin_line": Uint64(7),
             "span_filename": String("src/lib.rs"),
-            "supertrait": String("private::Sealed"),
+            "supertrait": String("Sealed"),
             "visibility_limit": String("public"),
         },
     ],

--- a/test_outputs/trait_added_supertrait.output.ron
+++ b/test_outputs/trait_added_supertrait.output.ron
@@ -3,7 +3,7 @@
         {
             "path": List([
                 String("trait_added_supertrait"),
-                String("WillGailOne"),
+                String("WillGainOne"),
             ]),
             "span_begin_line": Uint64(11),
             "span_filename": String("src/lib.rs"),
@@ -13,7 +13,7 @@
         {
             "path": List([
                 String("trait_added_supertrait"),
-                String("WillGailAnotherOne"),
+                String("WillGainAnotherOne"),
             ]),
             "span_begin_line": Uint64(14),
             "span_filename": String("src/lib.rs"),

--- a/test_outputs/trait_added_supertrait.output.ron
+++ b/test_outputs/trait_added_supertrait.output.ron
@@ -1,0 +1,60 @@
+{
+    "./test_crates/trait_added_supertrait/": [
+        {
+            "path": List([
+                String("trait_added_supertrait"),
+                String("WillGailOne"),
+            ]),
+            "span_begin_line": Uint64(11),
+            "span_filename": String("src/lib.rs"),
+            "supertrait": String("TraitOne"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "path": List([
+                String("trait_added_supertrait"),
+                String("WillGailAnotherOne"),
+            ]),
+            "span_begin_line": Uint64(14),
+            "span_filename": String("src/lib.rs"),
+            "supertrait": String("TraitTwo"),
+            "visibility_limit": String("public"),
+        },
+    ],
+    "./test_crates/trait_associated_const_added/": [
+        {
+            "path": List([
+                String("trait_associated_const_added"),
+                String("WillGainConstWithoutDefaultAndSeal"),
+            ]),
+            "span_begin_line": Uint64(16),
+            "span_filename": String("src/lib.rs"),
+            "supertrait": String("sealed::Sealed"),
+            "visibility_limit": String("public"),
+        },
+    ],
+    "./test_crates/trait_associated_type_added/": [
+        {
+            "path": List([
+                String("trait_associated_type_added"),
+                String("WillGainTypeWithoutDefaultAndSeal"),
+            ]),
+            "span_begin_line": Uint64(19),
+            "span_filename": String("src/lib.rs"),
+            "supertrait": String("sealed::Sealed"),
+            "visibility_limit": String("public"),
+        },
+    ],
+    "./test_crates/trait_newly_sealed/": [
+        {
+            "path": List([
+                String("trait_newly_sealed"),
+                String("TraitBecomesSealed"),
+            ]),
+            "span_begin_line": Uint64(7),
+            "span_filename": String("src/lib.rs"),
+            "supertrait": String("private::Sealed"),
+            "visibility_limit": String("public"),
+        },
+    ],
+}


### PR DESCRIPTION
Lint for "non-sealed trait added new supertraits"

See https://github.com/obi1kenobi/cargo-semver-checks/issues/870
Closes #441 

I blessed the tests, but it makes duplicate reports for `trait_newly_sealed` (as sealing a trait requires adding a supertrait) which may be annoying.