### PR TITLE
feat: add witnesses for `function_const_removed`

### DIFF
--- a/src/lints/function_const_removed.ron
+++ b/src/lints/function_const_removed.ron
@@ -48,4 +48,9 @@ SemverQuery(
     },
     error_message: "A publicly-visible function is no longer `const` and can no longer be used in a `const` context.",
     per_result_error_template: Some("function {{join \"::\" path}} in file {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+        hint_template: r#"const fn foo() {
+    {{join "::" path}}(...);
+}"#,
+    ),
 )

--- a/src/lints/function_const_removed.ron
+++ b/src/lints/function_const_removed.ron
@@ -49,7 +49,7 @@ SemverQuery(
     error_message: "A publicly-visible function is no longer `const` and can no longer be used in a `const` context.",
     per_result_error_template: Some("function {{join \"::\" path}} in file {{span_filename}}:{{span_begin_line}}"),
     witness: (
-        hint_template: r#"const fn foo() {
+        hint_template: r#"const fn witness() {
     {{join "::" path}}(...);
 }"#,
     ),

--- a/test_outputs/witnesses/function_const_removed.snap
+++ b/test_outputs/witnesses/function_const_removed.snap
@@ -1,0 +1,12 @@
+---
+source: src/query.rs
+description: "Lint `function_const_removed` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+---
+[["./test_crates/function_const_removed/"]]
+filename = 'src/lib.rs'
+begin_line = 1
+hint = '''
+const fn foo() {
+    function_const_removed::add(...);
+}'''

--- a/test_outputs/witnesses/function_const_removed.snap
+++ b/test_outputs/witnesses/function_const_removed.snap
@@ -7,6 +7,6 @@ expression: "&actual_witnesses"
 filename = 'src/lib.rs'
 begin_line = 1
 hint = '''
-const fn foo() {
+const fn witness() {
     function_const_removed::add(...);
 }'''


### PR DESCRIPTION
Related to https://github.com/obi1kenobi/cargo-semver-checks/issues/937

A better whitness would be the following, but I have no clue if this is possible and if yes, how.
I have tried a few things, but I am missing something. Maybe this would require a query.
```rs
add() // if len(arguments) == 0
add(...) // if len(arguments) >= 1
```

=> is the compromise okay of letting this be `add(...)` to save on adding a whitness-query just for this?