### PR TITLE
Add third party registry support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,8 @@ pub struct GlobalConfig {
     stdout: AutoStream<Box<dyn Write + 'static>>,
     stderr: AutoStream<Box<dyn Write + 'static>>,
     feature_flags: HashSet<FeatureFlag>,
+    /// Registry name to look up crates in
+    registry: Option<String>,
 }
 
 impl Default for GlobalConfig {
@@ -41,6 +43,7 @@ impl GlobalConfig {
             stdout: AutoStream::new(Box::new(std::io::stdout()), stdout_choice),
             stderr: AutoStream::new(Box::new(std::io::stderr()), stderr_choice),
             feature_flags: HashSet::new(),
+            registry: None,
         }
     }
 
@@ -315,6 +318,19 @@ impl GlobalConfig {
     #[inline]
     pub fn feature_flags(&self) -> &HashSet<FeatureFlag> {
         &self.feature_flags
+    }
+
+    /// Set (overwrite) the name of the registry to use for crate lookup
+    #[inline]
+    pub fn set_registry(&mut self, registry: String) -> &mut Self {
+        self.registry = Some(registry);
+        self
+    }
+
+    /// Return the name of the registry to use for crate lookup
+    #[inline]
+    pub fn registry(&self) -> Option<&str> {
+        self.registry.as_deref()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,10 @@ fn main() {
         None => args.check_release,
     };
 
+    if let Some(registry) = &check_release.registry {
+        config.set_registry(registry.clone());
+    }
+
     let check: cargo_semver_checks::Check = check_release.into();
 
     let report = exit_on_error(config.is_error(), || check.check_release(&mut config));
@@ -531,6 +535,11 @@ struct CheckRelease {
     /// `x86_64-unknown-linux-gnu`.
     #[arg(long = "target")]
     build_target: Option<String>,
+
+    /// Name of registry to use for crate lookups. Used with default behavior
+    /// and with `--baseline-version`.
+    #[arg(long = "registry")]
+    registry: Option<String>,
 
     #[clap(flatten)]
     unstable_options: UnstableOptions,

--- a/src/rustdoc_cmd.rs
+++ b/src/rustdoc_cmd.rs
@@ -478,11 +478,14 @@ fn create_placeholder_rustdoc_manifest(
         },
         dependencies: {
             let project_with_features: DependencyDetail = match crate_source {
-                CrateSource::Registry { version, .. } => DependencyDetail {
+                CrateSource::Registry {
+                    version, index_url, ..
+                } => DependencyDetail {
                     // We need the *exact* version as a dependency, or else cargo will
                     // give us the latest semver-compatible version which is not we want.
                     // Fixes: https://github.com/obi1kenobi/cargo-semver-checks/issues/261
                     version: Some(format!("={version}")),
+                    registry_index: Some(index_url.clone()),
                     features: crate_source
                         .feature_list_from_config(config, crate_data.feature_config),
                     default_features: matches!(


### PR DESCRIPTION
This adds a `--registry` command line flag to the check release capabilities. The argument to the flag is the name of the registry to use to lookup the crates when using the default behavior or --baseline-version. If left unset, the default behavior remains of --checking crates.io.