### PR TITLE
Add lint `declarative_macro_missing`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".github/", "brand/", "scripts/", "test_crates/", "test_outputs/", "t
 
 [dependencies]
 trustfall = "0.7.1"
-trustfall_rustdoc = { version = "0.16.2", default-features = false, features = ["v28", "v29", "v30", "v32", "v33", "v34", "rayon", "rustc-hash"] }
+trustfall_rustdoc = { version = "0.16.2", default-features = false, features = ["v28", "v29", "v30", "v32", "v33", "v34", "v35", "rayon", "rustc-hash"] }
 clap = { version = "4.5.17", features = ["derive", "cargo"] }
 serde_json = "1.0.128"
 anyhow = "1.0.89"

--- a/src/lints/declarative_macro_missing.ron
+++ b/src/lints/declarative_macro_missing.ron
@@ -26,7 +26,6 @@ SemverQuery(
                 item {
                     ... on Macro {
                         visibility_limit @filter(op: "=", value: ["$public"])
-                        public_api_eligible @filter(op: "=", value: ["$true"])
                         name @filter(op: "=", value: ["%name"])
                     }
                 }

--- a/src/lints/declarative_macro_missing.ron
+++ b/src/lints/declarative_macro_missing.ron
@@ -1,0 +1,46 @@
+SemverQuery(
+    id: "declarative_macro_missing",
+    human_readable_name: "macro_rules declaration removed or renamed",
+    description: "A declarative macro marked with #[macro_export] can no longer imported by its prior name.",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/reference/macros-by-example.html#path-based-scope"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Macro {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        public_api_eligible @filter(op: "=", value: ["$true"])
+                        name @output @tag
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+            current @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                item {
+                    ... on Macro {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        public_api_eligible @filter(op: "=", value: ["$true"])
+                        name @filter(op: "=", value: ["%name"])
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "zero": 0,
+        "true": true,
+    },
+    error_message: "A publicly-visible `macro_rules` declarative macro cannot be imported by its prior name. A `#[macro_export]` may have been removed, or the macro itself may have been renamed or removed entirely.",
+    per_result_error_template:  Some("macro_rules! {{name}}, previously in file {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+        hint_template: r#"{{name}}!(...);"#
+    ),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1009,6 +1009,7 @@ add_lints!(
     constructible_struct_adds_field,
     constructible_struct_adds_private_field,
     constructible_struct_changed_type,
+    declarative_macro_missing,
     derive_trait_impl_removed,
     enum_marked_non_exhaustive,
     enum_missing,

--- a/test_crates/declarative_macro_missing/new/Cargo.toml
+++ b/test_crates/declarative_macro_missing/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "declarative_macro_missing"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/declarative_macro_missing/new/src/lib.rs
+++ b/test_crates/declarative_macro_missing/new/src/lib.rs
@@ -1,0 +1,3 @@
+macro_rules! will_no_longer_be_exported {
+    () => {};
+}

--- a/test_crates/declarative_macro_missing/new/src/lib.rs
+++ b/test_crates/declarative_macro_missing/new/src/lib.rs
@@ -1,3 +1,15 @@
 macro_rules! will_no_longer_be_exported {
     () => {};
 }
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! became_doc_hidden {
+    () => {};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! always_doc_hidden {
+    () => {};
+}

--- a/test_crates/declarative_macro_missing/old/Cargo.toml
+++ b/test_crates/declarative_macro_missing/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "declarative_macro_missing"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/declarative_macro_missing/old/src/lib.rs
+++ b/test_crates/declarative_macro_missing/old/src/lib.rs
@@ -1,0 +1,13 @@
+#[macro_export]
+macro_rules! will_be_removed {
+    () => {};
+}
+
+#[macro_export]
+macro_rules! will_no_longer_be_exported {
+    () => {};
+}
+
+macro_rules! textual_scope_macro_removed {
+    () => {};
+}

--- a/test_crates/declarative_macro_missing/old/src/lib.rs
+++ b/test_crates/declarative_macro_missing/old/src/lib.rs
@@ -11,3 +11,14 @@ macro_rules! will_no_longer_be_exported {
 macro_rules! textual_scope_macro_removed {
     () => {};
 }
+
+#[macro_export]
+macro_rules! became_doc_hidden {
+    () => {};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! always_doc_hidden {
+    () => {};
+}

--- a/test_outputs/query_execution/declarative_macro_missing.snap
+++ b/test_outputs/query_execution/declarative_macro_missing.snap
@@ -1,0 +1,18 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+---
+{
+  "./test_crates/declarative_macro_missing/": [
+    {
+      "name": String("will_be_removed"),
+      "span_begin_line": Uint64(2),
+      "span_filename": String("src/lib.rs"),
+    },
+    {
+      "name": String("will_no_longer_be_exported"),
+      "span_begin_line": Uint64(7),
+      "span_filename": String("src/lib.rs"),
+    },
+  ],
+}

--- a/test_outputs/witnesses/declarative_macro_missing.snap
+++ b/test_outputs/witnesses/declarative_macro_missing.snap
@@ -1,0 +1,14 @@
+---
+source: src/query.rs
+description: "Lint `declarative_macro_missing` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+---
+[["./test_crates/declarative_macro_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 2
+hint = 'will_be_removed!(...);'
+
+[["./test_crates/declarative_macro_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 7
+hint = 'will_no_longer_be_exported!(...);'


### PR DESCRIPTION
Working to implement the first item in #946: "removing a declarative macro that used to exist".

There's this case as well, but I'm not sure if it can be currently queried for:

```rust
#[macro_export]
macro_rules! inner_pub_use_will_be_removed {
    () => {};
}

pub mod inner {
    // Is it a breaking change if you remove the next line?
    pub use crate::inner_pub_use_will_be_removed;
}
```