### PR TITLE
Enum unit variant changed kind

### DIFF
--- a/src/lints/enum_unit_variant_changed_kind.ron
+++ b/src/lints/enum_unit_variant_changed_kind.ron
@@ -1,0 +1,69 @@
+SemverQuery(
+    id: "enum_unit_variant_changed_kind",
+    human_readable_name: "An enum unit variant changed kind",
+    description: "A public enum unit variant that isn't #[non_exhaustive] changed kind",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: None,
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Enum {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        enum_name: name @output @tag
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        variant {
+                            ... on PlainVariant {
+                                kind: __typename @output @tag
+
+                                attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
+
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+
+                                variant_name: name @output @tag
+                            }
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Enum {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @filter(op: "=", value: ["%enum_name"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        variant {
+                            name @filter(op: "=", value: ["%variant_name"])
+                            attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+                            new_kind: __typename @filter(op: "!=", value: ["%kind"])   
+                            span_: span @optional {
+                                filename @output
+                                begin_line @output
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+        "non_exhaustive": "#[non_exhaustive]",
+    },
+    error_message: "A public enum's exhaustive unit variant has changed kind, breaking possible instantiations and patterns.",
+    per_result_error_template: Some("variant {{enum_name}}::{{variant_name}} in {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/lints/enum_unit_variant_changed_kind.ron
+++ b/src/lints/enum_unit_variant_changed_kind.ron
@@ -4,7 +4,7 @@ SemverQuery(
     description: "A public enum unit variant that isn't #[non_exhaustive] changed kind",
     required_update: Major,
     lint_level: Deny,
-    reference_link: None,
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new"),
     query: r#"
     {
         CrateDiff {
@@ -22,11 +22,8 @@ SemverQuery(
                         variant {
                             ... on PlainVariant {
                                 kind: __typename @output @tag
-
                                 attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
-
                                 public_api_eligible @filter(op: "=", value: ["$true"])
-
                                 variant_name: name @output @tag
                             }
                         }
@@ -49,6 +46,7 @@ SemverQuery(
                             attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
                             public_api_eligible @filter(op: "=", value: ["$true"])
                             new_kind: __typename @filter(op: "!=", value: ["%kind"])   
+                           
                             span_: span @optional {
                                 filename @output
                                 begin_line @output

--- a/src/lints/enum_unit_variant_changed_kind.ron
+++ b/src/lints/enum_unit_variant_changed_kind.ron
@@ -4,7 +4,9 @@ SemverQuery(
     description: "A public enum unit variant that isn't #[non_exhaustive] changed kind",
     required_update: Major,
     lint_level: Deny,
-    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new"),
+    // TODO: If the Rust reference gains a more detailed explanation of enum *variants*,
+    //       switch the explanation to point there instead. The current link isn't great.
+    reference_link: Some("https://doc.rust-lang.org/reference/items/enumerations.html"),
     query: r#"
     {
         CrateDiff {
@@ -41,10 +43,12 @@ SemverQuery(
                             public_api @filter(op: "=", value: ["$true"])
                         }
 
+                        # Don't check for exhaustiveness and public API eligibility here.
+                        # Variants that changed kind and gained #[doc(hidden)] should
+                        # report for both lints, since there is no implied continuity
+                        # between the old variant and the new one with the same name.   
                         variant {
                             name @filter(op: "=", value: ["%variant_name"])
-                            attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
-                            public_api_eligible @filter(op: "=", value: ["$true"])
                             new_kind: __typename @filter(op: "!=", value: ["%kind"]) @output   
                            
                             span_: span @optional {
@@ -62,6 +66,6 @@ SemverQuery(
         "true": true,
         "non_exhaustive": "#[non_exhaustive]",
     },
-    error_message: "A public enum's exhaustive unit variant has changed kind, breaking possible instantiations and patterns.",
+    error_message: "A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.",
     per_result_error_template: Some("variant {{enum_name}}::{{variant_name}} in {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/lints/enum_unit_variant_changed_kind.ron
+++ b/src/lints/enum_unit_variant_changed_kind.ron
@@ -45,7 +45,7 @@ SemverQuery(
                             name @filter(op: "=", value: ["%variant_name"])
                             attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
                             public_api_eligible @filter(op: "=", value: ["$true"])
-                            new_kind: __typename @filter(op: "!=", value: ["%kind"])   
+                            new_kind: __typename @filter(op: "!=", value: ["%kind"]) @output   
                            
                             span_: span @optional {
                                 filename @output

--- a/src/lints/enum_unit_variant_changed_kind.ron
+++ b/src/lints/enum_unit_variant_changed_kind.ron
@@ -44,7 +44,7 @@ SemverQuery(
                         }
 
                         # Don't check for exhaustiveness and public API eligibility here.
-                        # Variants that changed kind and gained #[doc(hidden)] should
+                        # Variants that changed kind and gained `#[doc(hidden)]` should
                         # report for both lints, since there is no implied continuity
                         # between the old variant and the new one with the same name.   
                         variant {

--- a/src/query.rs
+++ b/src/query.rs
@@ -795,6 +795,7 @@ add_lints!(
     enum_tuple_variant_field_added,
     enum_tuple_variant_field_missing,
     enum_tuple_variant_field_now_doc_hidden,
+    enum_unit_variant_changed_kind,
     enum_variant_added,
     enum_variant_missing,
     exported_function_changed_abi,

--- a/test_crates/enum_unit_variant_changed_kind/new/Cargo.toml
+++ b/test_crates/enum_unit_variant_changed_kind/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_unit_variant_changed_kind"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_unit_variant_changed_kind/new/src/lib.rs
+++ b/test_crates/enum_unit_variant_changed_kind/new/src/lib.rs
@@ -13,6 +13,16 @@ pub enum MultipleTest {
     WillStayUnitLike
 }
 
+pub enum TestBecomeDocHidden {
+    #[doc(hidden)]
+    WillBecomeStructLike{}
+}
+
+pub enum TestBecomeNonExhaustive {
+    #[non_exhaustive]
+    WillBecomeStructLike{}
+}
+
 // ---- Should not be reported ----
 pub enum TestUnit {
     WillStayUnitLike
@@ -30,28 +40,24 @@ pub enum TestTupleNonExhaustive {
 
 pub enum MultipleTestNonExhaustive {
     #[non_exhaustive]
-    WillBecomeStructLike,
+    WillBecomeStructLike{},
     #[non_exhaustive]
-    WillBecomeTupleLike,
+    WillBecomeTupleLike(()),
     #[non_exhaustive]
     WillStayUnitLike
 }
 
 pub enum TestDocHidden {
     #[doc(hidden)]
-    WillBecomeStructLike,
+    WillBecomeStructLike{},
     #[doc(hidden)]
-    WillBecomeTupleLike,
+    WillBecomeTupleLike(()),
     #[doc(hidden)]
     WillStayUnitLike
 }
 
-pub enum TestBecomeDocHidden {
-    #[doc(hidden)]
-    WillBecomeStructLike{}
-}
-
-pub enum TestBecomeNonExhaustive {
-    #[non_exhaustive]
-    WillBecomeStructLike{}
+pub enum MultipleStayTheSame {
+    StructLike{},
+    TupleLike(()),
+    UnitLike
 }

--- a/test_crates/enum_unit_variant_changed_kind/new/src/lib.rs
+++ b/test_crates/enum_unit_variant_changed_kind/new/src/lib.rs
@@ -1,0 +1,57 @@
+// ---- Should be reported ----
+pub enum TestStruct {
+    WillBecomeStructLike{}
+}
+
+pub enum TestTuple {
+    WillBecomeTupleLike(())
+}
+
+pub enum MultipleTest {
+    WillBecomeStructLike{},
+    WillBecomeTupleLike(()),
+    WillStayUnitLike
+}
+
+// ---- Should not be reported ----
+pub enum TestUnit {
+    WillStayUnitLike
+}
+
+pub enum TestStructNonExhaustive {
+    #[non_exhaustive]
+    WillBecomeStructLike{}
+}
+
+pub enum TestTupleNonExhaustive {
+    #[non_exhaustive]
+    WillBecomeTupleLike(())
+}
+
+pub enum MultipleTestNonExhaustive {
+    #[non_exhaustive]
+    WillBecomeStructLike,
+    #[non_exhaustive]
+    WillBecomeTupleLike,
+    #[non_exhaustive]
+    WillStayUnitLike
+}
+
+pub enum TestDocHidden {
+    #[doc(hidden)]
+    WillBecomeStructLike,
+    #[doc(hidden)]
+    WillBecomeTupleLike,
+    #[doc(hidden)]
+    WillStayUnitLike
+}
+
+pub enum TestBecomeDocHidden {
+    #[doc(hidden)]
+    WillBecomeStructLike{}
+}
+
+pub enum TestBecomeNonExhaustive {
+    #[non_exhaustive]
+    WillBecomeStructLike{}
+}

--- a/test_crates/enum_unit_variant_changed_kind/old/Cargo.toml
+++ b/test_crates/enum_unit_variant_changed_kind/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_unit_variant_changed_kind"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_unit_variant_changed_kind/old/src/lib.rs
+++ b/test_crates/enum_unit_variant_changed_kind/old/src/lib.rs
@@ -1,0 +1,55 @@
+// ---- Should be reported ----
+pub enum TestStruct {
+    WillBecomeStructLike
+}
+
+pub enum TestTuple {
+    WillBecomeTupleLike
+}
+
+pub enum MultipleTest {
+    WillBecomeStructLike,
+    WillBecomeTupleLike,
+    WillStayUnitLike
+}
+
+// ---- Should not be reported ----
+pub enum TestUnit {
+    WillStayUnitLike
+}
+
+pub enum TestStructNonExhaustive {
+    #[non_exhaustive]
+    WillBecomeStructLike
+}
+
+pub enum TestTupleNonExhaustive {
+    #[non_exhaustive]
+    WillBecomeTupleLike
+}
+
+pub enum MultipleTestNonExhaustive {
+    #[non_exhaustive]
+    WillBecomeStructLike,
+    #[non_exhaustive]
+    WillBecomeTupleLike,
+    #[non_exhaustive]
+    WillStayUnitLike
+}
+
+pub enum TestDocHidden {
+    #[doc(hidden)]
+    WillBecomeStructLike,
+    #[doc(hidden)]
+    WillBecomeTupleLike,
+    #[doc(hidden)]
+    WillStayUnitLike
+}
+
+pub enum TestBecomeDocHidden {
+    WillBecomeStructLike
+}
+
+pub enum TestBecomeNonExhaustive {
+    WillBecomeStructLike
+}

--- a/test_crates/enum_unit_variant_changed_kind/old/src/lib.rs
+++ b/test_crates/enum_unit_variant_changed_kind/old/src/lib.rs
@@ -13,6 +13,14 @@ pub enum MultipleTest {
     WillStayUnitLike
 }
 
+pub enum TestBecomeDocHidden {
+    WillBecomeStructLike
+}
+
+pub enum TestBecomeNonExhaustive {
+    WillBecomeStructLike
+}
+
 // ---- Should not be reported ----
 pub enum TestUnit {
     WillStayUnitLike
@@ -46,10 +54,8 @@ pub enum TestDocHidden {
     WillStayUnitLike
 }
 
-pub enum TestBecomeDocHidden {
-    WillBecomeStructLike
-}
-
-pub enum TestBecomeNonExhaustive {
-    WillBecomeStructLike
+pub enum MultipleStayTheSame {
+    StructLike{},
+    TupleLike(()),
+    UnitLike
 }

--- a/test_outputs/enum_unit_variant_changed_kind.output.ron
+++ b/test_outputs/enum_unit_variant_changed_kind.output.ron
@@ -3,6 +3,7 @@
         {
             "enum_name": String("PublicEnum"),
             "kind": String("PlainVariant"),
+            "new_kind": String("TupleVariant"),
             "path": List([
                 String("enum_tuple_variant_field_added"),
                 String("PublicEnum"),
@@ -16,6 +17,7 @@
         {
             "enum_name": String("TestStruct"),
             "kind": String("PlainVariant"),
+            "new_kind": String("StructVariant"),
             "path": List([
                 String("enum_unit_variant_changed_kind"),
                 String("TestStruct"),
@@ -27,6 +29,7 @@
         {
             "enum_name": String("TestTuple"),
             "kind": String("PlainVariant"),
+            "new_kind": String("TupleVariant"),
             "path": List([
                 String("enum_unit_variant_changed_kind"),
                 String("TestTuple"),
@@ -38,6 +41,7 @@
         {
             "enum_name": String("MultipleTest"),
             "kind": String("PlainVariant"),
+            "new_kind": String("StructVariant"),
             "path": List([
                 String("enum_unit_variant_changed_kind"),
                 String("MultipleTest"),
@@ -49,6 +53,7 @@
         {
             "enum_name": String("MultipleTest"),
             "kind": String("PlainVariant"),
+            "new_kind": String("TupleVariant"),
             "path": List([
                 String("enum_unit_variant_changed_kind"),
                 String("MultipleTest"),

--- a/test_outputs/enum_unit_variant_changed_kind.output.ron
+++ b/test_outputs/enum_unit_variant_changed_kind.output.ron
@@ -62,5 +62,29 @@
             "span_filename": String("src/lib.rs"),
             "variant_name": String("WillBecomeTupleLike"),
         },
+        {
+            "enum_name": String("TestBecomeDocHidden"),
+            "kind": String("PlainVariant"),
+            "new_kind": String("StructVariant"),
+            "path": List([
+                String("enum_unit_variant_changed_kind"),
+                String("TestBecomeDocHidden"),
+            ]),
+            "span_begin_line": Uint64(18),
+            "span_filename": String("src/lib.rs"),
+            "variant_name": String("WillBecomeStructLike"),
+        },
+        {
+            "enum_name": String("TestBecomeNonExhaustive"),
+            "kind": String("PlainVariant"),
+            "new_kind": String("StructVariant"),
+            "path": List([
+                String("enum_unit_variant_changed_kind"),
+                String("TestBecomeNonExhaustive"),
+            ]),
+            "span_begin_line": Uint64(23),
+            "span_filename": String("src/lib.rs"),
+            "variant_name": String("WillBecomeStructLike"),
+        },
     ],
 }

--- a/test_outputs/enum_unit_variant_changed_kind.output.ron
+++ b/test_outputs/enum_unit_variant_changed_kind.output.ron
@@ -1,0 +1,61 @@
+{
+    "./test_crates/enum_tuple_variant_field_added/": [
+        {
+            "enum_name": String("PublicEnum"),
+            "kind": String("PlainVariant"),
+            "path": List([
+                String("enum_tuple_variant_field_added"),
+                String("PublicEnum"),
+            ]),
+            "span_begin_line": Uint64(13),
+            "span_filename": String("src/lib.rs"),
+            "variant_name": String("PlainVariantBecomesTuple"),
+        },
+    ],
+    "./test_crates/enum_unit_variant_changed_kind/": [
+        {
+            "enum_name": String("TestStruct"),
+            "kind": String("PlainVariant"),
+            "path": List([
+                String("enum_unit_variant_changed_kind"),
+                String("TestStruct"),
+            ]),
+            "span_begin_line": Uint64(3),
+            "span_filename": String("src/lib.rs"),
+            "variant_name": String("WillBecomeStructLike"),
+        },
+        {
+            "enum_name": String("TestTuple"),
+            "kind": String("PlainVariant"),
+            "path": List([
+                String("enum_unit_variant_changed_kind"),
+                String("TestTuple"),
+            ]),
+            "span_begin_line": Uint64(7),
+            "span_filename": String("src/lib.rs"),
+            "variant_name": String("WillBecomeTupleLike"),
+        },
+        {
+            "enum_name": String("MultipleTest"),
+            "kind": String("PlainVariant"),
+            "path": List([
+                String("enum_unit_variant_changed_kind"),
+                String("MultipleTest"),
+            ]),
+            "span_begin_line": Uint64(11),
+            "span_filename": String("src/lib.rs"),
+            "variant_name": String("WillBecomeStructLike"),
+        },
+        {
+            "enum_name": String("MultipleTest"),
+            "kind": String("PlainVariant"),
+            "path": List([
+                String("enum_unit_variant_changed_kind"),
+                String("MultipleTest"),
+            ]),
+            "span_begin_line": Uint64(12),
+            "span_filename": String("src/lib.rs"),
+            "variant_name": String("WillBecomeTupleLike"),
+        },
+    ],
+}

--- a/test_outputs/variant_marked_non_exhaustive.output.ron
+++ b/test_outputs/variant_marked_non_exhaustive.output.ron
@@ -25,6 +25,19 @@
             "visibility_limit": String("public"),
         },
     ],
+    "./test_crates/enum_unit_variant_changed_kind/": [
+        {
+            "name": String("TestBecomeNonExhaustive"),
+            "path": List([
+                String("enum_unit_variant_changed_kind"),
+                String("TestBecomeNonExhaustive"),
+            ]),
+            "span_begin_line": Uint64(56),
+            "span_filename": String("src/lib.rs"),
+            "variant_name": String("WillBecomeStructLike"),
+            "visibility_limit": String("public"),
+        },
+    ],
     "./test_crates/non_exhaustive/": [
         {
             "name": String("MyEnum"),

--- a/test_outputs/variant_marked_non_exhaustive.output.ron
+++ b/test_outputs/variant_marked_non_exhaustive.output.ron
@@ -32,7 +32,7 @@
                 String("enum_unit_variant_changed_kind"),
                 String("TestBecomeNonExhaustive"),
             ]),
-            "span_begin_line": Uint64(56),
+            "span_begin_line": Uint64(23),
             "span_filename": String("src/lib.rs"),
             "variant_name": String("WillBecomeStructLike"),
             "visibility_limit": String("public"),


### PR DESCRIPTION
solves one lint from https://github.com/obi1kenobi/cargo-semver-checks/issues/884

Applied the same logic from enum_tuple_variant_field_added and similar lints for whether or not newly doc(hidden) and newly non_exhaustive variants should report for both. 

Also, not sure about the reference link. Maybe https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute would be better? 