### PR TITLE
Weekly `cargo update` of dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.20.4"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad639525b1c67b6a298f378417b060fbc04618bea559482a8484381cce27d965"
+checksum = "88da5a13c620b4ca0078845707ea9c3faf11edbc3ffd8497d11d686211cd1ac0"
 dependencies = [
  "serde",
  "toml 0.8.19",
@@ -2074,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2087,7 +2087,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
@@ -2243,9 +2242,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libredox"
@@ -2522,26 +2521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2555,9 +2534,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "powerfmt"
@@ -2728,9 +2707,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -3063,9 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -3463,9 +3442,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.21"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "serde",
@@ -3473,27 +3452,6 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -3533,9 +3491,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "28.1.6"
+version = "28.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c75c87b6555d5d888e2d7047d820cd4586302e42e9dd881ee28800f225b82a7"
+checksum = "5e5995164b553adc19d68cbd0fe1475cfe3f3b70726e1233d82892cd3b9f3e7c"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3545,9 +3503,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "29.1.6"
+version = "29.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2c2b64014ee66c61be248d12ee8db2d6973db90b6f68046e89f13588ca3475"
+checksum = "61c7aaabbf30077cba71ec778f335bc7f3e1f22ab6222bb2d0f6eb3c29ae3dd4"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3557,9 +3515,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "30.1.6"
+version = "30.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a00f2f51bc5f88028ad5ef064e40a9e8af5b313d7e37834c315b681cae2f4"
+checksum = "8a2df7c710f5ff71c63829c79e82c6a8ae80b06bd715d1966cd7de10489da358"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3569,9 +3527,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "32.1.6"
+version = "32.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f826c74e11761b4ef919396c16b3472ed767c81ce40ea6f234d9ba2ac79b65bd"
+checksum = "f8daef0186cf975e26f3ad9cbf9877e69130e7342ed6d174de4f4f92f447542d"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3581,9 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "33.1.6"
+version = "33.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970e7763e31dffc6ee25699cde56c11a45e33c505ab4b08da5e1f4c0861e44f4"
+checksum = "6924f628b5dfafbaa21f8d0cca24b10319c320fc93ffc4807ed6aca193d9bf6a"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3593,9 +3551,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "34.0.0"
+version = "34.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ba718a3adbe0a04a7b4760533c21b48289f66e70e0d25c53dbca2a75b58ec5"
+checksum = "dcf148a8afde9403d7634badb811f19ed14b990c858eda33c9d0b449f34d5569"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3641,12 +3599,12 @@ dependencies = [
  "serde",
  "serde_json",
  "trustfall",
- "trustfall-rustdoc-adapter 28.1.6",
- "trustfall-rustdoc-adapter 29.1.6",
- "trustfall-rustdoc-adapter 30.1.6",
- "trustfall-rustdoc-adapter 32.1.6",
- "trustfall-rustdoc-adapter 33.1.6",
- "trustfall-rustdoc-adapter 34.0.0",
+ "trustfall-rustdoc-adapter 28.1.7",
+ "trustfall-rustdoc-adapter 29.1.7",
+ "trustfall-rustdoc-adapter 30.1.7",
+ "trustfall-rustdoc-adapter 32.1.7",
+ "trustfall-rustdoc-adapter 33.1.7",
+ "trustfall-rustdoc-adapter 34.0.1",
 ]
 
 [[package]]
@@ -4100,9 +4058,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
Automation to keep dependencies in `Cargo.lock` current.

The following is the output from `cargo update`:

```txt
     Locking 14 packages to latest compatible versions
    Updating cargo_toml v0.20.4 -> v0.20.5
    Updating hyper-util v0.1.8 -> v0.1.9
    Updating libc v0.2.158 -> v0.2.159
    Removing pin-project v1.1.5
    Removing pin-project-internal v1.1.5
    Updating pkg-config v0.3.30 -> v0.3.31
    Updating redox_syscall v0.5.4 -> v0.5.6
    Updating serde_spanned v0.6.7 -> v0.6.8
    Updating toml_edit v0.22.21 -> v0.22.22
    Removing tower v0.4.13
    Removing tower-layer v0.3.3
    Removing trustfall-rustdoc-adapter v28.1.6
    Removing trustfall-rustdoc-adapter v29.1.6
    Removing trustfall-rustdoc-adapter v30.1.6
    Removing trustfall-rustdoc-adapter v32.1.6
    Removing trustfall-rustdoc-adapter v33.1.6
    Removing trustfall-rustdoc-adapter v34.0.0
      Adding trustfall-rustdoc-adapter v28.1.7 (latest: v34.0.1)
      Adding trustfall-rustdoc-adapter v29.1.7 (latest: v34.0.1)
      Adding trustfall-rustdoc-adapter v30.1.7 (latest: v34.0.1)
      Adding trustfall-rustdoc-adapter v32.1.7 (latest: v34.0.1)
      Adding trustfall-rustdoc-adapter v33.1.7 (latest: v34.0.1)
      Adding trustfall-rustdoc-adapter v34.0.1
    Updating winnow v0.6.18 -> v0.6.20
note: pass `--verbose` to see 59 unchanged dependencies behind latest
```
