### PR TITLE
Handle `priority` in the lints table

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@ use trustfall_rustdoc::{load_rustdoc, VersionedCrate};
 use rustdoc_cmd::RustdocCommand;
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::Instant;
 
 pub use config::{FeatureFlag, GlobalConfig};
@@ -492,7 +491,7 @@ note: skipped the following crates since they have no library target: {skipped}"
                 let workspace_overrides =
                     manifest::deserialize_lint_table(&metadata.workspace_metadata)
                         .context("[workspace.metadata.cargo-semver-checks] table is invalid")?
-                        .map(|table| Arc::new(table.inner));
+                        .map(|table| table.into_stack());
 
                 selected
                     .iter()
@@ -535,12 +534,16 @@ note: skipped the following crates since they have no library target: {skipped}"
 
                             if lint_workspace_key || metadata_workspace_key {
                                 if let Some(workspace) = &workspace_overrides {
-                                    overrides.push(Arc::clone(workspace));
+                                    for level in workspace {
+                                        overrides.push(level);
+                                    }
                                 }
                             }
 
                             if let Some(package) = package_overrides {
-                                overrides.push(Arc::new(package.inner));
+                                for level in package.into_stack() {
+                                    overrides.push(&level);
+                                }
                             }
 
                             let start = std::time::Instant::now();


### PR DESCRIPTION
Like the cargo `[lints]` table, the `priority` key in a lint entry is optional (defaults to 0), and a lower (more negative) `priority` overrides a higher (more positive) entry that configures the same lint (which lets us define how to handle a lint group containing a lint, and a lint group).  Changing `OverrideStack` from holding `Arc<OverrideMap>`s to just `OverrideMap`s is setting up for the upcoming lint group PR where each `OverrideMap` will be compiled based on lower items in the `OverrideStack`, so shared ownership doesn't make sense to use anymore.