### PR TITLE
new lint: `enum_variant_marked_deprecated`

### DIFF
--- a/src/lints/enum_variant_marked_deprecated.ron
+++ b/src/lints/enum_variant_marked_deprecated.ron
@@ -1,0 +1,66 @@
+SemverQuery(
+    id: "enum_variant_marked_deprecated",
+    human_readable_name: "enum variant #[deprecated] added",
+    description: "An enum variant has been newly marked with #[deprecated].",
+    required_update: Minor,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute"),
+    query: r#"
+    {
+        CrateDiff {
+            current {
+                item {
+                    ... on Enum {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @output
+                        # Filter out deprecated enums since rustdoc automatically marks their variants as deprecated.
+                        # This ensures we only detect variants that are explicitly marked with #[deprecated].
+                        deprecated @filter(op: "!=", value: ["$true"])
+
+                        importable_path {
+                            path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        variant {
+                            variant_name: name @output @tag
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+                            deprecated @filter(op: "=", value: ["$true"])
+
+                            span_: span @optional {
+                                filename @output
+                                begin_line @output
+                                end_line @output
+                            }
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on Enum {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        deprecated @filter(op: "!=", value: ["$true"])
+                        
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        variant {
+                            name @filter(op: "=", value: ["%variant_name"])
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+                            deprecated @filter(op: "!=", value: ["$true"])
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+    },
+    error_message: "An enum variant is now #[deprecated]. Downstream crates will get a compiler warning when using this variant.",
+    per_result_error_template: Some("variant {{join \"::\" path}}::{{variant_name}} in {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1247,6 +1247,7 @@ add_lints!(
     enum_tuple_variant_field_now_doc_hidden,
     enum_unit_variant_changed_kind,
     enum_variant_added,
+    enum_variant_marked_deprecated,
     enum_variant_marked_non_exhaustive,
     enum_variant_missing,
     exported_function_changed_abi,

--- a/test_crates/enum_variant_marked_deprecated/new/Cargo.toml
+++ b/test_crates/enum_variant_marked_deprecated/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_variant_marked_deprecated"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_variant_marked_deprecated/new/src/lib.rs
+++ b/test_crates/enum_variant_marked_deprecated/new/src/lib.rs
@@ -1,0 +1,93 @@
+#![no_std]
+
+// These enum variants are now marked as deprecated
+pub enum NormalEnum {
+    // Now deprecated
+    #[deprecated]
+    VariantToBeDeprecated,
+    // Now deprecated with a message
+    #[deprecated = "Use NormalVariant instead"]
+    VariantToBeDeprecatedWithMessage,
+    // Still normal
+    NormalVariant,
+}
+
+// This enum is now deprecated
+// Its variants should not trigger the lint since the enum itself is deprecated
+#[deprecated = "Use NormalEnum instead"]
+pub enum EnumToBeDeprecated {
+    VariantInDeprecatedEnum,
+    AnotherVariantInDeprecatedEnum,
+}
+
+// This enum was already deprecated
+// Changes to its variants should not trigger the lint
+#[deprecated]
+pub enum AlreadyDeprecatedEnum {
+    // This should not trigger the lint since the enum is already deprecated
+    #[deprecated]
+    VariantInAlreadyDeprecatedEnum,
+    AnotherVariantInAlreadyDeprecatedEnum,
+}
+
+// This enum has a mix of variant types to test different variant kinds
+pub enum MixedVariantKinds {
+    // Unit variant now deprecated
+    #[deprecated]
+    UnitVariant,
+    // Tuple variant now deprecated
+    #[deprecated = "Use NormalTuple instead"]
+    TupleVariant(i32, i64),
+    // Struct variant now deprecated
+    #[deprecated]
+    StructVariant {
+        field1: bool,
+        field2: u32,
+    },
+    // These remain normal
+    NormalUnit,
+    NormalTuple(f64),
+    NormalStruct {
+        value: i32,
+    },
+}
+
+// This enum is private and should not trigger the lint
+enum PrivateEnum {
+    #[deprecated]
+    PrivateVariantToBeDeprecated,
+    AnotherPrivateVariant,
+}
+
+// This enum has a hidden variant that should not trigger the lint
+pub enum EnumWithHiddenVariant {
+    NormalVariant,
+    #[doc(hidden)]
+    #[deprecated]
+    HiddenVariantToBeDeprecated,
+}
+
+// This variant was already deprecated and should not trigger the lint
+pub enum EnumWithAlreadyDeprecatedVariant {
+    NormalVariant,
+    #[deprecated]
+    AlreadyDeprecatedVariant,
+    #[deprecated = "New message"]
+    VariantWithMessageToBeChanged,
+}
+
+// This is a new enum with deprecated variants
+// It should not trigger the lint since it's a new enum
+pub enum NewEnumWithDeprecatedVariants {
+    NormalVariant,
+    #[deprecated]
+    DeprecatedVariant,
+}
+
+// This enum is hidden with #[doc(hidden)] and should not trigger the lint
+#[doc(hidden)]
+pub enum HiddenEnum {
+    #[deprecated]
+    VariantToBeDeprecated,
+    AnotherVariant,
+}

--- a/test_crates/enum_variant_marked_deprecated/old/Cargo.toml
+++ b/test_crates/enum_variant_marked_deprecated/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_variant_marked_deprecated"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_variant_marked_deprecated/old/src/lib.rs
+++ b/test_crates/enum_variant_marked_deprecated/old/src/lib.rs
@@ -1,0 +1,69 @@
+#![no_std]
+
+// These enum variants will be marked as deprecated in the new version
+pub enum NormalEnum {
+    // Will be marked as deprecated
+    VariantToBeDeprecated,
+    // Will be marked as deprecated with a message
+    VariantToBeDeprecatedWithMessage,
+    // Will remain normal
+    NormalVariant,
+}
+
+// This enum will be marked as deprecated in the new version
+// Its variants should not trigger the lint since the enum itself is deprecated
+pub enum EnumToBeDeprecated {
+    VariantInDeprecatedEnum,
+    AnotherVariantInDeprecatedEnum,
+}
+
+// This enum is already deprecated
+// Changes to its variants should not trigger the lint
+#[deprecated]
+pub enum AlreadyDeprecatedEnum {
+    VariantInAlreadyDeprecatedEnum,
+    AnotherVariantInAlreadyDeprecatedEnum,
+}
+
+// This enum has a mix of variant types to test different variant kinds
+pub enum MixedVariantKinds {
+    // Unit variant to be deprecated
+    UnitVariant,
+    // Tuple variant to be deprecated
+    TupleVariant(i32, i64),
+    // Struct variant to be deprecated
+    StructVariant { field1: bool, field2: u32 },
+    // These will remain normal
+    NormalUnit,
+    NormalTuple(f64),
+    NormalStruct { value: i32 },
+}
+
+// This enum is private and should not trigger the lint
+enum PrivateEnum {
+    PrivateVariantToBeDeprecated,
+    AnotherPrivateVariant,
+}
+
+// This enum has a hidden variant that should not trigger the lint
+pub enum EnumWithHiddenVariant {
+    NormalVariant,
+    #[doc(hidden)]
+    HiddenVariantToBeDeprecated,
+}
+
+// This variant is already deprecated and should not trigger the lint
+pub enum EnumWithAlreadyDeprecatedVariant {
+    NormalVariant,
+    #[deprecated]
+    AlreadyDeprecatedVariant,
+    #[deprecated = "Old message"]
+    VariantWithMessageToBeChanged,
+}
+
+// This enum is hidden with #[doc(hidden)] and should not trigger the lint
+#[doc(hidden)]
+pub enum HiddenEnum {
+    VariantToBeDeprecated,
+    AnotherVariant,
+}

--- a/test_outputs/query_execution/enum_variant_marked_deprecated.snap
+++ b/test_outputs/query_execution/enum_variant_marked_deprecated.snap
@@ -1,0 +1,68 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+---
+{
+  "./test_crates/enum_variant_marked_deprecated/": [
+    {
+      "name": String("NormalEnum"),
+      "path": List([
+        String("enum_variant_marked_deprecated"),
+        String("NormalEnum"),
+      ]),
+      "span_begin_line": Uint64(7),
+      "span_end_line": Uint64(7),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("VariantToBeDeprecated"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("NormalEnum"),
+      "path": List([
+        String("enum_variant_marked_deprecated"),
+        String("NormalEnum"),
+      ]),
+      "span_begin_line": Uint64(10),
+      "span_end_line": Uint64(10),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("VariantToBeDeprecatedWithMessage"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("MixedVariantKinds"),
+      "path": List([
+        String("enum_variant_marked_deprecated"),
+        String("MixedVariantKinds"),
+      ]),
+      "span_begin_line": Uint64(37),
+      "span_end_line": Uint64(37),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("UnitVariant"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("MixedVariantKinds"),
+      "path": List([
+        String("enum_variant_marked_deprecated"),
+        String("MixedVariantKinds"),
+      ]),
+      "span_begin_line": Uint64(40),
+      "span_end_line": Uint64(40),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("TupleVariant"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("MixedVariantKinds"),
+      "path": List([
+        String("enum_variant_marked_deprecated"),
+        String("MixedVariantKinds"),
+      ]),
+      "span_begin_line": Uint64(43),
+      "span_end_line": Uint64(46),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("StructVariant"),
+      "visibility_limit": String("public"),
+    },
+  ],
+}

--- a/test_outputs/query_execution/type_marked_deprecated.snap
+++ b/test_outputs/query_execution/type_marked_deprecated.snap
@@ -1,9 +1,22 @@
 ---
 source: src/query.rs
 expression: "&query_execution_results"
-snapshot_kind: text
 ---
 {
+  "./test_crates/enum_variant_marked_deprecated/": [
+    {
+      "name": String("EnumToBeDeprecated"),
+      "owner_type": String("Enum"),
+      "path": List([
+        String("enum_variant_marked_deprecated"),
+        String("EnumToBeDeprecated"),
+      ]),
+      "span_begin_line": Uint64(18),
+      "span_end_line": Uint64(21),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
   "./test_crates/struct_field_marked_deprecated/": [
     {
       "name": String("BothBecomeDeprecated"),


### PR DESCRIPTION
part of: #57 

would finish the last one too