### PR TITLE
Add zero-tolerance policy for AI slop "contributions".

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,16 @@
 
 ## Making your first contribution
 
+> [!IMPORTANT]  
+> **We have a zero-tolerance policy for low-quality AI-generated contributions.**
+>
+> It's very easy to use AI to generate low-quality "contributions" that are not carefully considered and do not meet the quality bar for inclusion in the codebase.
+> Such "contributions" do not benefit the project's stakeholders — in fact, they are a drain on maintainers' and reviewers' time and energy.
+> Instead, the "contributions" serve to boost the contributor's GitHub statistics or achieve other personal goals, at the expense of the project and its stakeholders.
+> 
+> Contributions that appear to be low-quality AI slop will be rejected without further explanation. Further contributions by the same authors will also be rejected without review or explanation, as the good faith assumption has already been breached once.
+> We express no opinion on AI assistance *in general*, and do not ban AI tools outright — we merely require that you take personal responsibility for the contribution's quality instead of relying on "the AI thought it was a good idea."
+
 Thanks for taking the time to contribute!
 The best starting point is adding a new lint.
 [Here is a list](https://github.com/obi1kenobi/cargo-semver-checks/issues?q=is%3Aopen+label%3AE-mentor+label%3AA-lint)


### PR DESCRIPTION
`cargo-semver-checks` and its associated projects are always on a maintainability precipice. Several prior SemVer linters were abandoned over maintainability concerns, since it's so hard to support the entire community's use cases, platforms, workflows, and overall needs.

Maintainer time is always limited. Allocating that limited time to low-quality AI-generated contributions made in bad faith to game GitHub metrics is not in the best interests of the Rust community or this project.

This policy proposes to exclude such contributions, and any future contributions from the same authors, from any consideration, review, feedback, or explanation.

Put simply: if no meaningful human time or effort was invested into preparing a contribution, we will refuse to spend any meaningful human time and effort in reviewing it.