### PR TITLE
Weekly `cargo update` of dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
@@ -386,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "9540e661f81799159abee814118cc139a2004b3a3aa3ea37724a1b66530b90e0"
 dependencies = [
  "shlex",
 ]
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "clap-verbosity-flag"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d19864d6b68464c59f7162c9914a0b569ddc2926b4a2d71afe62a9738eff53"
+checksum = "e099138e1807662ff75e2cebe4ae2287add879245574489f9b1588eb5e5564ed"
 dependencies = [
  "clap",
  "log",
@@ -722,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "libz-ng-sys",
@@ -2407,9 +2407,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -2537,6 +2540,12 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "powerfmt"
@@ -2727,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2739,9 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2750,9 +2759,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -2954,9 +2963,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-webpki"
@@ -3201,9 +3210,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3277,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -3491,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "28.1.7"
+version = "28.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5995164b553adc19d68cbd0fe1475cfe3f3b70726e1233d82892cd3b9f3e7c"
+checksum = "7556054abac8b2d9da7c37b888340b14c2215935108dadeddb358b2282b4bf9c"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3503,9 +3512,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "29.1.7"
+version = "29.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c7aaabbf30077cba71ec778f335bc7f3e1f22ab6222bb2d0f6eb3c29ae3dd4"
+checksum = "289386d00d0577e72c84fc2b3d2d1efb428b7ce069e0fd557b821d20433da8f0"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3515,9 +3524,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "30.1.7"
+version = "30.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2df7c710f5ff71c63829c79e82c6a8ae80b06bd715d1966cd7de10489da358"
+checksum = "74af34d39da474849a3b4662164ff6270e456d03372132f0c698b55fa0491002"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3527,9 +3536,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "32.1.7"
+version = "32.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8daef0186cf975e26f3ad9cbf9877e69130e7342ed6d174de4f4f92f447542d"
+checksum = "0334ac29abbfac7d0fbfd5d496f8848ec5cb40cc4cff2e321ccab0b7b5ea66d2"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3539,9 +3548,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "33.1.7"
+version = "33.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924f628b5dfafbaa21f8d0cca24b10319c320fc93ffc4807ed6aca193d9bf6a"
+checksum = "29e81aaeae0587a1ec919f8d922831bb78a5de4f7969e820e758deec00ce0b50"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3551,9 +3560,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "34.0.1"
+version = "34.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf148a8afde9403d7634badb811f19ed14b990c858eda33c9d0b449f34d5569"
+checksum = "17cf8d6fe76e2a0eabdbb4d767bda8812ab8c82dce7d42969bfb5de9ef2c7240"
 dependencies = [
  "rayon",
  "rustc-hash",
@@ -3599,12 +3608,12 @@ dependencies = [
  "serde",
  "serde_json",
  "trustfall",
- "trustfall-rustdoc-adapter 28.1.7",
- "trustfall-rustdoc-adapter 29.1.7",
- "trustfall-rustdoc-adapter 30.1.7",
- "trustfall-rustdoc-adapter 32.1.7",
- "trustfall-rustdoc-adapter 33.1.7",
- "trustfall-rustdoc-adapter 34.0.1",
+ "trustfall-rustdoc-adapter 28.1.8",
+ "trustfall-rustdoc-adapter 29.1.8",
+ "trustfall-rustdoc-adapter 30.1.8",
+ "trustfall-rustdoc-adapter 32.1.8",
+ "trustfall-rustdoc-adapter 33.1.8",
+ "trustfall-rustdoc-adapter 34.0.2",
 ]
 
 [[package]]
@@ -3631,9 +3640,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uluru"


### PR DESCRIPTION
Automation to keep dependencies in `Cargo.lock` current.

The following is the output from `cargo update`:

```txt
     Locking 19 packages to latest compatible versions
    Updating autocfg v1.3.0 -> v1.4.0
    Updating cc v1.1.21 -> v1.1.22
    Updating clap-verbosity-flag v2.2.1 -> v2.2.2
    Updating flate2 v1.0.33 -> v1.0.34
    Updating once_cell v1.19.0 -> v1.20.1
      Adding portable-atomic v1.9.0
    Updating regex v1.10.6 -> v1.11.0
    Updating regex-automata v0.4.7 -> v0.4.8
    Updating regex-syntax v0.8.4 -> v0.8.5
    Updating rustls-pki-types v1.8.0 -> v1.9.0
    Updating syn v2.0.77 -> v2.0.79
    Updating tempfile v3.12.0 -> v3.13.0
    Removing trustfall-rustdoc-adapter v28.1.7
    Removing trustfall-rustdoc-adapter v29.1.7
    Removing trustfall-rustdoc-adapter v30.1.7
    Removing trustfall-rustdoc-adapter v32.1.7
    Removing trustfall-rustdoc-adapter v33.1.7
    Removing trustfall-rustdoc-adapter v34.0.1
      Adding trustfall-rustdoc-adapter v28.1.8 (latest: v34.0.2)
      Adding trustfall-rustdoc-adapter v29.1.8 (latest: v34.0.2)
      Adding trustfall-rustdoc-adapter v30.1.8 (latest: v34.0.2)
      Adding trustfall-rustdoc-adapter v32.1.8 (latest: v34.0.2)
      Adding trustfall-rustdoc-adapter v33.1.8 (latest: v34.0.2)
      Adding trustfall-rustdoc-adapter v34.0.2
    Updating ucd-trie v0.1.6 -> v0.1.7
note: pass `--verbose` to see 59 unchanged dependencies behind latest
```
