### PR TITLE
Weekly `cargo update` of dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2390,9 +2390,9 @@ checksum = "744a264d26b88a6a7e37cbad97953fa233b94d585236310bcbc88474b4092d79"
 
 [[package]]
 name = "quinn"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d2fb862b7ba45e615c1429def928f2e15f815bdf933b27a2d3824e224c1f46"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -2408,9 +2408,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0a9b3a42929fad8a7c3de7f86ce0814cfa893328157672680e9fb1145549c5"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
  "rand",
@@ -2425,15 +2425,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
+checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3284,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "28.1.3"
+version = "28.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f215d49f2108689a3cf1c4ba4e48a47d40301567a1df3106836f882bd433a682"
+checksum = "0247b21c545fc4aed1c877450e9750743937d5eaddc6e1f085f72c8713ab3043"
 dependencies = [
  "rustdoc-types 0.24.0",
  "trustfall",
@@ -3294,9 +3294,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "29.1.3"
+version = "29.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c78be19778059e175300fe71f3869d3aa4991c72af09c65b232d1870904b287b"
+checksum = "962069854192b26d8073c052e26806afd74faed02131df5e344a8ea6ca30e2a4"
 dependencies = [
  "rustdoc-types 0.25.0",
  "trustfall",
@@ -3304,9 +3304,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "30.1.3"
+version = "30.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f89d7ebd7029268433ac0e647a45f1f6a829102441c95d4908dcea8803356e"
+checksum = "33c944186765c3c36585ff52d0d67fc02e5bc79a0ec52b96fe26d4ffe4de7dc7"
 dependencies = [
  "rustdoc-types 0.26.0",
  "trustfall",
@@ -3314,9 +3314,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "32.1.3"
+version = "32.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b381607f0009a87215190cc3ed5469eabfb4c057fc40117364de794fda09f86"
+checksum = "a0ed00d3646c9e22ebdf4565e21919a7b39b410839ef9e4026ac5524b60480a3"
 dependencies = [
  "rustdoc-types 0.28.1",
  "trustfall",
@@ -3324,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "33.1.3"
+version = "33.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e9b5aeb138eb9c4eb323fbcb1118816cebce7735ecb4916164c86b109c00f3"
+checksum = "830bc6cee8376524a6ef429ed4bf5ba1b7b4b58bfc6270e1339401c46a828135"
 dependencies = [
  "rustdoc-types 0.29.1",
  "trustfall",
@@ -3362,19 +3362,19 @@ dependencies = [
 
 [[package]]
 name = "trustfall_rustdoc"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285db3f0985971888b37632f9b28529ee069c9c941489c7049bf0f456e842c68"
+checksum = "838964586da4bf4aa7831f864411fddf7712140ff897f6d9279563081102aa5f"
 dependencies = [
  "anyhow",
  "serde",
  "serde_json",
  "trustfall",
- "trustfall-rustdoc-adapter 28.1.3",
- "trustfall-rustdoc-adapter 29.1.3",
- "trustfall-rustdoc-adapter 30.1.3",
- "trustfall-rustdoc-adapter 32.1.3",
- "trustfall-rustdoc-adapter 33.1.3",
+ "trustfall-rustdoc-adapter 28.1.4",
+ "trustfall-rustdoc-adapter 29.1.4",
+ "trustfall-rustdoc-adapter 30.1.4",
+ "trustfall-rustdoc-adapter 32.1.4",
+ "trustfall-rustdoc-adapter 33.1.4",
 ]
 
 [[package]]


### PR DESCRIPTION
Automation to keep dependencies in `Cargo.lock` current.

The following is the output from `cargo update`:

```txt
     Locking 9 packages to latest compatible versions
    Updating quinn v0.11.4 -> v0.11.5
    Updating quinn-proto v0.11.7 -> v0.11.8
    Updating quinn-udp v0.5.4 -> v0.5.5
    Removing trustfall-rustdoc-adapter v28.1.3
    Removing trustfall-rustdoc-adapter v29.1.3
    Removing trustfall-rustdoc-adapter v30.1.3
    Removing trustfall-rustdoc-adapter v32.1.3
    Removing trustfall-rustdoc-adapter v33.1.3
      Adding trustfall-rustdoc-adapter v28.1.4 (latest: v33.1.4)
      Adding trustfall-rustdoc-adapter v29.1.4 (latest: v33.1.4)
      Adding trustfall-rustdoc-adapter v30.1.4 (latest: v33.1.4)
      Adding trustfall-rustdoc-adapter v32.1.4 (latest: v33.1.4)
      Adding trustfall-rustdoc-adapter v33.1.4
    Updating trustfall_rustdoc v0.16.0 -> v0.16.1
note: pass `--verbose` to see 57 unchanged dependencies behind latest
```
