### PR TITLE
Build release binaries using Ubuntu 22.04 to avoid too-new glibc dep.

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -36,7 +36,7 @@ jobs:
             os: macos-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.os || 'ubuntu-22.04' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Resolves #1153.
