### PR TITLE
feat: add pub_static_now_mutable lint

### DIFF
--- a/src/lints/pub_static_now_mutable.ron
+++ b/src/lints/pub_static_now_mutable.ron
@@ -1,0 +1,51 @@
+SemverQuery(
+    id: "pub_static_now_mutable",
+    human_readable_name: "pub static is now mutable",
+    description: "An immutable static became mutable and thus an unsafe block is required to use it",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: Some("https://google.github.io/comprehensive-rust/unsafe-rust/mutable-static.html"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Static {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        mutable @filter(op: "!=", value: ["$true"])
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Static {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        mutable @filter(op: "=", value: ["$true"])
+                        static_name: name @output
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+    },
+    error_message: "An immutable static is now mutable and thus an unsafe block is required to use it",
+    per_result_error_template: Some("{{static_name}} in file {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1099,6 +1099,7 @@ add_lints!(
     pub_static_missing,
     pub_static_mut_now_immutable,
     pub_static_now_doc_hidden,
+    pub_static_now_mutable,
     repr_c_removed,
     repr_packed_added,
     repr_packed_removed,

--- a/test_crates/pub_static_now_mutable/new/Cargo.toml
+++ b/test_crates/pub_static_now_mutable/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "pub_static_now_mutable"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/pub_static_now_mutable/new/src/lib.rs
+++ b/test_crates/pub_static_now_mutable/new/src/lib.rs
@@ -1,0 +1,24 @@
+// Basic Test cases
+pub static mut STATIC_A: i32 = 0;
+pub static mut STATIC_B: i32 = 0;
+static mut STATIC_C: i32 = 0;
+
+// Test case for #[doc(hidden)] pub static
+#[doc(hidden)]
+pub static mut DOC_HIDDEN_STATIC_A: i32 = 0;
+
+// Renaming or making a static #[doc(hidden)] along with making it mutable
+// should trigger only one lint
+pub static mut DOC_HIDDEN_STATIC_B: i32 = 0;
+pub static mut STATIC_RENAME: i32 = 0;
+
+// Testing for static defined in private module
+mod PRIVATE_MODULE {
+    pub static mut STATIC_C: i32 = 0;
+}
+
+// Testing for static defined in #[doc(hidden)] module
+#[doc(hidden)]
+pub mod DOC_HIDDEN_MODULE {
+    pub static mut STATIC_C: i32 = 0;
+}

--- a/test_crates/pub_static_now_mutable/old/Cargo.toml
+++ b/test_crates/pub_static_now_mutable/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "pub_static_now_mutable"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/pub_static_now_mutable/old/src/lib.rs
+++ b/test_crates/pub_static_now_mutable/old/src/lib.rs
@@ -1,0 +1,25 @@
+// Basic Test cases
+pub static STATIC_A: i32 = 0;
+pub static mut STATIC_B: i32 = 0;
+static STATIC_C: i32 = 0;
+
+// Test case for #[doc(hidden)] pub static
+#[doc(hidden)]
+pub static DOC_HIDDEN_STATIC_A: i32 = 0;
+
+// Renaming or making a static #[doc(hidden)] along with making it mutable
+// should trigger only one lint
+#[doc(hidden)]
+pub static DOC_HIDDEN_STATIC_B: i32 = 0;
+pub static STATIC_RENAMED: i32 = 0;
+
+// Testing for static defined in private module
+mod PRIVATE_MODULE {
+    pub static STATIC_C: i32 = 0;
+}
+
+// Testing for static defined in #[doc(hidden)] module
+#[doc(hidden)]
+pub mod DOC_HIDDEN_MODULE {
+    pub static STATIC_C: i32 = 0;
+}

--- a/test_outputs/query_execution/pub_static_missing.snap
+++ b/test_outputs/query_execution/pub_static_missing.snap
@@ -1,6 +1,7 @@
 ---
 source: src/query.rs
 expression: "&query_execution_results"
+snapshot_kind: text
 ---
 {
   "./test_crates/pub_static_missing/": [
@@ -145,6 +146,18 @@ expression: "&query_execution_results"
         String("STATIC_RENAME"),
       ]),
       "span_begin_line": Uint64(13),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+  "./test_crates/pub_static_now_mutable/": [
+    {
+      "name": String("STATIC_RENAMED"),
+      "path": List([
+        String("pub_static_now_mutable"),
+        String("STATIC_RENAMED"),
+      ]),
+      "span_begin_line": Uint64(14),
       "span_filename": String("src/lib.rs"),
       "visibility_limit": String("public"),
     },

--- a/test_outputs/query_execution/pub_static_now_mutable.snap
+++ b/test_outputs/query_execution/pub_static_now_mutable.snap
@@ -1,0 +1,18 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+snapshot_kind: text
+---
+{
+  "./test_crates/pub_static_now_mutable/": [
+    {
+      "path": List([
+        String("pub_static_now_mutable"),
+        String("STATIC_A"),
+      ]),
+      "span_begin_line": Uint64(2),
+      "span_filename": String("src/lib.rs"),
+      "static_name": String("STATIC_A"),
+    },
+  ],
+}


### PR DESCRIPTION
This new lint is for public static variables which might be mutable
later on. This would require them to use an unsafe block which is
breaking.
