### PR TITLE
Add lint group infra

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@ use trustfall_rustdoc::{load_rustdoc, VersionedCrate};
 use rustdoc_cmd::RustdocCommand;
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::Instant;
 
 pub use config::{FeatureFlag, GlobalConfig};
@@ -492,7 +491,7 @@ note: skipped the following crates since they have no library target: {skipped}"
                 let workspace_overrides =
                     manifest::deserialize_lint_table(&metadata.workspace_metadata)
                         .context("[workspace.metadata.cargo-semver-checks] table is invalid")?
-                        .map(|table| Arc::new(table.inner));
+                        .map(|table| table.into_stack());
 
                 selected
                     .iter()
@@ -535,12 +534,16 @@ note: skipped the following crates since they have no library target: {skipped}"
 
                             if lint_workspace_key || metadata_workspace_key {
                                 if let Some(workspace) = &workspace_overrides {
-                                    overrides.push(Arc::clone(workspace));
+                                    for level in workspace {
+                                        overrides.push(level);
+                                    }
                                 }
                             }
 
                             if let Some(package) = package_overrides {
-                                overrides.push(Arc::new(package.inner));
+                                for level in package.into_stack() {
+                                    overrides.push(&level);
+                                }
                             }
 
                             let start = std::time::Instant::now();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod util;
 
 use anyhow::Context;
 use cargo_metadata::PackageId;
-use clap::ValueEnum;
+use clap::{crate_version, ValueEnum};
 use directories::ProjectDirs;
 use itertools::Itertools;
 
@@ -27,8 +27,8 @@ use std::time::Instant;
 
 pub use config::{FeatureFlag, GlobalConfig};
 pub use query::{
-    ActualSemverUpdate, LintLevel, OverrideMap, OverrideStack, QueryOverride, RequiredSemverUpdate,
-    SemverQuery,
+    ActualSemverUpdate, Identifier, LintGroup, LintLevel, OverrideMap, OverrideStack,
+    QueryOverride, RequiredSemverUpdate, SemverQuery,
 };
 
 /// Test a release for semver violations.
@@ -535,14 +535,22 @@ note: skipped the following crates since they have no library target: {skipped}"
                             if lint_workspace_key || metadata_workspace_key {
                                 if let Some(workspace) = &workspace_overrides {
                                     for level in workspace {
-                                        overrides.push(level);
+                                        overrides.try_push(level).with_context(|| format!("add a `priority` key to the entries in [workspace.metadata.cargo-semver-checks.lints].\n\
+                                            (at path {})\n\
+                                            See https://github.com/obi1kenobi/cargo-semver-checks/blob/v{}/README.md#configuration-priority for more info.",
+                                            metadata.workspace_root, crate_version!()
+                                        ))?;
                                     }
                                 }
                             }
 
                             if let Some(package) = package_overrides {
                                 for level in package.into_stack() {
-                                    overrides.push(&level);
+                                    overrides.try_push(&level).with_context(|| format!("add a `priority` key to the entries in [package.metadata.cargo-semver-checks.lints].\n\
+                                        (for crate {} at path {})\n\
+                                        See https://github.com/obi1kenobi/cargo-semver-checks/blob/v{}/README.md#configuration-priority for more info.",
+                                        selected.name, selected.manifest_path, crate_version!()
+                                    ))?;
                                 }
                             }
 

--- a/src/lints/enum_must_use_added.ron
+++ b/src/lints/enum_must_use_added.ron
@@ -4,6 +4,7 @@ SemverQuery(
     description: "An enum has been marked with #[must_use].",
     required_update: Minor,
     lint_level: Deny,
+    lint_group: must_use_added,
 
     // TODO: Change the reference link to point to the cargo semver reference
     //       once it has a section on attribute #[must_use].

--- a/src/lints/function_must_use_added.ron
+++ b/src/lints/function_must_use_added.ron
@@ -4,6 +4,7 @@ SemverQuery(
     description: "A function has been marked with #[must_use].",
     required_update: Minor,
     lint_level: Deny,
+    lint_group: must_use_added,
 
     // TODO: Change the reference link to point to the cargo semver reference
     //       once it has a section on attribute #[must_use].

--- a/src/lints/inherent_method_must_use_added.ron
+++ b/src/lints/inherent_method_must_use_added.ron
@@ -4,6 +4,7 @@ SemverQuery(
     description: "An inherent method or associated fn has been marked #[must_use].",
     required_update: Minor,
     lint_level: Deny,
+    lint_group: must_use_added,
 
     // TODO: Change the reference link to point to the cargo semver reference
     //       once it has a section on attribute #[must_use].

--- a/src/lints/struct_must_use_added.ron
+++ b/src/lints/struct_must_use_added.ron
@@ -4,6 +4,7 @@ SemverQuery(
     description: "A struct has been marked with #[must_use].",
     required_update: Minor,
     lint_level: Deny,
+    lint_group: must_use_added,
 
     // TODO: Change the reference link to point to the cargo semver reference
     //       once it has a section on attribute #[must_use].

--- a/src/lints/trait_must_use_added.ron
+++ b/src/lints/trait_must_use_added.ron
@@ -4,6 +4,7 @@ SemverQuery(
     description: "A trait has been marked with #[must_use].",
     required_update: Minor,
     lint_level: Deny,
+    lint_group: must_use_added,
 
     // TODO: Change the reference link to point to the cargo semver reference
     //       once it has a section on attribute #[must_use].

--- a/src/lints/union_must_use_added.ron
+++ b/src/lints/union_must_use_added.ron
@@ -4,6 +4,7 @@ SemverQuery(
     description: "A union has been marked with #[must_use].",
     required_update: Minor,
     lint_level: Deny,
+    lint_group: must_use_added,
     reference_link: Some("https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute"),
     query: r#"
     {

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::OnceLock};
 
 use ron::extensions::Extensions;
 use serde::{Deserialize, Serialize};
@@ -103,6 +103,10 @@ pub struct SemverQuery {
     /// The default lint level for when this lint occurs.
     pub lint_level: LintLevel,
 
+    /// The [`LintGroup`] that this query is a member of (currently optional).
+    #[serde(default)]
+    pub lint_group: Option<LintGroup>,
+
     #[serde(default)]
     pub reference: Option<String>,
 
@@ -159,6 +163,9 @@ impl SemverQuery {
     }
 }
 
+// TODO: replace with LazyLock once MSRV is >= 1.80
+pub(crate) static ALL_QUERIES: OnceLock<BTreeMap<String, SemverQuery>> = OnceLock::new();
+
 /// Configured values for a [`SemverQuery`] that differ from the lint's defaults.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -178,15 +185,49 @@ pub struct QueryOverride {
     pub lint_level: Option<LintLevel>,
 }
 
-/// A mapping of lint ids to configured values that override that lint's defaults.
-pub type OverrideMap = BTreeMap<String, QueryOverride>;
+/// A mapping of `Identifier`s to configured values that override those lints' defaults.
+pub type OverrideMap = BTreeMap<Identifier, QueryOverride>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LintGroup {
+    MustUseAdded,
+}
+
+/// An identifier that matches a lint, or a group of lints.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Identifier {
+    /// Identifies a group of lints, based on the [`SemverQuery::lint_group`] field.
+    Group(LintGroup),
+    /// Identifies a singular lint by id.
+    Lint(String),
+}
+
+impl Identifier {
+    /// Returns a list of lint ids that this identifier refers to, given the set of
+    /// all queries.
+    pub(crate) fn lints<'a>(
+        &'a self,
+        all_queries: &'a BTreeMap<String, SemverQuery>,
+    ) -> Vec<&'a str> {
+        match self {
+            Self::Group(gp) => all_queries
+                .iter()
+                .filter(|(_, q)| q.lint_group == Some(*gp))
+                .map(|(id, _)| id.as_str())
+                .collect(),
+            Self::Lint(lint) => vec![lint.as_str()],
+        }
+    }
+}
 
 /// Stores a stack of [`OverrideMap`]s such that items towards the top of
 /// the stack (later in the backing `Vec`) have *higher* precedence and override items lower in the stack.
 /// That is, when an override is set and not `None` for a given lint in multiple maps in the stack, the value
 /// at the top of the stack will be used to calculate the effective lint level or required version update.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct OverrideStack(Vec<OverrideMap>);
+pub struct OverrideStack(Vec<BTreeMap<String, QueryOverride>>);
 
 impl OverrideStack {
     /// Creates a new, empty [`OverrideStack`] instance.
@@ -199,8 +240,45 @@ impl OverrideStack {
     ///
     /// The inserted overrides will take precedence over any lower item in the stack,
     /// if both maps have a not-`None` entry for a given lint.
-    pub fn push(&mut self, item: &OverrideMap) {
-        self.0.push(item.clone());
+    ///
+    /// # Errors
+    ///
+    /// Returns an `Err` if there is a configuration conflict in the passed map: when
+    /// multiple entries in `item` configure the same entry for the same lint. To handle
+    /// configuration precedence in a defined way, call this function multiple times, and
+    /// entries at the top of the stack will override entries towards the bottom of the stack
+    /// when there is a conflict.
+    pub fn try_push(&mut self, item: &OverrideMap) -> anyhow::Result<()> {
+        let mut compiled_map = BTreeMap::<_, QueryOverride>::new();
+
+        for (id, overrides) in item {
+            let lints = id.lints(ALL_QUERIES.get_or_init(SemverQuery::all_queries));
+
+            for lint in lints {
+                if let Some(entry) = compiled_map.get_mut(lint) {
+                    if let Some(lint_level) = overrides.lint_level {
+                        if let Some(old) = entry.lint_level {
+                            anyhow::bail!("Configuration conflict detected for lint `{lint}`:\n\
+                                lint level is set to `{old:?}` and {lint_level:?} at the same config priority.");
+                        }
+                        entry.lint_level = Some(lint_level);
+                    }
+
+                    if let Some(required_update) = overrides.required_update {
+                        if let Some(old) = entry.required_update {
+                            anyhow::bail!("Configuration conflict detected for lint `{lint}`:\n\
+                                required update is set to `{old:?}` and {required_update:?} at the same config priority.");
+                        }
+                        entry.required_update = Some(required_update);
+                    }
+                } else {
+                    compiled_map.insert(lint.to_owned(), overrides.clone());
+                }
+            }
+        }
+
+        self.0.push(compiled_map);
+        Ok(())
     }
 
     /// Calculates the *effective* lint level of this query, by searching for an override
@@ -243,7 +321,8 @@ mod tests {
     };
 
     use crate::query::{
-        LintLevel, OverrideMap, OverrideStack, QueryOverride, RequiredSemverUpdate, SemverQuery,
+        Identifier, LintLevel, OverrideMap, OverrideStack, QueryOverride, RequiredSemverUpdate,
+        SemverQuery,
     };
     use crate::templating::make_handlebars_registry;
 
@@ -578,6 +657,7 @@ mod tests {
             id,
             lint_level,
             required_update,
+            lint_group: None,
             human_readable_name: String::new(),
             description: String::new(),
             reference: None,
@@ -592,22 +672,24 @@ mod tests {
     #[test]
     fn test_overrides() {
         let mut stack = OverrideStack::new();
-        stack.push(&OverrideMap::from_iter([
-            (
-                "query1".into(),
-                QueryOverride {
-                    lint_level: Some(LintLevel::Allow),
-                    required_update: Some(RequiredSemverUpdate::Minor),
-                },
-            ),
-            (
-                "query2".into(),
-                QueryOverride {
-                    lint_level: None,
-                    required_update: Some(RequiredSemverUpdate::Minor),
-                },
-            ),
-        ]));
+        stack
+            .try_push(&OverrideMap::from_iter([
+                (
+                    Identifier::Lint("query1".into()),
+                    QueryOverride {
+                        lint_level: Some(LintLevel::Allow),
+                        required_update: Some(RequiredSemverUpdate::Minor),
+                    },
+                ),
+                (
+                    Identifier::Lint("query2".into()),
+                    QueryOverride {
+                        lint_level: None,
+                        required_update: Some(RequiredSemverUpdate::Minor),
+                    },
+                ),
+            ]))
+            .expect("conflict");
 
         let q1 = make_blank_query(
             "query1".into(),
@@ -639,30 +721,34 @@ mod tests {
     #[test]
     fn test_override_precedence() {
         let mut stack = OverrideStack::new();
-        stack.push(&OverrideMap::from_iter([
-            (
-                "query1".into(),
-                QueryOverride {
-                    lint_level: Some(LintLevel::Allow),
-                    required_update: Some(RequiredSemverUpdate::Minor),
-                },
-            ),
-            (
-                ("query2".into()),
-                QueryOverride {
-                    lint_level: None,
-                    required_update: Some(RequiredSemverUpdate::Minor),
-                },
-            ),
-        ]));
+        stack
+            .try_push(&OverrideMap::from_iter([
+                (
+                    Identifier::Lint("query1".into()),
+                    QueryOverride {
+                        lint_level: Some(LintLevel::Allow),
+                        required_update: Some(RequiredSemverUpdate::Minor),
+                    },
+                ),
+                (
+                    Identifier::Lint("query2".into()),
+                    QueryOverride {
+                        lint_level: None,
+                        required_update: Some(RequiredSemverUpdate::Minor),
+                    },
+                ),
+            ]))
+            .expect("conflict");
 
-        stack.push(&OverrideMap::from_iter([(
-            "query1".into(),
-            QueryOverride {
-                required_update: None,
-                lint_level: Some(LintLevel::Warn),
-            },
-        )]));
+        stack
+            .try_push(&OverrideMap::from_iter([(
+                Identifier::Lint("query1".into()),
+                QueryOverride {
+                    required_update: None,
+                    lint_level: Some(LintLevel::Warn),
+                },
+            )]))
+            .expect("conflict");
 
         let q1 = make_blank_query(
             "query1".into(),

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -368,3 +368,19 @@ fn multiple_ambiguous_package_name_definitions() {
         ],
     );
 }
+
+/// Snapshot the error message when there is a configuration conflict in `[package.metadata]`
+#[test]
+fn configuration_conflict() {
+    assert_integration_test(
+        "configuration_conflict",
+        &[
+            "cargo",
+            "semver-checks",
+            "--baseline-root",
+            "test_crates/manifest_tests/configuration_conflict/old",
+            "--manifest-path",
+            "test_crates/manifest_tests/configuration_conflict/new",
+        ],
+    );
+}

--- a/test_crates/manifest_tests/configuration_conflict/new/Cargo.toml
+++ b/test_crates/manifest_tests/configuration_conflict/new/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+publish = false
+name = "configuration_conflict"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.cargo-semver-checks.lints]
+must_use_added = "warn"
+function_must_use_added = { level = "deny", required-update = "major" }

--- a/test_crates/manifest_tests/configuration_conflict/old/Cargo.toml
+++ b/test_crates/manifest_tests/configuration_conflict/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "configuration_conflict"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/lint_group/new/Cargo.toml
+++ b/test_crates/manifest_tests/lint_group/new/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+publish = false
+name = "lint_group"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.cargo-semver-checks.lints]
+must_use_added = { level = "warn", required-update = "major" }
+function_must_use_added = { level = "deny", priority = -1 }
+enum_must_use_added = { level = "allow", priority = 1 }

--- a/test_crates/manifest_tests/lint_group/new/src/lib.rs
+++ b/test_crates/manifest_tests/lint_group/new/src/lib.rs
@@ -1,0 +1,14 @@
+/// Should trigger the function_must_use_added lint, which is configured
+/// as allow (priority -1) and major (priority 0)
+#[must_use]
+pub fn function() {}
+
+/// Should trigger the enum_must_use_added lint, which is configured as
+/// warn and major from the `must_use_added` lint group
+#[must_use]
+pub enum Enum {}
+
+/// Should trigger the struct_must_use_added lint, which is configured as deny with priority 1,
+/// but overriden in the `must_use_added` with priority 0.
+#[must_use]
+pub struct Struct;

--- a/test_crates/manifest_tests/lint_group/old/Cargo.toml
+++ b/test_crates/manifest_tests/lint_group/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "lint_group"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/lint_group/old/src/lib.rs
+++ b/test_crates/manifest_tests/lint_group/old/src/lib.rs
@@ -1,0 +1,14 @@
+/// Should trigger the function_must_use_added lint, which is configured
+/// as allow (priority -1) and major (priority 0)
+// + #[must_use]
+pub fn function() {}
+
+/// Should trigger the enum_must_use_added lint, which is configured as
+/// warn and major from the `must_use_added` lint group
+// + #[must_use]
+pub enum Enum {}
+
+/// Should trigger the struct_must_use_added lint, which is configured as deny with priority 1,
+/// but overriden in the `must_use_added` with priority 0.
+// + #[must_use]
+pub struct Struct;

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__configuration_conflict-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__configuration_conflict-input.snap
@@ -1,0 +1,30 @@
+---
+source: src/snapshot_tests.rs
+expression: check
+---
+Check(
+  scope: Scope(
+    mode: DenyList(PackageSelection(
+      selection: DefaultMembers,
+      excluded_packages: [],
+    )),
+  ),
+  current: Rustdoc(
+    source: Root("test_crates/manifest_tests/configuration_conflict/new"),
+  ),
+  baseline: Rustdoc(
+    source: Root("test_crates/manifest_tests/configuration_conflict/old"),
+  ),
+  release_type: None,
+  current_feature_config: FeatureConfig(
+    features_group: Heuristic,
+    extra_features: [],
+    is_baseline: false,
+  ),
+  baseline_feature_config: FeatureConfig(
+    features_group: Heuristic,
+    extra_features: [],
+    is_baseline: true,
+  ),
+  build_target: None,
+)

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__configuration_conflict-output.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__configuration_conflict-output.snap
@@ -1,0 +1,11 @@
+---
+source: src/snapshot_tests.rs
+expression: result
+---
+--- error ---
+add a `priority` key to the entries in [package.metadata.cargo-semver-checks.lints].
+(for crate configuration_conflict at path [ROOT]/test_crates/manifest_tests/configuration_conflict/new/Cargo.toml)
+See https://github.com/obi1kenobi/cargo-semver-checks/blob/v0.35.0/README.md#configuration-priority for more info.
+--- stdout ---
+
+--- stderr ---

--- a/tests/lint_config.rs
+++ b/tests/lint_config.rs
@@ -140,3 +140,19 @@ fn test_only_read_config_from_new_manifest() {
         .stderr(predicates::str::is_match("FAIL(.*)struct_missing").expect("regex should be valid"))
         .failure();
 }
+
+/// Tests basic lint group functionality
+#[test]
+fn test_lint_groups() {
+    let assert = command_for_crate("lint_group").assert();
+    assert
+        // priority -1 deny overrides priority 0 warn, but use required update from priority 0
+        // because none is set in priority -1
+        .stderr(
+            predicates::str::is_match("FAIL(.*)major(.*)function_must_use_added").expect("regex"),
+        )
+        // configuration from lint group
+        .stderr(predicates::str::is_match("WARN(.*)major(.*)struct_must_use_added").expect("regex"))
+        // priority 0 (lint group) warn overrides priority 1 allow
+        .stderr(predicates::str::is_match("WARN(.*)major(.*)enum_must_use_added").expect("regex"));
+}


### PR DESCRIPTION
Adds:

- the `Identifier` enum for consistent configuration with lint groups and lints
- `OverrideStack::try_push` which tries to compile a `Map<Identifier, Override>` to a `Map<String (= lint id), Override>`, and errors on a conflict
- the `must_use_added` lint group
 - currently the `lint_group` field on `SemverQuery` is optional while we figure out what lints go in what groups (and what groups to include).  `must_use_added` is an example from my design draft, but we can definitely go in a different direction.  Eventually the goal is to make `lint_group` not an Option, so every lint is associated with exactly one lint group
- some tests + documentation, and user documentation in the README