### PR TITLE
Add some lint group infra + 'all' lint group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,12 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -95,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.87"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "arc-swap"
@@ -189,17 +195,17 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
+ "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -386,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "shlex",
 ]
@@ -401,9 +407,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -432,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -511,9 +517,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -750,7 +756,7 @@ checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "libz-ng-sys",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -859,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "git-version"
@@ -1367,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.11"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebfc4febd088abdcbc9f1246896e57e37b7a34f6909840045a1767c6dafac7af"
+checksum = "38d5b8722112fa2fa87135298780bc833b0e9f6c56cc82795d209804b3a03484"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -1543,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.10"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cae0e8661c3ff92688ce1c8b8058b3efb312aba9492bbe93661a21705ab431b"
+checksum = "f924267408915fddcd558e3f37295cc7d6a3e50f8bd8b606cee0808c3915157e"
 
 [[package]]
 name = "gix-transport"
@@ -1639,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "globset"
-version = "0.4.15"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1671,9 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "6.1.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25b617d1375ef96eeb920ae717e3da34a02fc979fe632c75128350f9e1f74a"
+checksum = "5226a0e122dc74917f3a701484482bed3ee86d016c7356836abbaa033133a157"
 dependencies = [
  "log",
  "pest",
@@ -1801,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http",
@@ -1849,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.23"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1876,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.40.0"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6593a41c7a73841868772495db7dc1e8ecab43bb5c0b6da2059246c4b506ab60"
+checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
 dependencies = [
  "console",
  "lazy_static",
@@ -1902,9 +1908,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1938,9 +1944,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jiff"
-version = "0.1.13"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a45489186a6123c128fdf6016183fcfab7113e1820eb813127e036e287233fb"
+checksum = "437651126da47900d4d70255ab15f5c69510ca4e0d88c9f01b5b8d41a45c3a9b"
 dependencies = [
  "jiff-tzdb-platform",
  "windows-sys 0.59.0",
@@ -1948,15 +1954,15 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91335e575850c5c4c673b9bd467b0e025f164ca59d0564f69d0c2ee0ffad4653"
+checksum = "05fac328b3df1c0f18a3c2ab6cb7e06e4e549f366017d796e3e66b6d6889abe6"
 
 [[package]]
 name = "jiff-tzdb-platform"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9835f0060a626fe59f160437bc725491a6af23133ea906500027d1bd2f8f4329"
+checksum = "f8da387d5feaf355954c2c122c194d6df9c57d865125a67984bb453db5336940"
 dependencies = [
  "jiff-tzdb",
 ]
@@ -2102,6 +2108,15 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
@@ -2232,9 +2247,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.12"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2243,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.12"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d"
+checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2253,9 +2268,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.12"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe"
+checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2266,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.12"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174"
+checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
 dependencies = [
  "once_cell",
  "pest",
@@ -2683,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.36"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -2752,11 +2767,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2776,18 +2791,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2796,9 +2811,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
  "memchr",
@@ -2895,9 +2910,9 @@ dependencies = [
 
 [[package]]
 name = "similar-asserts"
-version = "1.6.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe85670573cd6f0fa97940f26e7e6601213c3b0555246c24234131f88c5709e"
+checksum = "e041bb827d1bfca18f213411d51b665309f1afb37a04a5d1464530e13779fc0f"
 dependencies = [
  "console",
  "serde",
@@ -3156,9 +3171,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3269,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "28.1.6"
+version = "28.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c75c87b6555d5d888e2d7047d820cd4586302e42e9dd881ee28800f225b82a7"
+checksum = "0247b21c545fc4aed1c877450e9750743937d5eaddc6e1f085f72c8713ab3043"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3281,9 +3296,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "29.1.6"
+version = "29.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2c2b64014ee66c61be248d12ee8db2d6973db90b6f68046e89f13588ca3475"
+checksum = "962069854192b26d8073c052e26806afd74faed02131df5e344a8ea6ca30e2a4"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3293,9 +3308,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "30.1.6"
+version = "30.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a00f2f51bc5f88028ad5ef064e40a9e8af5b313d7e37834c315b681cae2f4"
+checksum = "33c944186765c3c36585ff52d0d67fc02e5bc79a0ec52b96fe26d4ffe4de7dc7"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3305,9 +3320,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "32.1.6"
+version = "32.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f826c74e11761b4ef919396c16b3472ed767c81ce40ea6f234d9ba2ac79b65bd"
+checksum = "a0ed00d3646c9e22ebdf4565e21919a7b39b410839ef9e4026ac5524b60480a3"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3317,9 +3332,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "33.1.6"
+version = "33.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970e7763e31dffc6ee25699cde56c11a45e33c505ab4b08da5e1f4c0861e44f4"
+checksum = "830bc6cee8376524a6ef429ed4bf5ba1b7b4b58bfc6270e1339401c46a828135"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3365,11 +3380,11 @@ dependencies = [
  "serde",
  "serde_json",
  "trustfall",
- "trustfall-rustdoc-adapter 28.1.6",
- "trustfall-rustdoc-adapter 29.1.6",
- "trustfall-rustdoc-adapter 30.1.6",
- "trustfall-rustdoc-adapter 32.1.6",
- "trustfall-rustdoc-adapter 33.1.6",
+ "trustfall-rustdoc-adapter 28.1.4",
+ "trustfall-rustdoc-adapter 29.1.4",
+ "trustfall-rustdoc-adapter 30.1.4",
+ "trustfall-rustdoc-adapter 32.1.4",
+ "trustfall-rustdoc-adapter 33.1.4",
 ]
 
 [[package]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@ use trustfall_rustdoc::{load_rustdoc, VersionedCrate};
 use rustdoc_cmd::RustdocCommand;
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::Instant;
 
 pub use config::{FeatureFlag, GlobalConfig};
@@ -492,7 +491,7 @@ note: skipped the following crates since they have no library target: {skipped}"
                 let workspace_overrides =
                     manifest::deserialize_lint_table(&metadata.workspace_metadata)
                         .context("[workspace.metadata.cargo-semver-checks] table is invalid")?
-                        .map(|table| Arc::new(table.inner));
+                        .map(|table| table.into_stack());
 
                 selected
                     .iter()
@@ -535,12 +534,18 @@ note: skipped the following crates since they have no library target: {skipped}"
 
                             if lint_workspace_key || metadata_workspace_key {
                                 if let Some(workspace) = &workspace_overrides {
-                                    overrides.push(Arc::clone(workspace));
+                                    for level in workspace {
+                                        overrides.try_push(level).context("configuration conflict found in workspace overrides.\n\
+                                            use the `priority` field in the manifest to set precedence.")?;
+                                    }
                                 }
                             }
 
                             if let Some(package) = package_overrides {
-                                overrides.push(Arc::new(package.inner));
+                                for level in package.into_stack() {
+                                overrides.try_push(&level).with_context(|| format!("configuration conflict found in package {} overrides.\n\
+                                    use the `priority` field in the manifest to set precedence.", selected.name))?;
+                                }
                             }
 
                             let start = std::time::Instant::now();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ use std::time::Instant;
 
 pub use config::{FeatureFlag, GlobalConfig};
 pub use query::{
-    ActualSemverUpdate, LintLevel, OverrideMap, OverrideStack, QueryOverride, RequiredSemverUpdate,
-    SemverQuery,
+    ActualSemverUpdate, CompiledOverrideMap, Identifier, LintLevel, OverrideMap, OverrideStack,
+    QueryOverride, RequiredSemverUpdate, SemverQuery,
 };
 
 /// Test a release for semver violations.

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -289,7 +289,7 @@ mod tests {
             .expect("Lint table should be present")
             .into_stack();
 
-        assert_eq!(
+        similar_asserts::assert_eq!(
             wks,
             vec![
                 OverrideMap(BTreeMap::from_iter([(

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -122,6 +122,12 @@ pub(crate) enum OverrideConfig {
         level: Option<LintLevel>,
         #[serde(default)]
         required_update: Option<RequiredSemverUpdate>,
+        /// The priority for this configuration.  If there are multiple entries that
+        /// configure a lint (e.g., a lint group containing a lint and the lint itself),
+        /// the configuration entry with the **lowest** priority takes precedence.
+        /// The default value, if omitted, is 0.
+        #[serde(default)]
+        priority: i64,
     },
     /// Shorthand for specifying just a lint level and leaving
     /// the other members as default: e.g.,

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -368,3 +368,20 @@ fn multiple_ambiguous_package_name_definitions() {
         ],
     );
 }
+
+/// Tests for the all lint group in lint overrides
+#[test]
+fn all_lint_group() {
+    assert_integration_test(
+        "all_lint_group",
+        &[
+            "cargo",
+            "semver-checks",
+            "--baseline-root",
+            "test_crates/manifest_tests/all_lint_group/old",
+            "--manifest-path",
+            "test_crates/manifest_tests/all_lint_group/new",
+            "-v",
+        ],
+    );
+}

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -178,6 +178,8 @@ fn assert_integration_test(test_name: &str, invocation: &[&str]) {
         r"v\d+\.\d+\.\d+(-[\w\.-]+)?/src/lints",
         "[VERSION]/src/lints",
     );
+    // Filter the printed number of threads that `cargo-semver-checks` is running on.
+    settings.add_filter(r"on \d+ threads", "on [THREADS] threads");
 
     // The `settings` are applied to the current thread as long as the returned
     // drop guard  `_grd` is alive, so we use a `let` binding to keep it alive

--- a/test_crates/manifest_tests/all_lint_group/new/Cargo.toml
+++ b/test_crates/manifest_tests/all_lint_group/new/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+publish = false
+name = "all_lint_group"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.cargo-semver-checks.lints]
+all = "warn" # priority 0
+# priority 0, should not conflict because it's a different field
+function_missing = { required-update = "minor" }
+# should be overridden by 'all' because it has a more positive priority
+module_missing = { level = "allow", priority = 2}
+# should override 'all'  because it has a more negative priority
+trait_missing = { level = "deny", priority = -1}

--- a/test_crates/manifest_tests/all_lint_group/new/src/lib.rs
+++ b/test_crates/manifest_tests/all_lint_group/new/src/lib.rs
@@ -1,0 +1,8 @@
+// This should be warn-level (all entry) and minor (individual entry)
+// pub fn function_missing() {}
+// This should be warn-level (individual deny overridden by all allow)
+// pub mod module_missing {}
+// Deny-level (individual deny overrides warn all)
+// pub trait TraitMissing {}
+// Warn-level (all entry).
+// pub enum EnumMissing {}

--- a/test_crates/manifest_tests/all_lint_group/old/Cargo.toml
+++ b/test_crates/manifest_tests/all_lint_group/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "all_lint_group"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/all_lint_group/old/src/lib.rs
+++ b/test_crates/manifest_tests/all_lint_group/old/src/lib.rs
@@ -1,0 +1,8 @@
+// This should be warn-level (all entry) and minor (individual entry)
+pub fn function_missing() {}
+// This should be warn-level (individual deny overridden by all allow)
+pub mod module_missing {}
+// Deny-level (individual deny overrides warn all)
+pub trait TraitMissing {}
+// Warn-level (all entry).
+pub enum EnumMissing {}

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__all_lint_group-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__all_lint_group-input.snap
@@ -1,0 +1,30 @@
+---
+source: src/snapshot_tests.rs
+expression: check
+---
+Check(
+  scope: Scope(
+    mode: DenyList(PackageSelection(
+      selection: DefaultMembers,
+      excluded_packages: [],
+    )),
+  ),
+  current: Rustdoc(
+    source: Root("test_crates/manifest_tests/all_lint_group/new"),
+  ),
+  baseline: Rustdoc(
+    source: Root("test_crates/manifest_tests/all_lint_group/old"),
+  ),
+  release_type: None,
+  current_feature_config: FeatureConfig(
+    features_group: Heuristic,
+    extra_features: [],
+    is_baseline: false,
+  ),
+  baseline_feature_config: FeatureConfig(
+    features_group: Heuristic,
+    extra_features: [],
+    is_baseline: true,
+  ),
+  build_target: None,
+)

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__all_lint_group-output.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__all_lint_group-output.snap
@@ -1,0 +1,148 @@
+---
+source: src/snapshot_tests.rs
+expression: result
+---
+success: false
+--- stdout ---
+
+--- failure trait_missing: pub trait removed or renamed ---
+
+Description:
+A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/[VERSION]/src/lints/trait_missing.ron
+
+Failed in:
+  trait all_lint_group::TraitMissing, previously in file [ROOT]/test_crates/manifest_tests/all_lint_group/old/src/lib.rs:6
+
+--- warning enum_missing: pub enum removed or renamed ---
+
+Description:
+A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/[VERSION]/src/lints/enum_missing.ron
+
+Failed in:
+  enum all_lint_group::EnumMissing, previously in file [ROOT]/test_crates/manifest_tests/all_lint_group/old/src/lib.rs:8
+
+--- warning function_missing: pub fn removed or renamed ---
+
+Description:
+A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/[VERSION]/src/lints/function_missing.ron
+
+Failed in:
+  function all_lint_group::function_missing, previously in file [ROOT]/test_crates/manifest_tests/all_lint_group/old/src/lib.rs:2
+
+--- warning module_missing: pub module removed or renamed ---
+
+Description:
+A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/[VERSION]/src/lints/module_missing.ron
+
+Failed in:
+  mod all_lint_group::module_missing, previously in file [ROOT]/test_crates/manifest_tests/all_lint_group/old/src/lib.rs:4
+
+--- stderr ---
+     Parsing all_lint_group v0.1.0 (current)
+      Parsed [TIME] (current)
+     Parsing all_lint_group v0.1.0 (baseline)
+      Parsed [TIME] (baseline)
+    Checking all_lint_group v0.1.0 -> v0.1.0 (no change)
+    Starting [TOTAL] checks, 0 unnecessary on 8 threads
+        PASS [TIME]       major        auto_trait_impl_removed
+        PASS [TIME]       major        constructible_struct_adds_field
+        PASS [TIME]       major        constructible_struct_adds_private_field
+        PASS [TIME]       major        constructible_struct_changed_type
+        PASS [TIME]       major        derive_trait_impl_removed
+        PASS [TIME]       major        enum_marked_non_exhaustive
+        WARN [TIME]       major        enum_missing
+        PASS [TIME]       minor        enum_must_use_added
+        PASS [TIME]       major        enum_now_doc_hidden
+        PASS [TIME]       major        enum_repr_int_changed
+        PASS [TIME]       major        enum_repr_int_removed
+        PASS [TIME]       major        enum_repr_transparent_removed
+        PASS [TIME]       major        enum_struct_variant_field_added
+        PASS [TIME]       major        enum_struct_variant_field_missing
+        PASS [TIME]       major        enum_struct_variant_field_now_doc_hidden
+        PASS [TIME]       major        enum_tuple_variant_changed_kind
+        PASS [TIME]       major        enum_tuple_variant_field_added
+        PASS [TIME]       major        enum_tuple_variant_field_missing
+        PASS [TIME]       major        enum_tuple_variant_field_now_doc_hidden
+        PASS [TIME]       major        enum_unit_variant_changed_kind
+        PASS [TIME]       major        enum_variant_added
+        PASS [TIME]       major        enum_variant_marked_non_exhaustive
+        PASS [TIME]       major        enum_variant_missing
+        PASS [TIME]       major        exported_function_changed_abi
+        PASS [TIME]       major        function_abi_no_longer_unwind
+        PASS [TIME]       major        function_changed_abi
+        PASS [TIME]       major        function_const_removed
+        PASS [TIME]       major        function_export_name_changed
+        WARN [TIME]       minor        function_missing
+        PASS [TIME]       minor        function_must_use_added
+        PASS [TIME]       major        function_now_doc_hidden
+        PASS [TIME]       major        function_parameter_count_changed
+        PASS [TIME]       major        function_unsafe_added
+        PASS [TIME]       major        inherent_associated_const_now_doc_hidden
+        PASS [TIME]       major        inherent_associated_pub_const_missing
+        PASS [TIME]       major        inherent_method_const_removed
+        PASS [TIME]       major        inherent_method_missing
+        PASS [TIME]       minor        inherent_method_must_use_added
+        PASS [TIME]       major        inherent_method_now_doc_hidden
+        PASS [TIME]       major        inherent_method_unsafe_added
+        PASS [TIME]       major        method_parameter_count_changed
+        WARN [TIME]       major        module_missing
+        PASS [TIME]       major        pub_module_level_const_missing
+        PASS [TIME]       major        pub_module_level_const_now_doc_hidden
+        PASS [TIME]       major        pub_static_missing
+        PASS [TIME]       major        pub_static_mut_now_immutable
+        PASS [TIME]       major        pub_static_now_doc_hidden
+        PASS [TIME]       major        repr_c_removed
+        PASS [TIME]       major        repr_packed_added
+        PASS [TIME]       major        repr_packed_removed
+        PASS [TIME]       major        sized_impl_removed
+        PASS [TIME]       major        struct_marked_non_exhaustive
+        PASS [TIME]       major        struct_missing
+        PASS [TIME]       minor        struct_must_use_added
+        PASS [TIME]       major        struct_now_doc_hidden
+        PASS [TIME]       major        struct_pub_field_missing
+        PASS [TIME]       major        struct_pub_field_now_doc_hidden
+        PASS [TIME]       major        struct_repr_transparent_removed
+        PASS [TIME]       major        struct_with_pub_fields_changed_type
+        PASS [TIME]       major        trait_associated_const_added
+        PASS [TIME]       major        trait_associated_const_default_removed
+        PASS [TIME]       major        trait_associated_const_now_doc_hidden
+        PASS [TIME]       major        trait_associated_type_added
+        PASS [TIME]       major        trait_associated_type_default_removed
+        PASS [TIME]       major        trait_associated_type_now_doc_hidden
+        PASS [TIME]       major        trait_method_added
+        PASS [TIME]       major        trait_method_default_impl_removed
+        PASS [TIME]       major        trait_method_missing
+        PASS [TIME]       major        trait_method_now_doc_hidden
+        PASS [TIME]       major        trait_method_unsafe_added
+        PASS [TIME]       major        trait_method_unsafe_removed
+        FAIL [TIME]       major        trait_missing
+        PASS [TIME]       minor        trait_must_use_added
+        PASS [TIME]       major        trait_newly_sealed
+        PASS [TIME]       major        trait_no_longer_object_safe
+        PASS [TIME]       major        trait_now_doc_hidden
+        PASS [TIME]       major        trait_removed_associated_constant
+        PASS [TIME]       major        trait_removed_associated_type
+        PASS [TIME]       major        trait_removed_supertrait
+        PASS [TIME]       major        trait_unsafe_added
+        PASS [TIME]       major        trait_unsafe_removed
+        PASS [TIME]       major        tuple_struct_to_plain_struct
+        PASS [TIME]       minor        type_marked_deprecated
+        PASS [TIME]       major        union_field_missing
+        PASS [TIME]       major        union_missing
+        PASS [TIME]       minor        union_must_use_added
+        PASS [TIME]       major        union_now_doc_hidden
+        PASS [TIME]       major        union_pub_field_now_doc_hidden
+        PASS [TIME]       major        unit_struct_changed_kind
+     Checked [TIME] [TOTAL] checks: [PASS] pass, 1 fail, 3 warn, 0 skip
+
+     Summary semver requires new major version: 1 major and 0 minor checks failed
+     Warning produced 2 major and 1 minor level warnings
+    Finished [TIME] all_lint_group

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__all_lint_group-output.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__all_lint_group-output.snap
@@ -51,7 +51,7 @@ Failed in:
      Parsing all_lint_group v0.1.0 (baseline)
       Parsed [TIME] (baseline)
     Checking all_lint_group v0.1.0 -> v0.1.0 (no change)
-    Starting [TOTAL] checks, 0 unnecessary on 8 threads
+    Starting [TOTAL] checks, 0 unnecessary on [THREADS] threads
         PASS [TIME]       major        auto_trait_impl_removed
         PASS [TIME]       major        constructible_struct_adds_field
         PASS [TIME]       major        constructible_struct_adds_private_field


### PR DESCRIPTION
Adds the lint pseudo-group `all` to configure all lints in `cargo-semver-checks`.  Mainly adds the beginnings of infrastructure to specify lint groups:
- adds the `priority` field to TOML like the `cargo` lints table
  - makes it an error if there are conflicting entries for the same lint at the same priority level (this is by field)
  - reorganized schema to encode the fact that `{}` or `{priority = ...}` is an error
- changes up data structures to support lint groups:
  - `OverrideMap` is now a middle-level structure `Identifier -> Overrides` (where identifier is group, pseudo-group, or lint name) that compiles to a `String (lint name) -> Overrides`, and makes it an error if there was a conflict
    - in the future `compile` may need to take an `&OverrideStack` to calculate e.g. the `warnings` group but that can be added later

When we add lint groups, the lint group names will need to be statically known so we can deserialize correctly in `Identifier`.