### PR TITLE
enable `implicit some` feature on query rons.

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, sync::Arc};
 
+use ron::extensions::Extensions;
 use serde::{Deserialize, Serialize};
 use trustfall::TransparentValue;
 
@@ -128,7 +129,13 @@ impl SemverQuery {
     pub fn all_queries() -> BTreeMap<String, SemverQuery> {
         let mut queries = BTreeMap::default();
         for (id, query_text) in get_queries() {
-            let query: SemverQuery = ron::from_str(query_text).unwrap_or_else(|e| {
+            let mut deserializer = ron::Deserializer::from_str_with_options(
+                query_text,
+                ron::Options::default().with_default_extension(Extensions::IMPLICIT_SOME),
+            )
+            .expect("Failed to construct deserializer.");
+
+            let query = Self::deserialize(&mut deserializer).unwrap_or_else(|e| {
                 panic!(
                     "\
 Failed to parse a query: {e}


### PR DESCRIPTION
This lets (but does not require) us specify `T` on a query field that called for `Option<T>` without wrapping in `Some`. 

See https://github.com/obi1kenobi/cargo-semver-checks/pull/893#discussion_r1739902679