### PR TITLE
fixed a typo in `NoneExhaustiveFieldlessUnit`

### DIFF
--- a/test_crates/struct_becomes_enum/new/src/lib.rs
+++ b/test_crates/struct_becomes_enum/new/src/lib.rs
@@ -92,7 +92,7 @@ impl NonExhaustiveEmptyStructToEnum {
 // The following structs are also not externally-constructible due to `#[non_exhaustive]`.
 
 #[non_exhaustive]
-pub enum NoneExhaustiveFieldlessUnit {
+pub enum NonExhaustiveFieldlessUnit {
     Var,
 }
 

--- a/test_crates/struct_becomes_enum/old/src/lib.rs
+++ b/test_crates/struct_becomes_enum/old/src/lib.rs
@@ -92,7 +92,7 @@ impl NonExhaustiveEmptyStructToEnum {
 // The following structs are also not externally-constructible due to `#[non_exhaustive]`.
 
 #[non_exhaustive]
-pub struct NoneExhaustiveFieldlessUnit;
+pub struct NonExhaustiveFieldlessUnit;
 
 #[non_exhaustive]
 pub struct NonExhaustiveFieldlessTuple();


### PR DESCRIPTION
This is an unrelated typo I noticed in #963
Pulled out to not break the "not changing unrelated stuff" rule