### PR TITLE
Add "certs-source" flag to CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,6 +514,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,6 +1894,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2778,6 +2789,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -2924,6 +2936,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2987,6 +3011,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.8.0",
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3226,7 +3273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.8.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,10 @@ fs-err = "3.0.0"
 # Note that `tame-index` and `gix` must be upgraded in lock-step to retain the same `gix`
 # minor version. Otherwise, one will compile `gix` two times in different minor versions.
 gix = { version = "0.70", default-features = false, features = ["max-performance-safe", "revision"] }
-tame-index = { version = "0.17", features = ["sparse"] }
+# Purposefully leave the default features on, so we compile-in support for
+# both the native certs and the standard WebPKI certs. This way users can
+# select which certificate store to use at runtime.
+tame-index = { version = "0.17", features = ["sparse", "native-certs"] }
 
 human-panic = "2.0.2"
 bugreport = "0.5.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ use std::path::{Path, PathBuf};
 use check_release::run_check_release;
 use rustdoc_gen::CrateDataForRustdoc;
 
-pub use config::{FeatureFlag, GlobalConfig};
+pub use config::{CertsSource, FeatureFlag, GlobalConfig};
 pub use query::{
     ActualSemverUpdate, LintLevel, OverrideMap, OverrideStack, QueryOverride, RequiredSemverUpdate,
     SemverQuery, Witness,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,8 @@ use std::{collections::HashSet, env, path::PathBuf};
 use anstyle::{AnsiColor, Color, Reset, Style};
 use cargo_config2::Config;
 use cargo_semver_checks::{
-    FeatureFlag, GlobalConfig, PackageSelection, ReleaseType, Rustdoc, ScopeSelection, SemverQuery,
-    WitnessGeneration,
+    CertsSource, FeatureFlag, GlobalConfig, PackageSelection, ReleaseType, Rustdoc, ScopeSelection,
+    SemverQuery, WitnessGeneration,
 };
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use std::io::Write;
@@ -24,6 +24,7 @@ fn main() {
     configure_color(args.color_choice);
     let mut config = GlobalConfig::new();
     config.set_log_level(args.verbosity.log_level());
+    config.set_certs_source(args.certs_source.unwrap_or_default());
     config.set_feature_flags(feature_flags);
 
     exit_on_error(true, || validate_feature_flags(&mut config, &args));
@@ -309,6 +310,10 @@ struct SemverChecks {
     // docstring for help is on the `clap_verbosity_flag::Verbosity` struct itself
     #[command(flatten)]
     verbosity: clap_verbosity_flag::Verbosity<clap_verbosity_flag::InfoLevel>,
+
+    /// What certificate store to use, Mozilla's or the system store
+    #[arg(long = "certs-source", global = true, value_name = "SOURCE")]
+    certs_source: Option<CertsSource>,
 
     /// Enable unstable feature flags, run `cargo semver-checks -Z help` for more help.
     #[arg(

--- a/src/rustdoc_gen.rs
+++ b/src/rustdoc_gen.rs
@@ -608,7 +608,8 @@ impl RustdocFromRegistry {
             }
             ComboIndexCache::Sparse(sparse) => {
                 let client = tame_index::external::reqwest::blocking::Client::builder()
-                    .http2_prior_knowledge()
+                    .tls_built_in_native_certs(config.certs_source().use_native())
+                    .tls_built_in_webpki_certs(config.certs_source().use_webpki())
                     .build()
                     .context("failed to build HTTP client")?;
                 index::RemoteSparseIndex::new(sparse, client).into()


### PR DESCRIPTION
Adds a new "certs-source" flag to the CLI, exposed as a new field on `GlobalConfig` with a getter a setter, and with an enum reflecting a choice of either the WebPKI Mozilla certificate store or the native/system one.

This also updates the `tame-index` feature-set to include the native-cert support, and updates the client-building logic for the use of `tame-index` to turn the certificate store options on or off depending on the user's choice.

Note that this commit also removes the call to
`ClientBuilder::http2_prior_knowledge`. That call causes the `tame-index` client to assume the endpoint its accessing supports HTTP2 and just attempt to connect with that protocol rather than trying HTTP1 and upgrading based on server response.

Unfortunately, while Crates.io *does* support HTTP2 (and thus this setting would be correct for it), not all corporate network security software *does*, and in my case the use of HTTP2 prior knowledge assumptions mean requests from `cargo-semver-checks` fail even with the correct certificates.

The result of the removal is that HTTP requests will initiate with an HTTP1 request and then upgrade to HTTP2 when possible (when not going through something like the network security software I'm dealing with).

If that's not desirable to turn off unconditionally, it could _also_ be added as a CLI flag, or inferred based on the choice of certificate store.

---

See this Discussion question for more background: https://github.com/obi1kenobi/cargo-semver-checks/discussions/1134