### PR TITLE
Draft: refactor cli with `annotate-snippets`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "annotate-snippets"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e35ed54e5ea7997c14ed4c70ba043478db1112e98263b3b035907aa197d991"
+dependencies = [
+ "anstyle",
+ "unicode-width",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +331,7 @@ dependencies = [
 name = "cargo-semver-checks"
 version = "0.35.0"
 dependencies = [
+ "annotate-snippets",
  "anstream",
  "anstyle",
  "anyhow",
@@ -3720,6 +3731,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3911,7 +3928,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ anstyle = "1.0.8"
 anstream = "0.6.15"
 urlencoding = "2.1.3"
 cargo-config2 = "0.1.29"
+annotate-snippets = "0.11.4"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/lints/function_missing.ron
+++ b/src/lints/function_missing.ron
@@ -45,7 +45,7 @@ SemverQuery(
         "true": true,
     },
     error_message: "A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.",
-    per_result_error_template: Some("function {{join \"::\" path}}"),
+    per_result_error_template: Some("function {{join \"::\" path}}, previously in file {{span_filename}}:{{span_begin_line}}"),
     witness: (
         hint_template: r#"{{join "::" path}}(...);"#,
     ),

--- a/src/lints/function_missing.ron
+++ b/src/lints/function_missing.ron
@@ -45,7 +45,7 @@ SemverQuery(
         "true": true,
     },
     error_message: "A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.",
-    per_result_error_template: Some("function {{join \"::\" path}}, previously in file {{span_filename}}:{{span_begin_line}}"),
+    per_result_error_template: Some("function {{join \"::\" path}}"),
     witness: (
         hint_template: r#"{{join "::" path}}(...);"#,
     ),


### PR DESCRIPTION
Opening this PR not to merge immediately (or even ever) but to show what we could do with `annotate-snippets` and get feedback on the CLI design (to be more rustc/clippy-like).

### Screenshots:

#### `cargo semver-checks --baseline-root test_crates/function_const_removed/old --manifest-path test_crates/function_const_removed/new -Z unstable-options --witness-hints`

<details>
<summary>old</summary>

![image](https://github.com/user-attachments/assets/cb542189-f3d4-48ff-97c9-c0e06ede835d)

</details>

<details>
<summary>new</summary>

![image](https://github.com/user-attachments/assets/80544c0e-0865-49f9-b37b-6308bbaa375f)

</details>

<details>
<summary>when file is not available for span</summary>

![image](https://github.com/user-attachments/assets/32b2e477-b577-453a-888e-b419c6dad766)

</details>

#### on `manifest_tests/workspace_overrides` test crate (warnings + errors)

<details>
<summary>old</summary>

![image](https://github.com/user-attachments/assets/5387d488-fa0e-4a16-8998-d2707799a103)

</details>

<details>
<summary>new</summary>

![image](https://github.com/user-attachments/assets/133addeb-1504-4279-b7e9-603de6f40b73)

</details>

### On compatibility with clippy/rustc:

This is mostly just a port of our current failure printing to use `annotate-snippets` (and adding printing the one-line span snippet).

`clippy`/`rustc` linters show generally less information per lint, and don't group instances of lints occurring by lint type.  We group all lint results and print lots of info for each lint (description, ref link, info link) as well as per-result error info.

<details>
<summary>sample clippy/rustc lints</summary>

![image](https://github.com/user-attachments/assets/6fa14e72-997b-4699-96fd-2141f0bb1fc5)

</details> 

I don't know if we actually want parity with `rustc` in this regard, though.