### PR TITLE
Properly silence cargo output unless `--verbose`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,7 +378,9 @@ impl Check {
     }
 
     pub fn check_release(&self, config: &mut GlobalConfig) -> anyhow::Result<Report> {
-        let rustdoc_cmd = RustdocCommand::new().deps(false).silence(config.is_info());
+        let rustdoc_cmd = RustdocCommand::new()
+            .deps(false)
+            .silence(!config.is_verbose());
 
         // If both the current and baseline rustdoc are given explicitly as a file path,
         // we don't need to use the installed rustc, and this check can be skipped.


### PR DESCRIPTION
Before this, output was always silenced since the check was inverted.
It would only be unsilenced if the log level was less verbose than INFO,
which is the opposite of what we want.
