### PR TITLE
new lint: `macro_marked_deprecated`

### DIFF
--- a/src/lints/macro_marked_deprecated.ron
+++ b/src/lints/macro_marked_deprecated.ron
@@ -47,8 +47,8 @@ SemverQuery(
         "true": true,
     },
     error_message: "A `macro_rules!` declarative macro is now #[deprecated]. Downstream crates will get a compiler warning when using this macro.",
-    per_result_error_template: Some("macro {{join \"::\" path}} in {{span_filename}}:{{span_begin_line}}"),
+    per_result_error_template: Some("macro {{name}} in {{span_filename}}:{{span_begin_line}}"),
     witness: Some((
-        hint_template: r#"{{join "::" path}}!(...);"#,
+        hint_template: r#"{{name}}!(...);"#,
     )),
 )

--- a/src/lints/macro_marked_deprecated.ron
+++ b/src/lints/macro_marked_deprecated.ron
@@ -1,0 +1,54 @@
+SemverQuery(
+    id: "macro_marked_deprecated",
+    human_readable_name: "macro #[deprecated] added",
+    description: "A `macro_rules!` declarative macro has been newly marked with #[deprecated].",
+    required_update: Minor,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/reference/macros-by-example.html#the-deprecated-attribute"),
+    query: r#"
+    {
+        CrateDiff {
+            current {
+                item {
+                    ... on Macro {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @output
+                        deprecated @filter(op: "=", value: ["$true"])
+
+                        importable_path {
+                            path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on Macro {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        deprecated @filter(op: "!=", value: ["$true"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+    },
+    error_message: "A `macro_rules!` declarative macro is now #[deprecated]. Downstream crates will get a compiler warning when using this macro.",
+    per_result_error_template: Some("macro {{join \"::\" path}} in {{span_filename}}:{{span_begin_line}}"),
+    witness: Some((
+        hint_template: r#"{{join "::" path}}!(...);"#,
+    )),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1182,6 +1182,7 @@ add_lints!(
     inherent_method_must_use_added,
     inherent_method_now_doc_hidden,
     inherent_method_unsafe_added,
+    macro_marked_deprecated,
     macro_no_longer_exported,
     macro_now_doc_hidden,
     method_parameter_count_changed,

--- a/test_crates/macro_marked_deprecated/new/Cargo.toml
+++ b/test_crates/macro_marked_deprecated/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "macro_marked_deprecated"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/macro_marked_deprecated/new/src/lib.rs
+++ b/test_crates/macro_marked_deprecated/new/src/lib.rs
@@ -1,0 +1,79 @@
+// These macros are now deprecated and should be reported
+#[deprecated]
+#[macro_export]
+macro_rules! macro_to_deprecated {
+    () => {
+        42
+    };
+}
+
+#[deprecated = "This macro is deprecated"]
+#[macro_export]
+macro_rules! macro_to_deprecated_message {
+    ($x:expr) => {
+        $x + 1
+    };
+}
+
+// These macros should not trigger the lint
+#[macro_export]
+macro_rules! macro_stays_normal {
+    ($x:expr) => {
+        $x.to_string()
+    };
+}
+
+#[deprecated]
+#[macro_export]
+macro_rules! macro_already_deprecated {
+    () => {
+        true
+    };
+}
+
+#[deprecated = "New message"]
+#[macro_export]
+macro_rules! macro_message_changes {
+    () => {
+        "hello"
+    };
+}
+
+// Private macros should not be reported
+#[deprecated]
+macro_rules! private_macro_to_deprecated {
+    () => {
+        0
+    };
+}
+
+// Hidden macros should not be reported
+#[doc(hidden)]
+#[deprecated]
+#[macro_export]
+macro_rules! hidden_macro_to_deprecated {
+    () => {
+        1
+    };
+}
+
+mod foo {
+    // Public macro. Exported even though it's in a private module,
+    // because of the `#[macro_export]`.
+    #[deprecated]
+    #[macro_export]
+    macro_rules! inner_macro_exported_to_deprecated {
+        () => {
+            100
+        };
+    }
+}
+
+mod bar {
+    #[deprecated]
+    macro_rules! inner_macro_to_deprecated {
+        () => {
+            100
+        };
+    }
+}

--- a/test_crates/macro_marked_deprecated/old/Cargo.toml
+++ b/test_crates/macro_marked_deprecated/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "macro_marked_deprecated"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/macro_marked_deprecated/old/src/lib.rs
+++ b/test_crates/macro_marked_deprecated/old/src/lib.rs
@@ -1,0 +1,73 @@
+// These macros will be marked deprecated
+#[macro_export]
+macro_rules! macro_to_deprecated {
+    () => {
+        42
+    };
+}
+
+#[macro_export]
+macro_rules! macro_to_deprecated_message {
+    ($x:expr) => {
+        $x + 1
+    };
+}
+
+// These macros should not trigger the lint
+#[macro_export]
+macro_rules! macro_stays_normal {
+    ($x:expr) => {
+        $x.to_string()
+    };
+}
+
+#[deprecated]
+#[macro_export]
+macro_rules! macro_already_deprecated {
+    () => {
+        true
+    };
+}
+
+#[deprecated = "Old message"]
+#[macro_export]
+macro_rules! macro_message_changes {
+    () => {
+        "hello"
+    };
+}
+
+// Private macros should not be reported
+macro_rules! private_macro_to_deprecated {
+    () => {
+        0
+    };
+}
+
+// Hidden macros should not be reported
+#[doc(hidden)]
+#[macro_export]
+macro_rules! hidden_macro_to_deprecated {
+    () => {
+        1
+    };
+}
+
+mod foo {
+    // Public macro. Exported even though it's in a private module,
+    // because of the `#[macro_export]`.
+    #[macro_export]
+    macro_rules! inner_macro_exported_to_deprecated {
+        () => {
+            100
+        };
+    }
+}
+
+mod bar {
+    macro_rules! inner_macro_to_deprecated {
+        () => {
+            100
+        };
+    }
+}

--- a/test_outputs/query_execution/macro_marked_deprecated.snap
+++ b/test_outputs/query_execution/macro_marked_deprecated.snap
@@ -1,0 +1,38 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+---
+{
+  "./test_crates/macro_marked_deprecated/": [
+    {
+      "name": String("macro_to_deprecated"),
+      "path": List([
+        String("macro_marked_deprecated"),
+        String("macro_to_deprecated"),
+      ]),
+      "span_begin_line": Uint64(4),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("macro_to_deprecated_message"),
+      "path": List([
+        String("macro_marked_deprecated"),
+        String("macro_to_deprecated_message"),
+      ]),
+      "span_begin_line": Uint64(12),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("inner_macro_exported_to_deprecated"),
+      "path": List([
+        String("macro_marked_deprecated"),
+        String("inner_macro_exported_to_deprecated"),
+      ]),
+      "span_begin_line": Uint64(65),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+}

--- a/test_outputs/witnesses/macro_marked_deprecated.snap
+++ b/test_outputs/witnesses/macro_marked_deprecated.snap
@@ -1,0 +1,19 @@
+---
+source: src/query.rs
+description: "Lint `macro_marked_deprecated` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+---
+[["./test_crates/macro_marked_deprecated/"]]
+filename = 'src/lib.rs'
+begin_line = 4
+hint = 'macro_to_deprecated!(...);'
+
+[["./test_crates/macro_marked_deprecated/"]]
+filename = 'src/lib.rs'
+begin_line = 12
+hint = 'macro_to_deprecated_message!(...);'
+
+[["./test_crates/macro_marked_deprecated/"]]
+filename = 'src/lib.rs'
+begin_line = 65
+hint = 'inner_macro_exported_to_deprecated!(...);'


### PR DESCRIPTION
part of: #57
should I add another lint: `proc_macro_marked_deprecated`