### PR TITLE
Add next Rust minor to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         #
         #            Also make sure to update the MSRV in the cargo-semver-checks-action CI:
         #            https://github.com/obi1kenobi/cargo-semver-checks-action/blob/main/.github/workflows/test-action.yml#L18
-        toolchain: ["1.77", "1.78", "1.79", "1.80", "stable", "beta"]
+        toolchain: ["1.77", "1.78", "1.79", "1.80", "1.81", "stable", "beta"]
         experimental: [false]
         include:
           - toolchain: "nightly"


### PR DESCRIPTION
Automation to ensure we test on all supported Rust versions as new stable Rust versions are released.

The following is the output from `git diff`:

```diff
diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
index c89eab0..3bae760 100644
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         #
         #            Also make sure to update the MSRV in the cargo-semver-checks-action CI:
         #            https://github.com/obi1kenobi/cargo-semver-checks-action/blob/main/.github/workflows/test-action.yml#L18
-        toolchain: ["1.77", "1.78", "1.79", "1.80", "stable", "beta"]
+        toolchain: ["1.77", "1.78", "1.79", "1.80", "1.81", "stable", "beta"]
         experimental: [false]
         include:
           - toolchain: "nightly"
```
