### PR TITLE
Add the `type_requires_more_const_generic_params` lint.

### DIFF
--- a/src/lints/type_requires_more_const_generic_params.ron
+++ b/src/lints/type_requires_more_const_generic_params.ron
@@ -1,0 +1,77 @@
+SemverQuery(
+    id: "type_requires_more_const_generic_params",
+    human_readable_name: "type now requires more const generic parameters",
+    description: "A type now requires more const generic parameters than before.",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/reference/items/generics.html#const-generics"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on ImplOwner {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @output
+                        owner_type: __typename @tag @output
+
+                        importable_path {
+                            path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        generic_parameter @fold
+                                        @transform(op: "count")
+                                        @tag(name: "old_required_const_count")
+                                        @output(name: "old_required_const_count") {
+                            ... on GenericConstParameter {
+                                old_required_consts: name @output
+                                has_default @filter(op: "!=", value: ["$true"])
+                            }
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on ImplOwner {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        __typename @filter(op: "=", value: ["%owner_type"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        generic_parameter @fold
+                                          @transform(op: "count")
+                                          @filter(op: ">", value: ["%old_required_const_count"])
+                                          @output(name: "new_required_const_count") {
+                            ... on GenericConstParameter {
+                                new_required_consts: name @output
+                                has_default @filter(op: "!=", value: ["$true"])
+                            }
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+    },
+    error_message: "A type now requires more const generic parameters than it used to. Uses of this type that supplied the previously-required number of const generics will be broken. To fix this, consider supplying default values for newly-added const generics.",
+    per_result_error_template: Some("{{owner_type}} {{name}} ({{old_required_const_count}} -> {{new_required_const_count}} required const generics) in {{span_filename}}:{{span_begin_line}}"),
+    // TODO: see https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#adding-a-witness
+    // for information about this field.
+    //
+    // The witness would be a type ascription with the old number
+    // of required const generics, which is insufficient for the new definition.
+    witness: None,
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1220,6 +1220,7 @@ add_lints!(
     tuple_struct_to_plain_struct,
     type_marked_deprecated,
     type_mismatched_generic_lifetimes,
+    type_requires_more_const_generic_params,
     union_field_added_with_all_pub_fields,
     union_field_added_with_non_pub_fields,
     union_field_missing,

--- a/test_crates/type_requires_more_generic_consts/new/Cargo.toml
+++ b/test_crates/type_requires_more_generic_consts/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "type_requires_more_generic_consts"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/type_requires_more_generic_consts/new/src/lib.rs
+++ b/test_crates/type_requires_more_generic_consts/new/src/lib.rs
@@ -1,0 +1,19 @@
+#[non_exhaustive]
+pub struct NotGeneric<const COUNT: usize> {
+    data: [i64; COUNT],
+}
+
+#[non_exhaustive]
+pub enum DefaultBecomesRequired<const N: usize, const M: usize = 1> {
+    First([i64; N]),
+    Second([i64; M]),
+}
+
+pub union ConstGenericAdded<T, const N: usize> {
+    left: std::mem::ManuallyDrop<[T; N]>,
+}
+
+// This one isn't breaking, so it shouldn't be flagged!
+pub union DefaultedConstGenericAdded<T, const N: usize = 16> {
+    left: std::mem::ManuallyDrop<[T; N]>,
+}

--- a/test_crates/type_requires_more_generic_consts/old/Cargo.toml
+++ b/test_crates/type_requires_more_generic_consts/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "type_requires_more_generic_consts"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/type_requires_more_generic_consts/old/src/lib.rs
+++ b/test_crates/type_requires_more_generic_consts/old/src/lib.rs
@@ -1,0 +1,17 @@
+#[non_exhaustive]
+pub struct NotGeneric {}
+
+#[non_exhaustive]
+pub enum DefaultBecomesRequired<const N: usize = 1, const M: usize = 1> {
+    First([i64; N]),
+    Second([i64; M]),
+}
+
+pub union ConstGenericAdded<T> {
+    left: std::mem::ManuallyDrop<[T; 16]>,
+}
+
+// This one isn't breaking, so it shouldn't be flagged!
+pub union DefaultedConstGenericAdded<T> {
+    left: std::mem::ManuallyDrop<[T; 16]>,
+}

--- a/test_outputs/query_execution/type_requires_more_const_generic_params.snap
+++ b/test_outputs/query_execution/type_requires_more_const_generic_params.snap
@@ -1,0 +1,60 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+snapshot_kind: text
+---
+{
+  "./test_crates/type_requires_more_generic_consts/": [
+    {
+      "name": String("NotGeneric"),
+      "new_required_const_count": Uint64(1),
+      "new_required_consts": List([
+        String("COUNT"),
+      ]),
+      "old_required_const_count": Uint64(0),
+      "old_required_consts": List([]),
+      "owner_type": String("Struct"),
+      "path": List([
+        String("type_requires_more_generic_consts"),
+        String("NotGeneric"),
+      ]),
+      "span_begin_line": Uint64(2),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("DefaultBecomesRequired"),
+      "new_required_const_count": Uint64(1),
+      "new_required_consts": List([
+        String("N"),
+      ]),
+      "old_required_const_count": Uint64(0),
+      "old_required_consts": List([]),
+      "owner_type": String("Enum"),
+      "path": List([
+        String("type_requires_more_generic_consts"),
+        String("DefaultBecomesRequired"),
+      ]),
+      "span_begin_line": Uint64(7),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("ConstGenericAdded"),
+      "new_required_const_count": Uint64(1),
+      "new_required_consts": List([
+        String("N"),
+      ]),
+      "old_required_const_count": Uint64(0),
+      "old_required_consts": List([]),
+      "owner_type": String("Union"),
+      "path": List([
+        String("type_requires_more_generic_consts"),
+        String("ConstGenericAdded"),
+      ]),
+      "span_begin_line": Uint64(12),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+}


### PR DESCRIPTION
It checks for structs/enums/unions that begin requiring a higher minimum number of const generic arguments than they used to.
