### PR TITLE
Remove more kinds of `cargo` output related to blocking on file locks.

### DIFF
--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -171,7 +171,7 @@ fn assert_integration_test(test_name: &str, invocation: &[&str]) {
     settings.add_filter(&regex::escape(&repo_root.to_string_lossy()), "[ROOT]");
     // Remove cargo blocking lines (e.g. from `cargo doc` output) as the amount of blocks
     // is not reproducible.
-    settings.add_filter("    Blocking waiting for file lock on package cache\n", "");
+    settings.add_filter("    Blocking waiting for file lock on [^\n]+\n", "");
     // Filter out the current `cargo-semver-checks` version in links to lint references,
     // as this will break across version changes.
     settings.add_filter(

--- a/tests/integration_snapshots.rs
+++ b/tests/integration_snapshots.rs
@@ -175,7 +175,7 @@ fn set_snapshot_filters(settings: &mut insta::Settings) {
     settings.add_filter(&regex::escape(&repo_root.to_string_lossy()), "[ROOT]");
     // Remove cargo blocking lines (e.g. from `cargo doc` output) as the amount of blocks
     // is not reproducible.
-    settings.add_filter("    Blocking waiting for file lock on package cache\n", "");
+    settings.add_filter("    Blocking waiting for file lock on [^\n]+\n", "");
     // Filter out the current `cargo-semver-checks` version in links to lint references,
     // as this will break across version changes.
     settings.add_filter(


### PR DESCRIPTION
Encountered a new `cargo` output line while streaming with @orhun:
>     Blocking waiting for file lock on build directory

Let's eliminate it from our snapshots, since it isn't relevant to what we're testing.