### PR TITLE
Remove outdated TODOs related to trait sealing.

### DIFF
--- a/src/lints/trait_method_missing.ron
+++ b/src/lints/trait_method_missing.ron
@@ -21,13 +21,6 @@ SemverQuery(
 
                         method {
                             method_name: name @output @tag
-
-                            # TODO: Once we can check whether traits are sealed, split this lint:
-                            # - Sealed traits should ignore ineligible (~approx. `#[doc(hidden)]`)
-                            #   methods since they are indeed never public API.
-                            # - Non-sealed traits should only ignore ineligible methods
-                            #   if they have a default implementation; otherwise, implementors
-                            #   of the trait have to impl the method regardless of `#[doc(hidden)]`.
                             public_api_eligible @filter(op: "=", value: ["$true"])
 
                             span_: span @optional {

--- a/src/lints/trait_method_parameter_count_changed.ron
+++ b/src/lints/trait_method_parameter_count_changed.ron
@@ -21,14 +21,6 @@ SemverQuery(
 
                         method {
                             method_name: name @output @tag
-
-                            # TODO: Once we decide to split trait method lints based on whether the
-                            # trait is sealed (e.g. see `trait_method_missing`), split this lint:
-                            # - Sealed traits should ignore ineligible (~approx. `#[doc(hidden)]`)
-                            #   methods since they are indeed never public API.
-                            # - Non-sealed traits should only ignore ineligible methods
-                            #   if they have a default implementation; otherwise, implementors
-                            #   of the trait have to impl the method regardless of `#[doc(hidden)]`.
                             public_api_eligible @filter(op: "=", value: ["$true"])
 
                             old_parameter_: parameter @fold @transform(op: "count") @output @tag(name: "parameters")

--- a/src/lints/trait_removed_associated_constant.ron
+++ b/src/lints/trait_removed_associated_constant.ron
@@ -21,13 +21,6 @@ SemverQuery(
 
                         associated_constant {
                             associated_constant: name @output @tag
-
-                            # TODO: Once we can check whether traits are sealed, split this lint:
-                            # - Sealed traits should ignore ineligible (~approx. `#[doc(hidden)]`)
-                            #   associated constants since they are indeed never public API.
-                            # - Non-sealed traits should only ignore ineligible constants
-                            #   if they have a default value; otherwise, implementors
-                            #   of the trait have to set the const regardless of `#[doc(hidden)]`.
                             public_api_eligible @filter(op: "=", value: ["$true"])
 
                             span_: span @optional {

--- a/src/lints/trait_removed_associated_type.ron
+++ b/src/lints/trait_removed_associated_type.ron
@@ -21,12 +21,6 @@ SemverQuery(
 
                         associated_type {
                             associated_type: name @output @tag
-
-                            # TODO: Once we can check whether traits are sealed, split this lint:
-                            # - Sealed traits should ignore ineligible (~approx. `#[doc(hidden)]`)
-                            #   associated types since they are indeed never public API.
-                            # - Non-sealed traits cannot do so, because implementors
-                            #   of the trait have to set the type regardless of `#[doc(hidden)]`.
                             public_api_eligible @filter(op: "=", value: ["$true"])
 
                             span_: span {


### PR DESCRIPTION
We don't actually want to split those lints, since trait items that are `#[doc(hidden)]` but required for implementations of the trait make the trait public API sealed.
