### PR TITLE
feat: Always run lint mode

### DIFF
--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -528,7 +528,7 @@ pub(super) fn run_check_release(
         Ok(CrateReport {
             required_bump: required_bump.map(ReleaseType::from),
             detected_bump: version_change,
-            has_always_run_issues: produced_always_run_errors || produced_always_run_warnings,
+            has_always_run_issues: total_always_run_issues > 0,
         })
     } else {
         config

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -653,12 +653,17 @@ pub struct CrateReport {
     /// For example, if the crate contains breaking changes, this is [`Some(ReleaseType::Major)`].
     /// If no additional bump beyond the already-detected one is required, this is [`Option::None`].
     required_bump: Option<ReleaseType>,
+    /// Whether the crate has breaking changes that require attention regardless of version bump.
+    has_always_run_issues: bool,
 }
 
 impl CrateReport {
     /// Check if the semver check was successful.
     /// `true` if required bump <= detected bump.
     pub fn success(&self) -> bool {
+        if self.has_always_run_issues {
+            return false;
+        }
         match self.required_bump {
             // If `None`, no additional bump is required.
             None => true,

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -179,8 +179,7 @@ impl LintTable {
 #[serde(untagged)]
 pub(crate) enum OverrideConfig {
     /// Specify both lint level and required update by name, with optional lint mode.
-    /// `lint_name = { level = "deny", required-update = "major" }
-    /// `lint_name = { level = "deny", required-update = "major", mode = "always-run" }
+    /// `lint_name = { level = "deny", required-update = "major" }`
     #[serde(rename_all = "kebab-case")]
     Both {
         level: LintLevel,
@@ -194,7 +193,7 @@ pub(crate) enum OverrideConfig {
         priority: i64,
     },
     /// Specify just lint level by name, with optional priority.
-    /// `lint_name = { level = "deny" }
+    /// `lint_name = { level = "deny" }`
     #[serde(rename_all = "kebab-case")]
     LintLevel {
         level: LintLevel,
@@ -202,7 +201,7 @@ pub(crate) enum OverrideConfig {
         priority: i64,
     },
     /// Specify just required update by name, with optional priority.
-    /// `lint_name = { required-update = "minor" }
+    /// `lint_name = { required-update = "minor" }`
     #[serde(rename_all = "kebab-case")]
     RequiredUpdate {
         required_update: RequiredSemverUpdate,

--- a/src/query.rs
+++ b/src/query.rs
@@ -61,11 +61,11 @@ impl LintLevel {
 #[non_exhaustive]
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LintMode {
+    #[serde(alias = "always-run")]
+    AlwaysRun,
     #[default]
     #[serde(alias = "semver")]
     SemVer,
-    #[serde(alias = "always-run")]
-    AlwaysRun,
 }
 
 /// Kind of semver update.


### PR DESCRIPTION
I tried to follow what @suaviloquence did when he added `lint_level` to the query.

Some thoughts after taking more look into the issue: 
- should we introduce another field in the SemVerQuery called `lint_mode` which is an Enum to be either `SemVer` or `AlwaysRun` with default to be `SemVer`? Or should we encapsulate the `required_update` field into this LintMode enum since when lint_mode is `AlwaysRun`, `RequiredSemverUpdate` seems meaningless? I am still in favor of the 1st one for better DX but the second one is more clear? 

- We will run all need-to-run queries together, but when displaying the overall view should we seperate them? since before the category would be `major`/`minor` now we have `always-run`
<details>
  <summary>example command output</summary>

```shell
       Built [   0.265s] (baseline)
     Parsing pub_api_sealed_trait_became_unconditionally_sealed v0.1.0 (baseline)
      Parsed [   0.001s] (baseline)
    Checking pub_api_sealed_trait_became_unconditionally_sealed v0.1.0 -> v0.1.0 (no change)
    Starting 148 checks, 0 unnecessary on 12 threads
        PASS [   0.002s]       major        attribute_proc_macro_missing
        PASS [   0.001s]       major        auto_trait_impl_removed
        PASS [   0.002s]       major        constructible_struct_adds_field
        PASS [   0.000s]       major        constructible_struct_adds_private_field
        PASS [   0.002s]       major        constructible_struct_changed_type
        PASS [   0.000s]       major        declarative_macro_missing
        PASS [   0.000s]       major        derive_helper_attr_removed
        PASS [   0.000s]       major        derive_proc_macro_missing
        PASS [   0.001s]       major        derive_trait_impl_removed
        PASS [   0.002s]       major        enum_discriminants_undefined_non_exhaustive_variant
        PASS [   0.000s]       major        enum_discriminants_undefined_non_unit_variant
        PASS [   0.000s]       major        enum_marked_non_exhaustive
        PASS [   0.000s]       major        enum_missing
        PASS [   0.002s]       minor        enum_must_use_added
        PASS [   0.000s]       major        enum_no_repr_variant_discriminant_changed
        PASS [   0.000s]       major        enum_now_doc_hidden
        PASS [   0.002s]       major        enum_repr_int_changed
        PASS [   0.002s]       major        enum_repr_int_removed
        PASS [   0.002s]       major        enum_repr_transparent_removed
        PASS [   0.001s]       major        enum_repr_variant_discriminant_changed
        PASS [   0.001s]       major        enum_struct_variant_field_added
        PASS [   0.001s]       major        enum_struct_variant_field_missing
        PASS [   0.000s]       major        enum_struct_variant_field_now_doc_hidden
        PASS [   0.000s]       major        enum_tuple_variant_changed_kind
        PASS [   0.000s]       major        enum_tuple_variant_field_added
        PASS [   0.000s]       major        enum_tuple_variant_field_missing
        PASS [   0.001s]       major        enum_tuple_variant_field_now_doc_hidden
        PASS [   0.002s]       major        enum_unit_variant_changed_kind
        PASS [   0.000s]       major        enum_variant_added
        PASS [   0.000s]       major        enum_variant_marked_non_exhaustive
        PASS [   0.000s]       major        enum_variant_missing
        PASS [   0.000s]       major        exported_function_changed_abi
        PASS [   0.003s]       major        feature_missing
        PASS [   0.001s]       major        feature_not_enabled_by_default
        PASS [   0.000s]       major        function_abi_no_longer_unwind
        PASS [   0.003s]       major        function_abi_now_unwind
        PASS [   0.000s]       major        function_changed_abi
        PASS [   0.002s]       major        function_const_removed
        PASS [   0.000s]       major        function_export_name_changed
        PASS [   0.000s]       major        function_like_proc_macro_missing
        PASS [   0.000s]       minor        function_marked_deprecated
        PASS [   0.000s]       major        function_missing
        PASS [   0.000s]       minor        function_must_use_added
        PASS [   0.000s]       major        function_now_doc_hidden
        PASS [   0.000s]       major        function_parameter_count_changed
        PASS [   0.000s]       major        function_requires_different_const_generic_params
        PASS [   0.001s]       major        function_requires_different_generic_type_params
        PASS [   0.000s]       major        function_unsafe_added
        PASS [   0.000s]       minor        global_value_marked_deprecated
        PASS [   0.001s]       major        inherent_associated_const_now_doc_hidden
        PASS [   0.000s]       major        inherent_associated_pub_const_missing
        PASS [   0.000s]       major        inherent_method_const_removed
        PASS [   0.000s]       major        inherent_method_missing
        PASS [   0.000s]       minor        inherent_method_must_use_added
        PASS [   0.000s]       major        inherent_method_now_doc_hidden
        PASS [   0.001s]       major        inherent_method_unsafe_added
        PASS [   0.000s]       minor        macro_marked_deprecated
        PASS [   0.000s]       major        macro_no_longer_exported
        PASS [   0.000s]       major        macro_now_doc_hidden
        PASS [   0.001s]       major        method_parameter_count_changed
        PASS [   0.001s]       major        method_requires_different_const_generic_params
        PASS [   0.001s]       major        method_requires_different_generic_type_params
        PASS [   0.000s]       major        module_missing
        PASS [   0.000s]       major        non_exhaustive_struct_changed_type
        PASS [   0.000s]       major        partial_ord_enum_struct_variant_fields_reordered
        PASS [   0.001s]       major        partial_ord_enum_variants_reordered
        PASS [   0.000s]       major        partial_ord_struct_fields_reordered
        PASS [   0.000s]       minor        proc_macro_marked_deprecated
        PASS [   0.000s]       major        proc_macro_now_doc_hidden
        WARN [   0.001s]     always-run     pub_api_sealed_trait_became_unconditionally_sealed
        PASS [   0.000s]       minor        pub_api_sealed_trait_became_unsealed
        PASS [   0.000s]       major        pub_module_level_const_missing
        PASS [   0.000s]       major        pub_module_level_const_now_doc_hidden
        PASS [   0.000s]       major        pub_static_missing
        PASS [   0.003s]       major        pub_static_mut_now_immutable
        PASS [   0.000s]       major        pub_static_now_doc_hidden
        PASS [   0.000s]       major        pub_static_now_mutable
        PASS [   0.000s]       major        repr_c_enum_struct_variant_fields_reordered
        PASS [   0.000s]       major        repr_c_plain_struct_fields_reordered
        PASS [   0.000s]       major        repr_c_removed
        PASS [   0.001s]       major        repr_packed_added
        PASS [   0.001s]       major        repr_packed_removed
        PASS [   0.001s]       major        sized_impl_removed
        PASS [   0.000s]       major        static_became_unsafe
        PASS [   0.000s]       minor        struct_field_marked_deprecated
        PASS [   0.000s]       major        struct_marked_non_exhaustive
        PASS [   0.000s]       major        struct_missing
        PASS [   0.000s]       minor        struct_must_use_added
        PASS [   0.000s]       major        struct_now_doc_hidden
        PASS [   0.000s]       major        struct_pub_field_missing
        PASS [   0.000s]       major        struct_pub_field_now_doc_hidden
        PASS [   0.000s]       major        struct_repr_transparent_removed
        PASS [   0.002s]       major        struct_with_no_pub_fields_changed_type
        PASS [   0.000s]       major        struct_with_pub_fields_changed_type
        PASS [   0.001s]       major        trait_added_supertrait
        PASS [   0.000s]       major        trait_allows_fewer_const_generic_params
        PASS [   0.000s]       major        trait_allows_fewer_generic_type_params
        PASS [   0.000s]       major        trait_associated_const_added
        PASS [   0.000s]       major        trait_associated_const_default_removed
        PASS [   0.001s]       minor        trait_associated_const_marked_deprecated
        PASS [   0.001s]       major        trait_associated_const_now_doc_hidden
        PASS [   0.000s]       major        trait_associated_type_added
        PASS [   0.000s]       major        trait_associated_type_default_removed
        PASS [   0.000s]       minor        trait_associated_type_marked_deprecated
        PASS [   0.000s]       major        trait_associated_type_now_doc_hidden
        PASS [   0.000s]       minor        trait_marked_deprecated
        PASS [   0.000s]       major        trait_method_added
        PASS [   0.000s]       major        trait_method_default_impl_removed
        PASS [   0.000s]       minor        trait_method_marked_deprecated
        PASS [   0.000s]       major        trait_method_missing
        PASS [   0.000s]       major        trait_method_now_doc_hidden
        PASS [   0.003s]       major        trait_method_parameter_count_changed
        PASS [   0.001s]       major        trait_method_requires_different_const_generic_params
        PASS [   0.000s]       major        trait_method_requires_different_generic_type_params
        PASS [   0.000s]       major        trait_method_unsafe_added
        PASS [   0.000s]       major        trait_method_unsafe_removed
        PASS [   0.000s]       major        trait_mismatched_generic_lifetimes
        PASS [   0.000s]       major        trait_missing
        PASS [   0.000s]       minor        trait_must_use_added
        PASS [   0.000s]       major        trait_newly_sealed
        PASS [   0.000s]       major        trait_no_longer_dyn_compatible
        PASS [   0.000s]       major        trait_now_doc_hidden
        PASS [   0.000s]       major        trait_removed_associated_constant
        PASS [   0.000s]       major        trait_removed_associated_type
        PASS [   0.000s]       major        trait_removed_supertrait
        PASS [   0.000s]       major        trait_requires_more_const_generic_params
        PASS [   0.000s]       major        trait_requires_more_generic_type_params
        PASS [   0.000s]       major        trait_unsafe_added
        PASS [   0.000s]       major        trait_unsafe_removed
        PASS [   0.000s]       major        tuple_struct_to_plain_struct
        PASS [   0.000s]       major        type_allows_fewer_const_generic_params
        PASS [   0.000s]       major        type_allows_fewer_generic_type_params
        PASS [   0.000s]       minor        type_associated_const_marked_deprecated
        PASS [   0.000s]       minor        type_marked_deprecated
        PASS [   0.000s]       minor        type_method_marked_deprecated
        PASS [   0.000s]       major        type_mismatched_generic_lifetimes
        PASS [   0.000s]       major        type_requires_more_const_generic_params
        PASS [   0.000s]       major        type_requires_more_generic_type_params
        PASS [   0.000s]       minor        unconditionally_sealed_trait_became_pub_api_sealed
        PASS [   0.001s]       minor        unconditionally_sealed_trait_became_unsealed
        PASS [   0.000s]       major        union_field_added_with_all_pub_fields
        PASS [   0.000s]       major        union_field_added_with_non_pub_fields
        PASS [   0.000s]       major        union_field_missing
        PASS [   0.000s]       major        union_missing
        PASS [   0.000s]       minor        union_must_use_added
        PASS [   0.000s]       major        union_now_doc_hidden
        PASS [   0.000s]       major        union_pub_field_now_doc_hidden
        PASS [   0.000s]       major        unit_struct_changed_kind
     Checked [   0.012s] 148 checks: 147 pass, 0 fail, 1 warn, 0 skip

--- risk warning pub_api_sealed_trait_became_unconditionally_sealed: public API sealed trait became unconditionally sealed ---

Description:
A public API sealed trait has become unconditionally sealed, blocking all downstream implementations including those from first-party crates that rely on the non-public API.
        ref: https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/pub_api_sealed_trait_became_unconditionally_sealed.ron

Failed in:
  trait pub_api_sealed_trait_became_unconditionally_sealed::public_api_sealed_to_unconditionally_sealed::TraitExtendsUnconditionallyHiddenTrait in file /Users/frankmac/projects/rs/cargo-semver-checks/test_crates/pub_api_sealed_trait_became_unconditionally_sealed/new/src/lib.rs:8
  trait pub_api_sealed_trait_became_unconditionally_sealed::public_api_sealed_to_unconditionally_sealed::MethodReturningUnconditionallyHiddenToken in file /Users/frankmac/projects/rs/cargo-semver-checks/test_crates/pub_api_sealed_trait_became_unconditionally_sealed/new/src/lib.rs:10
  trait pub_api_sealed_trait_became_unconditionally_sealed::public_api_sealed_to_unconditionally_sealed::HiddenSealedWithWhereSelfBound in file /Users/frankmac/projects/rs/cargo-semver-checks/test_crates/pub_api_sealed_trait_became_unconditionally_sealed/new/src/lib.rs:18
  trait pub_api_sealed_trait_became_unconditionally_sealed::public_api_sealed_to_unconditionally_sealed::MethodTakingUnconditionallyHiddenToken in file /Users/frankmac/projects/rs/cargo-semver-checks/test_crates/pub_api_sealed_trait_became_unconditionally_sealed/new/src/lib.rs:14

 Risk Notice 1 potentially risky changes detected that require attention regardless of version bump
    Finished [   0.667s] pub_api_sealed_trait_became_unconditionally_sealed
```
</details>

Todo:
- [ ] add test for override config
- [ ] add test for meta-table override
- [ ] add test to  test-crate `manifest_tests` ?
- [ ] new cli `run mode`
- [ ] cli `list` type fix




