### PR TITLE
Build test indexes in parallel using `rayon`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ predicates = "3.1.2"
 insta = { version = "1.40.0", features = ["ron", "filters", "toml"] }
 regex = "1.10.6"
 insta-cmd = "0.6.0"
+rayon = "1.10.0"
 
 # In dev and test profiles, compile all dependencies with optimizations enabled,
 # but still checking debug assertions and overflows.

--- a/src/query.rs
+++ b/src/query.rs
@@ -333,6 +333,7 @@ mod tests {
     use std::{collections::BTreeMap, path::Path};
 
     use anyhow::Context;
+    use rayon::prelude::*;
     use serde::{Deserialize, Serialize};
     use trustfall::{FieldValue, TransparentValue};
     use trustfall_rustdoc::{
@@ -418,7 +419,7 @@ mod tests {
 
     fn initialize_test_crate_rustdocs() -> BTreeMap<String, (VersionedStorage, VersionedStorage)> {
         get_test_crate_names()
-            .iter()
+            .par_iter()
             .map(|crate_pair| {
                 let old_rustdoc = load_pregenerated_rustdoc(crate_pair.as_str(), "old");
                 let new_rustdoc = load_pregenerated_rustdoc(crate_pair, "new");
@@ -431,7 +432,7 @@ mod tests {
     fn initialize_test_crate_indexes(
     ) -> BTreeMap<String, (VersionedIndex<'static>, VersionedIndex<'static>)> {
         get_all_test_crates()
-            .iter()
+            .par_iter()
             .map(|(key, (old_crate, new_crate))| {
                 let old_index = VersionedIndex::from_storage(old_crate);
                 let new_index = VersionedIndex::from_storage(new_crate);


### PR DESCRIPTION
`rayon` is already a transitive dependency for us. Add it as a dev-dependency and use it when deserializing rustdoc and building indexes.

This saves a few more seconds per `cargo test` run.
