### PR TITLE
Add support for specifying features with commas `feat1,feat2`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -484,17 +484,31 @@ struct CheckRelease {
     /// Add a feature to the set of features being checked.
     /// The feature will be used in both the baseline and the current version
     /// of the crate.
-    #[arg(long, value_name = "NAME", help_heading = "Features")]
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "NAME",
+        help_heading = "Features"
+    )]
     features: Vec<String>,
 
     /// Add a feature to the set of features being checked.
     /// The feature will be used in the baseline version of the crate only.
-    #[arg(long, value_name = "NAME", help_heading = "Features")]
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "NAME",
+        help_heading = "Features"
+    )]
     baseline_features: Vec<String>,
-
     /// Add a feature to the set of features being checked.
     /// The feature will be used in the current version of the crate only.
-    #[arg(long, value_name = "NAME", help_heading = "Features")]
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "NAME",
+        help_heading = "Features"
+    )]
     current_features: Vec<String>,
 
     /// Use all the features, including features named

--- a/test_crates/feature_flags_validation/new/Cargo.toml
+++ b/test_crates/feature_flags_validation/new/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+publish = false
+name = "feature_flags_validation"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[features]
+default = ["std", "alloc"]
+foo = []
+std = []
+bar = []
+alloc = []
+unstable = []
+nightly = []
+bench = []
+no_std = []
+__foo = []

--- a/test_crates/feature_flags_validation/new/src/lib.rs
+++ b/test_crates/feature_flags_validation/new/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(feature = "foo")]
+pub fn foo_becomes_gated() {}
+
+#[cfg(feature = "bar")]
+pub fn bar_becomes_gated() {}
+
+#[cfg(any(feature = "unstable", feature = "nightly",))]
+pub fn unstable_function() {}

--- a/test_crates/feature_flags_validation/old/Cargo.toml
+++ b/test_crates/feature_flags_validation/old/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+publish = false
+name = "feature_flags_validation"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[features]
+default = ["std", "alloc"]
+std = []
+alloc = []
+unstable = []
+nightly = []
+bench = []
+no_std = []
+__foo = []
+unstable-foo=[]
+unstable_foo=[]
+_bar=[]

--- a/test_crates/feature_flags_validation/old/src/lib.rs
+++ b/test_crates/feature_flags_validation/old/src/lib.rs
@@ -1,0 +1,17 @@
+#[cfg(not(all(feature = "std", feature = "alloc")))]
+compile_error!("`std` and `alloc` features are  currently required to build this awesome crate");
+
+pub fn foo_becomes_gated() {}
+pub fn bar_becomes_gated() {}
+
+#[cfg(any(
+    feature = "unstable",
+    feature = "nightly",
+    feature = "bench",
+    feature = "no_std",
+    feature = "__foo",
+    feature = "unstable-foo",
+    feature = "unstable_foo",
+    feature = "_bar"
+))]
+pub fn unstable_function() {}

--- a/test_outputs/function_missing.output.ron
+++ b/test_outputs/function_missing.output.ron
@@ -1,4 +1,26 @@
 {
+    "./test_crates/feature_flags_validation/": [
+        {
+            "name": String("foo_becomes_gated"),
+            "path": List([
+                String("feature_flags_validation"),
+                String("foo_becomes_gated"),
+            ]),
+            "span_begin_line": Uint64(4),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+        {
+            "name": String("bar_becomes_gated"),
+            "path": List([
+                String("feature_flags_validation"),
+                String("bar_becomes_gated"),
+            ]),
+            "span_begin_line": Uint64(5),
+            "span_filename": String("src/lib.rs"),
+            "visibility_limit": String("public"),
+        },
+    ],
     "./test_crates/features_simple/": [
         {
             "name": String("feature_dependent_function"),

--- a/tests/feature_config.rs
+++ b/tests/feature_config.rs
@@ -71,6 +71,52 @@ fn simple_default_features() {
 }
 
 #[test]
+fn simple_validation_feature_flags() {
+    CargoSemverChecks::new(
+        "test_crates/feature_flags_validation/new/",
+        "test_crates/feature_flags_validation/old/Cargo.toml",
+    )
+    .add_arg("--only-explicit-features")
+    .add_arg("--baseline-features")
+    .add_arg("std,alloc")
+    .add_arg("--current-features")
+    .add_arg("foo,bar")
+    // without --features flag still works, but this is about flag validation
+    .add_arg("--features")
+    .add_arg("unstable,nightly")
+    .run_all()
+    .into_iter()
+    .for_each(|a| {
+        a.success();
+    });
+    // We repeat the same test, but specify each flag separately,
+    // to ensure that both ways can be parsed
+    CargoSemverChecks::new(
+        "test_crates/feature_flags_validation/new/",
+        "test_crates/feature_flags_validation/old/Cargo.toml",
+    )
+    .add_arg("--only-explicit-features")
+    .add_arg("--baseline-features")
+    .add_arg("std")
+    .add_arg("--baseline-features")
+    .add_arg("alloc")
+    .add_arg("--current-features")
+    .add_arg("foo")
+    .add_arg("--current-features")
+    .add_arg("bar")
+    // without --features flag still works, but this is about flag validation
+    .add_arg("--features")
+    .add_arg("unstable")
+    .add_arg("--features")
+    .add_arg("nightly")
+    .run_all()
+    .into_iter()
+    .for_each(|a| {
+        a.success();
+    });
+}
+
+#[test]
 fn simple_heuristic_features() {
     CargoSemverChecks::new(
         "test_crates/features_simple/new/",


### PR DESCRIPTION
Fixes #915  by enabling support for specifying features via commas. Specifically it adds support for the flags:
* --baseline-features
* --current-features
* --features

Before:
`cargo semver-checks --baseline-features foo,bar`
Raised:
```
warning: Feature `std,multicall` is not present in the baseline.
```

Now:
`cargo semver-checks --baseline-features foo,bar`
Succeeds fine. 

Thank you! :) 
