### PR TITLE
Reduce size of uploaded crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "./README.md"
 keywords = ["semver", "linter", "check", "crate", "cargo"]
 categories = ["command-line-utilities", "development-tools::cargo-plugins"]
 rust-version = "1.77"
+exclude = [".github/", "brand/", "scripts/", "test_crates/", "test_outputs/", "tests/"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Currently, the compressed size of the `cargo-semver-checks` crate on crates.io is 1.6MiB, as listed on crates.io and lib.rs. This is mostly attributed to the brand and test directories, which are not essential for the crate to compile. We can avoid uploading these directories by explicitly excluding them in the manifest using `package.exclude`.