### PR TITLE
Add the `type_allows_fewer_const_generic_params` lint.

### DIFF
--- a/src/lints/type_allows_fewer_const_generic_params.ron
+++ b/src/lints/type_allows_fewer_const_generic_params.ron
@@ -1,0 +1,76 @@
+SemverQuery(
+    id: "type_allows_fewer_const_generic_params",
+    human_readable_name: "type now allows fewer const generic parameters",
+    description: "A type now allows fewer const generic parameters than before.",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/reference/items/generics.html#const-generics"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on ImplOwner {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @output
+                        owner_type: __typename @tag @output
+
+                        importable_path {
+                            path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        generic_parameter @fold
+                                        @transform(op: "count")
+                                        @tag(name: "old_allowed_const_count")
+                                        @output(name: "old_allowed_const_count") {
+                            ... on GenericConstParameter {
+                                old_allowed_consts: name @output
+                            }
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on ImplOwner {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        __typename @filter(op: "=", value: ["%owner_type"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        generic_parameter @fold
+                                          @transform(op: "count")
+                                          @filter(op: "<", value: ["%old_allowed_const_count"])
+                                          @output(name: "new_allowed_const_count") {
+                            ... on GenericConstParameter {
+                                new_allowed_consts: name @output
+                            }
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+    },
+    error_message: "A type now allows fewer const generic parameters than it used to. Uses of this type that supplied all previously-supported const generics will be broken.",
+    per_result_error_template: Some("{{owner_type}} {{name}} allows {{old_allowed_const_count}} -> {{new_allowed_const_count}} const generics in {{span_filename}}:{{span_begin_line}}"),
+    // TODO: see https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#adding-a-witness
+    // for information about this field.
+    //
+    // The witness would be a type ascription with the old number
+    // of allowed const generics (including ones that provided default values),
+    // which will be too many generics for the new definition.
+    witness: None,
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1218,6 +1218,7 @@ add_lints!(
     trait_unsafe_added,
     trait_unsafe_removed,
     tuple_struct_to_plain_struct,
+    type_allows_fewer_const_generic_params,
     type_marked_deprecated,
     type_mismatched_generic_lifetimes,
     type_requires_more_const_generic_params,

--- a/test_crates/type_allows_fewer_const_generic_params/new/Cargo.toml
+++ b/test_crates/type_allows_fewer_const_generic_params/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "type_allows_fewer_const_generic_params"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/type_allows_fewer_const_generic_params/new/src/lib.rs
+++ b/test_crates/type_allows_fewer_const_generic_params/new/src/lib.rs
@@ -1,0 +1,11 @@
+pub struct Example<const N: usize> {
+    data: [i64; N],
+}
+
+pub enum NotGenericAnymore {
+    First([i64; 16]),
+}
+
+pub union NotGenericEither<T> {
+    left: std::mem::ManuallyDrop<[T; 4]>,
+}

--- a/test_crates/type_allows_fewer_const_generic_params/old/Cargo.toml
+++ b/test_crates/type_allows_fewer_const_generic_params/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "type_allows_fewer_const_generic_params"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/type_allows_fewer_const_generic_params/old/src/lib.rs
+++ b/test_crates/type_allows_fewer_const_generic_params/old/src/lib.rs
@@ -1,0 +1,12 @@
+pub struct Example<const N: usize, const M: usize = 8> {
+    data: [i64; N],
+    data2: [i64; M],
+}
+
+pub enum NotGenericAnymore<const N: usize> {
+    First([i64; N]),
+}
+
+pub union NotGenericEither<T, const N: usize> {
+    left: std::mem::ManuallyDrop<[T; N]>,
+}

--- a/test_outputs/query_execution/type_allows_fewer_const_generic_params.snap
+++ b/test_outputs/query_execution/type_allows_fewer_const_generic_params.snap
@@ -1,0 +1,63 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+snapshot_kind: text
+---
+{
+  "./test_crates/type_allows_fewer_const_generic_params/": [
+    {
+      "name": String("Example"),
+      "new_allowed_const_count": Uint64(1),
+      "new_allowed_consts": List([
+        String("N"),
+      ]),
+      "old_allowed_const_count": Uint64(2),
+      "old_allowed_consts": List([
+        String("N"),
+        String("M"),
+      ]),
+      "owner_type": String("Struct"),
+      "path": List([
+        String("type_allows_fewer_const_generic_params"),
+        String("Example"),
+      ]),
+      "span_begin_line": Uint64(1),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("NotGenericAnymore"),
+      "new_allowed_const_count": Uint64(0),
+      "new_allowed_consts": List([]),
+      "old_allowed_const_count": Uint64(1),
+      "old_allowed_consts": List([
+        String("N"),
+      ]),
+      "owner_type": String("Enum"),
+      "path": List([
+        String("type_allows_fewer_const_generic_params"),
+        String("NotGenericAnymore"),
+      ]),
+      "span_begin_line": Uint64(5),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("NotGenericEither"),
+      "new_allowed_const_count": Uint64(0),
+      "new_allowed_consts": List([]),
+      "old_allowed_const_count": Uint64(1),
+      "old_allowed_consts": List([
+        String("N"),
+      ]),
+      "owner_type": String("Union"),
+      "path": List([
+        String("type_allows_fewer_const_generic_params"),
+        String("NotGenericEither"),
+      ]),
+      "span_begin_line": Uint64(9),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+}


### PR DESCRIPTION
It catches structs/enums/unions that no longer support the previous number of const generic parameters.
