### PR TITLE
chore: add a witness for `enum_variant_missing`

### DIFF
--- a/src/lints/enum_variant_missing.ron
+++ b/src/lints/enum_variant_missing.ron
@@ -19,6 +19,8 @@ SemverQuery(
                         }
 
                         variant {
+                            kind: __typename @output
+
                             variant_name: name @output @tag
                             public_api_eligible @filter(op: "=", value: ["$true"])
 
@@ -57,6 +59,6 @@ SemverQuery(
     error_message: "A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.",
     per_result_error_template: Some("variant {{enum_name}}::{{variant_name}}, previously in file {{span_filename}}:{{span_begin_line}}"),
     witness: (
-        hint_template: r#"let witness = {{join "::" path}}::{{variant_name}};"#,
+        hint_template: r#"let witness = {{join "::" path}}::{{variant_name}}{{#if (eq kind "StructVariant")}}{...}{{/if}}{{#if (eq kind "TupleVariant")}}(...){{/if}};"#,
     ),
 )

--- a/src/lints/enum_variant_missing.ron
+++ b/src/lints/enum_variant_missing.ron
@@ -59,6 +59,6 @@ SemverQuery(
     error_message: "A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.",
     per_result_error_template: Some("variant {{enum_name}}::{{variant_name}}, previously in file {{span_filename}}:{{span_begin_line}}"),
     witness: (
-        hint_template: r#"let witness = {{join "::" path}}::{{variant_name}}{{#if (eq kind "StructVariant")}}{...}{{/if}}{{#if (eq kind "TupleVariant")}}(...){{/if}};"#,
+        hint_template: r#"let witness = {{join "::" path}}::{{variant_name}}{{#if (eq kind "StructVariant")}} {...}{{/if}}{{#if (eq kind "TupleVariant")}}(...){{/if}};"#,
     ),
 )

--- a/src/lints/enum_variant_missing.ron
+++ b/src/lints/enum_variant_missing.ron
@@ -56,4 +56,7 @@ SemverQuery(
     },
     error_message: "A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.",
     per_result_error_template: Some("variant {{enum_name}}::{{variant_name}}, previously in file {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+        hint_template: r#"let witness = {{join "::" path}}::{{variant_name}};"#,
+    ),
 )

--- a/test_crates/enum_variant_missing/new/src/lib.rs
+++ b/test_crates/enum_variant_missing/new/src/lib.rs
@@ -1,3 +1,11 @@
-pub enum VariantWillBeRemoved {
+pub enum PlainVariantWillBeRemoved {
     Foo,
+}
+
+pub enum TupleVariantWillBeRemoved {
+    Foo(usize),
+}
+
+pub enum StructVariantWillBeRemoved {
+    Foo { bar: usize },
 }

--- a/test_crates/enum_variant_missing/old/src/lib.rs
+++ b/test_crates/enum_variant_missing/old/src/lib.rs
@@ -11,9 +11,13 @@ pub enum TupleVariantWillBeRemoved {
 }
 
 pub enum StructVariantWillBeRemoved {
-    Foo { bar: usize },
+    Foo {
+        bar: usize,
+    },
     /// Testing: <https://doc.rust-lang.org/cargo/reference/semver.html#item-remove>
-    Bar { bar: usize },
+    Bar {
+        bar: usize,
+    },
 }
 
 /// This enum should not be reported by the `enum_variant_missing` rule:

--- a/test_crates/enum_variant_missing/old/src/lib.rs
+++ b/test_crates/enum_variant_missing/old/src/lib.rs
@@ -1,8 +1,19 @@
-pub enum VariantWillBeRemoved {
+pub enum PlainVariantWillBeRemoved {
     Foo,
-
     /// Testing: <https://doc.rust-lang.org/cargo/reference/semver.html#item-remove>
     Bar,
+}
+
+pub enum TupleVariantWillBeRemoved {
+    Foo(usize),
+    /// Testing: <https://doc.rust-lang.org/cargo/reference/semver.html#item-remove>
+    Bar(usize),
+}
+
+pub enum StructVariantWillBeRemoved {
+    Foo { bar: usize },
+    /// Testing: <https://doc.rust-lang.org/cargo/reference/semver.html#item-remove>
+    Bar{ bar: usize },
 }
 
 /// This enum should not be reported by the `enum_variant_missing` rule:

--- a/test_crates/enum_variant_missing/old/src/lib.rs
+++ b/test_crates/enum_variant_missing/old/src/lib.rs
@@ -13,7 +13,7 @@ pub enum TupleVariantWillBeRemoved {
 pub enum StructVariantWillBeRemoved {
     Foo { bar: usize },
     /// Testing: <https://doc.rust-lang.org/cargo/reference/semver.html#item-remove>
-    Bar{ bar: usize },
+    Bar { bar: usize },
 }
 
 /// This enum should not be reported by the `enum_variant_missing` rule:

--- a/test_outputs/query_execution/enum_missing.snap
+++ b/test_outputs/query_execution/enum_missing.snap
@@ -56,7 +56,7 @@ expression: "&query_execution_results"
         String("enum_variant_missing"),
         String("ShouldNotMatch"),
       ]),
-      "span_begin_line": Uint64(22),
+      "span_begin_line": Uint64(26),
       "span_filename": String("src/lib.rs"),
       "visibility_limit": String("public"),
     },

--- a/test_outputs/query_execution/enum_missing.snap
+++ b/test_outputs/query_execution/enum_missing.snap
@@ -56,7 +56,7 @@ expression: "&query_execution_results"
         String("enum_variant_missing"),
         String("ShouldNotMatch"),
       ]),
-      "span_begin_line": Uint64(11),
+      "span_begin_line": Uint64(22),
       "span_filename": String("src/lib.rs"),
       "visibility_limit": String("public"),
     },

--- a/test_outputs/query_execution/enum_variant_missing.snap
+++ b/test_outputs/query_execution/enum_variant_missing.snap
@@ -49,7 +49,7 @@ expression: "&query_execution_results"
         String("enum_variant_missing"),
         String("StructVariantWillBeRemoved"),
       ]),
-      "span_begin_line": Uint64(16),
+      "span_begin_line": Uint64(18),
       "span_filename": String("src/lib.rs"),
       "variant_name": String("Bar"),
       "visibility_limit": String("public"),

--- a/test_outputs/query_execution/enum_variant_missing.snap
+++ b/test_outputs/query_execution/enum_variant_missing.snap
@@ -6,6 +6,7 @@ expression: "&query_execution_results"
   "./test_crates/enum_struct_variant_field_missing/": [
     {
       "enum_name": String("IgnoredEnum"),
+      "kind": String("StructVariant"),
       "path": List([
         String("enum_struct_variant_field_missing"),
         String("IgnoredEnum"),
@@ -18,12 +19,37 @@ expression: "&query_execution_results"
   ],
   "./test_crates/enum_variant_missing/": [
     {
-      "enum_name": String("VariantWillBeRemoved"),
+      "enum_name": String("PlainVariantWillBeRemoved"),
+      "kind": String("PlainVariant"),
       "path": List([
         String("enum_variant_missing"),
-        String("VariantWillBeRemoved"),
+        String("PlainVariantWillBeRemoved"),
       ]),
-      "span_begin_line": Uint64(5),
+      "span_begin_line": Uint64(4),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("Bar"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "enum_name": String("TupleVariantWillBeRemoved"),
+      "kind": String("TupleVariant"),
+      "path": List([
+        String("enum_variant_missing"),
+        String("TupleVariantWillBeRemoved"),
+      ]),
+      "span_begin_line": Uint64(10),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("Bar"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "enum_name": String("StructVariantWillBeRemoved"),
+      "kind": String("StructVariant"),
+      "path": List([
+        String("enum_variant_missing"),
+        String("StructVariantWillBeRemoved"),
+      ]),
+      "span_begin_line": Uint64(16),
       "span_filename": String("src/lib.rs"),
       "variant_name": String("Bar"),
       "visibility_limit": String("public"),

--- a/test_outputs/witnesses/enum_variant_missing.snap
+++ b/test_outputs/witnesses/enum_variant_missing.snap
@@ -15,10 +15,10 @@ hint = 'let witness = enum_variant_missing::PlainVariantWillBeRemoved::Bar;'
 
 [["./test_crates/enum_variant_missing/"]]
 filename = 'src/lib.rs'
-begin_line = 9
+begin_line = 10
 hint = 'let witness = enum_variant_missing::TupleVariantWillBeRemoved::Bar(...);'
 
 [["./test_crates/enum_variant_missing/"]]
 filename = 'src/lib.rs'
-begin_line = 14
+begin_line = 16
 hint = 'let witness = enum_variant_missing::StructVariantWillBeRemoved::Bar{...};'

--- a/test_outputs/witnesses/enum_variant_missing.snap
+++ b/test_outputs/witnesses/enum_variant_missing.snap
@@ -21,4 +21,4 @@ hint = 'let witness = enum_variant_missing::TupleVariantWillBeRemoved::Bar(...);
 [["./test_crates/enum_variant_missing/"]]
 filename = 'src/lib.rs'
 begin_line = 16
-hint = 'let witness = enum_variant_missing::StructVariantWillBeRemoved::Bar{...};'
+hint = 'let witness = enum_variant_missing::StructVariantWillBeRemoved::Bar {...};'

--- a/test_outputs/witnesses/enum_variant_missing.snap
+++ b/test_outputs/witnesses/enum_variant_missing.snap
@@ -6,9 +6,19 @@ expression: "&actual_witnesses"
 [["./test_crates/enum_struct_variant_field_missing/"]]
 filename = 'src/lib.rs'
 begin_line = 14
-hint = 'let witness = enum_struct_variant_field_missing::IgnoredEnum::StructVariantWillBeMissing;'
+hint = 'let witness = enum_struct_variant_field_missing::IgnoredEnum::StructVariantWillBeMissing{...};'
 
 [["./test_crates/enum_variant_missing/"]]
 filename = 'src/lib.rs'
-begin_line = 5
-hint = 'let witness = enum_variant_missing::VariantWillBeRemoved::Bar;'
+begin_line = 4
+hint = 'let witness = enum_variant_missing::PlainVariantWillBeRemoved::Bar;'
+
+[["./test_crates/enum_variant_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 9
+hint = 'let witness = enum_variant_missing::TupleVariantWillBeRemoved::Bar(...);'
+
+[["./test_crates/enum_variant_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 14
+hint = 'let witness = enum_variant_missing::StructVariantWillBeRemoved::Bar{...};'

--- a/test_outputs/witnesses/enum_variant_missing.snap
+++ b/test_outputs/witnesses/enum_variant_missing.snap
@@ -6,7 +6,7 @@ expression: "&actual_witnesses"
 [["./test_crates/enum_struct_variant_field_missing/"]]
 filename = 'src/lib.rs'
 begin_line = 14
-hint = 'let witness = enum_struct_variant_field_missing::IgnoredEnum::StructVariantWillBeMissing{...};'
+hint = 'let witness = enum_struct_variant_field_missing::IgnoredEnum::StructVariantWillBeMissing {...};'
 
 [["./test_crates/enum_variant_missing/"]]
 filename = 'src/lib.rs'
@@ -20,5 +20,5 @@ hint = 'let witness = enum_variant_missing::TupleVariantWillBeRemoved::Bar(...);
 
 [["./test_crates/enum_variant_missing/"]]
 filename = 'src/lib.rs'
-begin_line = 16
+begin_line = 18
 hint = 'let witness = enum_variant_missing::StructVariantWillBeRemoved::Bar {...};'

--- a/test_outputs/witnesses/enum_variant_missing.snap
+++ b/test_outputs/witnesses/enum_variant_missing.snap
@@ -1,0 +1,14 @@
+---
+source: src/query.rs
+description: "Lint `enum_variant_missing` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+---
+[["./test_crates/enum_struct_variant_field_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 14
+hint = 'let witness = enum_struct_variant_field_missing::IgnoredEnum::StructVariantWillBeMissing;'
+
+[["./test_crates/enum_variant_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 5
+hint = 'let witness = enum_variant_missing::VariantWillBeRemoved::Bar;'


### PR DESCRIPTION
Similar to https://github.com/obi1kenobi/cargo-semver-checks/pull/977 (but a bit more wrong syntax gets produced)

Similar to , this is not quite correct syntax:
a query for `variant` would be nessesary to have the correct brackets to construct the enum (struct, vs plain vs tuple).