### PR TITLE
Add `function_requires_different_const_generic_params` lint.

### DIFF
--- a/src/lints/function_requires_different_const_generic_params.ron
+++ b/src/lints/function_requires_different_const_generic_params.ron
@@ -1,0 +1,77 @@
+SemverQuery(
+    id: "function_requires_different_const_generic_params",
+    human_readable_name: "function now requires a different number of const generic parameters",
+    // Currently, const generics in functions and methods cannot have defaults set.
+    // This is why we have only one lint ("requires different number") instead of
+    // two separate lints ("requires" / "allows") like for structs/traits etc.
+    description: "A function now requires a different number of const generic parameters than before.",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/reference/items/generics.html#const-generics"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Function {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @output
+
+                        importable_path {
+                            path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        generic_parameter @fold
+                                          @transform(op: "count")
+                                          @tag(name: "old_required_const_count")
+                                          @output(name: "old_required_const_count") {
+                            ... on GenericConstParameter {
+
+                                old_required_consts: name @output
+                            }
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Function {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        generic_parameter @fold
+                                          @transform(op: "count")
+                                          @filter(op: "!=", value: ["%old_required_const_count"])
+                                          @output(name: "new_required_const_count") {
+                            ... on GenericConstParameter {
+                                new_required_consts: name @output
+                            }
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+    },
+    error_message: "A function now requires a different number of const generic parameters than it used to. Uses of this function that supplied the previous number of const generics will be broken.",
+    per_result_error_template: Some("function {{name}} ({{old_required_const_count}} -> {{new_required_const_count}} const generics) in {{span_filename}}:{{span_begin_line}}"),
+    // TODO: see https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#adding-a-witness
+    // for information about this field.
+    //
+    // The witness would be a function invocation with the old number
+    // of const generics, which is insufficient for the new definition.
+    witness: None,
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1160,6 +1160,7 @@ add_lints!(
     function_must_use_added,
     function_now_doc_hidden,
     function_parameter_count_changed,
+    function_requires_different_const_generic_params,
     function_unsafe_added,
     inherent_associated_const_now_doc_hidden,
     inherent_associated_pub_const_missing,

--- a/test_crates/function_requires_different_const_generic_params/new/Cargo.toml
+++ b/test_crates/function_requires_different_const_generic_params/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "function_requires_different_const_generic_params"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/function_requires_different_const_generic_params/new/src/lib.rs
+++ b/test_crates/function_requires_different_const_generic_params/new/src/lib.rs
@@ -1,0 +1,9 @@
+pub fn previously_not_generic<const N: usize>() -> [i64; N] {
+    todo!()
+}
+
+pub fn add_const_generic<const N: usize, const M: usize>(data: [i64; N]) -> [i64; M] {
+    todo!()
+}
+
+pub fn remove_const_generic(data: [i64; 8]) {}

--- a/test_crates/function_requires_different_const_generic_params/old/Cargo.toml
+++ b/test_crates/function_requires_different_const_generic_params/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "function_requires_different_const_generic_params"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/function_requires_different_const_generic_params/old/src/lib.rs
+++ b/test_crates/function_requires_different_const_generic_params/old/src/lib.rs
@@ -1,0 +1,5 @@
+pub fn previously_not_generic() {}
+
+pub fn add_const_generic<const N: usize>(data: [i64; N]) {}
+
+pub fn remove_const_generic<const M: usize>(data: [i64; M]) {}

--- a/test_outputs/query_execution/function_requires_different_const_generic_params.snap
+++ b/test_outputs/query_execution/function_requires_different_const_generic_params.snap
@@ -1,0 +1,60 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+snapshot_kind: text
+---
+{
+  "./test_crates/function_requires_different_const_generic_params/": [
+    {
+      "name": String("previously_not_generic"),
+      "new_required_const_count": Uint64(1),
+      "new_required_consts": List([
+        String("N"),
+      ]),
+      "old_required_const_count": Uint64(0),
+      "old_required_consts": List([]),
+      "path": List([
+        String("function_requires_different_const_generic_params"),
+        String("previously_not_generic"),
+      ]),
+      "span_begin_line": Uint64(1),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("add_const_generic"),
+      "new_required_const_count": Uint64(2),
+      "new_required_consts": List([
+        String("N"),
+        String("M"),
+      ]),
+      "old_required_const_count": Uint64(1),
+      "old_required_consts": List([
+        String("N"),
+      ]),
+      "path": List([
+        String("function_requires_different_const_generic_params"),
+        String("add_const_generic"),
+      ]),
+      "span_begin_line": Uint64(5),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("remove_const_generic"),
+      "new_required_const_count": Uint64(0),
+      "new_required_consts": List([]),
+      "old_required_const_count": Uint64(1),
+      "old_required_consts": List([
+        String("M"),
+      ]),
+      "path": List([
+        String("function_requires_different_const_generic_params"),
+        String("remove_const_generic"),
+      ]),
+      "span_begin_line": Uint64(9),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+}

--- a/test_outputs/query_execution/function_requires_more_const_generic_params.snap
+++ b/test_outputs/query_execution/function_requires_more_const_generic_params.snap
@@ -1,0 +1,9 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+---
+{
+    "./test_crates/function_requires_more_const_generic_params/": [
+        // TODO
+    ]
+}


### PR DESCRIPTION
It catches top-level functions that now use more or fewer const generic parameters. Functions cannot have defaults on their const generics, so we only have one lint here, not two.
