### PR TITLE
Make hash optional in bugreport integration test

### DIFF
--- a/tests/integration_snapshots.rs
+++ b/tests/integration_snapshots.rs
@@ -52,7 +52,7 @@ fn bugreport() {
         // much of this is not reproducible on different machines, so we have
         // to heavily filter it.
         settings.add_filter(
-            r"cargo-semver-checks \d+\.\d+\.\d+(-[\w\.-]+)? \(\w+(-modified)?\)",
+            r"cargo-semver-checks \d+\.\d+\.\d+(-[\w\.-]+)? (\(\w+(-modified)?\))?",
             "cargo-semver-checks [VERSION] ([HASH])",
         );
         settings.add_filter(


### PR DESCRIPTION
Fixes #985