### PR TITLE
Report the root cause of non-fatal errors.

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -110,7 +110,8 @@ impl<'a> crate::data_generation::ProgressCallbacks<'a> for Callbacks<'a> {
         let _ = self.config.log_info(|config| {
             config.shell_warn(format!(
                 "encountered non-fatal error while working on crate \
-                {crate_name} v{version} ({kind}): {error}",
+                {crate_name} v{version} ({kind}): {error} (root cause: {})",
+                error.root_cause()
             ))?;
             Ok(())
         });


### PR DESCRIPTION
We don't want to get opaque errors like `encountered non-fatal error while working on crate example v1.0 (current): skipping package metadata due to failure to load it; package manifest checks will not discover any breakage` that don't tell us what actually happened to cause this.