### PR TITLE
Ajust and add target testcases

### DIFF
--- a/tests/specified_target.rs
+++ b/tests/specified_target.rs
@@ -34,6 +34,14 @@ fn with_env_var_riscv64gc_unknown_linux_gnu() {
 }
 
 #[test]
+fn with_env_var_aarch64_unknown_none() {
+    base()
+        .env("CARGO_BUILD_TARGET", "aarch64-unknown-none")
+        .assert()
+        .success();
+}
+
+#[test]
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 fn with_flag() {
     base()
@@ -48,6 +56,15 @@ fn with_flag_riscv64gc_unknown_linux_gnu() {
     base()
         .env_remove("CARGO_BUILD_TARGET")
         .arg("--target=riscv64gc-unknown-linux-gnu")
+        .assert()
+        .success();
+}
+
+#[test]
+fn with_flag_aarch64_unknown_none() {
+    base()
+        .env_remove("CARGO_BUILD_TARGET")
+        .arg("--target=aarch64-unknown-none")
         .assert()
         .success();
 }


### PR DESCRIPTION
Context: https://github.com/obi1kenobi/cargo-semver-checks/pull/1071#issuecomment-2581912310

These conditinal compiled tests requring target can be tested if `rustup target add riscv64gc-unknown-linux-gnu` is set up. I've tested them locally, and they will pass with riscv64gc-unknown-linux-gnu target installed. 

But I'm not sure if adding [target field in ci.yml](https://github.com/obi1kenobi/cargo-semver-checks/blob/7273ccdfede459e5d402309c19148cae0fb4ff32/.github/workflows/ci.yml#L186) is enough. (Haven't added it yet) 

It's weird riscv64gc-unknown-linux-gnu target can be recognized by cargo, but aarch64_unknown_none not, which is the problem I ran into.  `with_{env_var,flag}_aarch64_unknown_none` testcases always fail on `["1.81", "1.82", "1.83", "stable", "beta"]` toolchains and [the nightly one before this weekend](https://github.com/obi1kenobi/cargo-semver-checks/issues/1068#issuecomment-2581704041). So it'd be a bad idea to incorporate them for now and near future.

Feel free to close this PR if you do not accept it.