### PR TITLE
Require test crates to pass  `cargo check`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
           # Don't complain about dead code or unused items.
           RUSTFLAGS: -A dead_code -A unused
         run: |
-          find test_crates/ -name 'Cargo.toml' | xargs -n 1 cargo check --manifest-path
+          find test_crates/ -name 'Cargo.toml' -print0 | xargs --null -n 1 cargo check --manifest-path
 
   rust-tests:
     name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,8 +195,15 @@ jobs:
           # TODO: Clean up warnings around `non_snake_case` and `non_upper_case_globals`.
           #       In the meantime, we suppress them as well since they clog the logs.
           RUSTFLAGS: -A dead_code -A deprecated -A unused -A private_bounds -A conflicting_repr_hints -A non_snake_case -A non_upper_case_globals
+        # Exclude test crates that intentionally do not pass `cargo check`
+        # in order to serve their test purpose.
         run: |
-          find test_crates/ -name 'Cargo.toml' -print0 | xargs --null -n 1 cargo check --manifest-path
+          find test_crates/ \
+            -path 'test_crates/manifest_tests/workspace_baseline_compile_error/*' -prune -o \
+            -path 'test_crates/manifest_tests/workspace_baseline_conditional_compile_error/*' -prune -o \
+            -path 'test_crates/feature_flags_validation/*' -prune -o \
+            -type f -name 'Cargo.toml' -print | \
+          xargs -n 1 --exec cargo check --manifest-path {}
 
   rust-tests:
     name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
             -path 'test_crates/feature_flags_validation/*' -prune -o \
             -type f -name 'Cargo.toml' \
             -print0 | \
-          xargs -0 -n 1 --exec cargo check --manifest-path {}
+          xargs -0 -n 1 cargo check --manifest-path
 
   rust-tests:
     name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
         id: toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly  # Because we sometimes test unstable features.
           rustflags: ""
           cache: false
 
@@ -185,8 +185,16 @@ jobs:
 
       - name: '"cargo check" each test crate'
         env:
-          # Don't complain about dead code or unused items.
-          RUSTFLAGS: -A dead_code -A unused
+          # Don't complain about dead code, deprecated items, or unused items.
+          # Those are common in almost every test crate.
+          #
+          # Also don't complain about test crates that rely on:
+          # - non-pub trait bounds (`private_bounds`)
+          # - `repr(C, i16)` and similar code (`conflicting_repr_hints`)
+          #
+          # TODO: Clean up warnings around `non_snake_case` and `non_upper_case_globals`.
+          #       In the meantime, we suppress them as well since they clog the logs.
+          RUSTFLAGS: -A dead_code -A deprecated -A unused -A private_bounds -A conflicting_repr_hints -A non_snake_case -A non_upper_case_globals
         run: |
           find test_crates/ -name 'Cargo.toml' -print0 | xargs --null -n 1 cargo check --manifest-path
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     needs:
       - lint
       - rust-tests
+      - cargo-check-test-crates
       - cross-version-caching
       - cross-feature-caching
       - run-on-rust-libp2p
@@ -161,6 +162,34 @@ jobs:
           RUSTDOCFLAGS: -D warnings
         run: cargo doc --manifest-path semver/Cargo.toml --workspace --no-deps --document-private-items
 
+  cargo-check-test-crates:
+    name: Ensure test crates pass "cargo check"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install rust
+        id: toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          rustflags: ""
+          cache: false
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: 'semver'
+
+      - name: '"cargo check" each test crate'
+        env:
+          # Don't complain about dead code or unused items.
+          RUSTFLAGS: -A dead_code -A unused
+        run: |
+          find test_crates/ -name 'Cargo.toml' | xargs -n 1 cargo check --manifest-path
+
   rust-tests:
     name: Run tests
     runs-on: ubuntu-latest
@@ -205,7 +234,7 @@ jobs:
         run: |
           cd semver
           ./scripts/regenerate_test_rustdocs.sh +${{ matrix.toolchain }}
-      
+
       - name: Fake rustdoc mtime on cache hit
         if: steps.cache-test-rustdocs.outputs.cache-hit == 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,7 @@ jobs:
             -path 'test_crates/manifest_tests/workspace_baseline_compile_error/*' -prune -o \
             -path 'test_crates/manifest_tests/workspace_baseline_conditional_compile_error/*' -prune -o \
             -path 'test_crates/feature_flags_validation/*' -prune -o \
+            -path 'test_crates/broken_rustdoc/*' -prune -o \
             -type f -name 'Cargo.toml' \
             -print0 | \
           xargs -0 -n 1 cargo check --manifest-path

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,8 +202,9 @@ jobs:
             -path 'test_crates/manifest_tests/workspace_baseline_compile_error/*' -prune -o \
             -path 'test_crates/manifest_tests/workspace_baseline_conditional_compile_error/*' -prune -o \
             -path 'test_crates/feature_flags_validation/*' -prune -o \
-            -type f -name 'Cargo.toml' -print | \
-          xargs -n 1 --exec cargo check --manifest-path {}
+            -type f -name 'Cargo.toml' \
+            -print0 | \
+          xargs -0 -n 1 --exec cargo check --manifest-path {}
 
   rust-tests:
     name: Run tests


### PR DESCRIPTION
It seems not all our test crates pass `cargo check` since rustdoc (with good reasons) allows certain compile errors to go unobserved.

In a couple of our test crates, that's expected and desirable. For example, we have test cases for what happens when we lint a crate that doesn't build.

In most cases, that's a bug in the test that we should fix.
