### PR TITLE
Add `enum_non_exhaustive_struct_variant_field_added` lint.

### DIFF
--- a/src/lints/enum_non_exhaustive_struct_variant_field_added.ron
+++ b/src/lints/enum_non_exhaustive_struct_variant_field_added.ron
@@ -1,7 +1,7 @@
 SemverQuery(
     id: "enum_non_exhaustive_struct_variant_field_added",
     human_readable_name: "pub enum #[non_exhaustive] struct variant field added",
-    description: "An enum's #[non_exhaustive] struct variant has a new field.",
+    description: "A pub enum's #[non_exhaustive] struct variant has a new field.",
     required_update: Minor,
     lint_level: Allow,
     reference_link: Some("https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute"),
@@ -21,7 +21,6 @@ SemverQuery(
 
                         variant {
                             ... on StructVariant {
-                                attrs @filter(op: "contains", value: ["$non_exhaustive"])
                                 public_api_eligible @filter(op: "=", value: ["$true"])
                                 variant_name: name @output @tag
 
@@ -71,6 +70,6 @@ SemverQuery(
         "zero": 0,
         "non_exhaustive": "#[non_exhaustive]",
     },
-    error_message: "An enum's #[non_exhaustive] struct variant has a new field, which affects how it is constructed within its defining crate.",
+    error_message: "A pub enum's #[non_exhaustive] struct variant has a new field. Pattern matches that explicitly list fields will now fail to compile.",
     per_result_error_template: Some("field {{field_name}} of variant {{enum_name}}::{{variant_name}} in {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/lints/enum_non_exhaustive_struct_variant_field_added.ron
+++ b/src/lints/enum_non_exhaustive_struct_variant_field_added.ron
@@ -70,6 +70,6 @@ SemverQuery(
         "zero": 0,
         "non_exhaustive": "#[non_exhaustive]",
     },
-    error_message: "A pub enum's #[non_exhaustive] struct variant has a new field. Pattern matches that explicitly list fields will now fail to compile.",
+    error_message: "A field was added to an enum's non-exhaustive struct variant.",
     per_result_error_template: Some("field {{field_name}} of variant {{enum_name}}::{{variant_name}} in {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/lints/enum_non_exhaustive_struct_variant_field_added.ron
+++ b/src/lints/enum_non_exhaustive_struct_variant_field_added.ron
@@ -1,0 +1,76 @@
+SemverQuery(
+    id: "enum_non_exhaustive_struct_variant_field_added",
+    human_readable_name: "pub enum #[non_exhaustive] struct variant field added",
+    description: "An enum's #[non_exhaustive] struct variant has a new field.",
+    required_update: Minor,
+    lint_level: Allow,
+    reference_link: Some("https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute"),
+    query: r#"
+    {
+        CrateDiff {
+            current {
+                item {
+                    ... on Enum {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        enum_name: name @output
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        variant {
+                            ... on StructVariant {
+                                attrs @filter(op: "contains", value: ["$non_exhaustive"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+                                variant_name: name @output @tag
+
+                                field {
+                                    field_name: name @output @tag
+
+                                    span_: span @optional {
+                                        filename @output
+                                        begin_line @output
+                                        end_line @output
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on Enum {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        variant {
+                            ... on StructVariant {
+                                name @filter(op: "=", value: ["%variant_name"])
+                                attrs @filter(op: "contains", value: ["$non_exhaustive"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+
+                                field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                                    name @filter(op: "=", value: ["%field_name"])
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+        "zero": 0,
+        "non_exhaustive": "#[non_exhaustive]",
+    },
+    error_message: "An enum's #[non_exhaustive] struct variant has a new field, which affects how it is constructed within its defining crate.",
+    per_result_error_template: Some("field {{field_name}} of variant {{enum_name}}::{{variant_name}} in {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1234,6 +1234,7 @@ add_lints!(
     enum_must_use_added,
     enum_no_longer_non_exhaustive,
     enum_no_repr_variant_discriminant_changed,
+    enum_non_exhaustive_struct_variant_field_added,
     enum_now_doc_hidden,
     enum_repr_int_changed,
     enum_repr_int_removed,

--- a/test_crates/enum_non_exhaustive_struct_variant_field_added/new/Cargo.toml
+++ b/test_crates/enum_non_exhaustive_struct_variant_field_added/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_non_exhaustive_struct_variant_field_added"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_non_exhaustive_struct_variant_field_added/new/src/lib.rs
+++ b/test_crates/enum_non_exhaustive_struct_variant_field_added/new/src/lib.rs
@@ -19,7 +19,7 @@ pub(crate) enum PrivateEnum {
 }
 
 // This enum's variant will become exhaustive while also gaining a field.
-// That should trigger a separate lint, and not this one.
+// It should trigger this lint.
 pub enum EnumWithNonExhaustiveVariant {
     NonExhaustiveVariant { x: i64, y: usize },
 }

--- a/test_crates/enum_non_exhaustive_struct_variant_field_added/new/src/lib.rs
+++ b/test_crates/enum_non_exhaustive_struct_variant_field_added/new/src/lib.rs
@@ -1,28 +1,25 @@
 #![no_std]
 
-pub enum PubEnum {
+pub enum ExhaustiveEnum {
     #[non_exhaustive]
-    Foo {
-        x: i64,
-        y: usize,
-    }
+    Foo { x: i64, y: usize },
+}
+
+#[non_exhaustive]
+pub enum NonExhaustiveEnum {
+    #[non_exhaustive]
+    Foo { x: i64, y: usize },
 }
 
 // This enum is not public, so it should not be reported by the lint,
 // regardless of the new field in the variant.
 pub(crate) enum PrivateEnum {
     #[non_exhaustive]
-    Foo {
-        x: i64,
-        y: usize,
-    }
+    Foo { x: i64, y: usize },
 }
 
 // This enum's variant will become exhaustive while also gaining a field.
 // That should trigger a separate lint, and not this one.
 pub enum EnumWithNonExhaustiveVariant {
-    NonExhaustiveVariant {
-        x: i64,
-        y: usize,
-    }
+    NonExhaustiveVariant { x: i64, y: usize },
 }

--- a/test_crates/enum_non_exhaustive_struct_variant_field_added/new/src/lib.rs
+++ b/test_crates/enum_non_exhaustive_struct_variant_field_added/new/src/lib.rs
@@ -1,0 +1,28 @@
+#![no_std]
+
+pub enum PubEnum {
+    #[non_exhaustive]
+    Foo {
+        x: i64,
+        y: usize,
+    }
+}
+
+// This enum is not public, so it should not be reported by the lint,
+// regardless of the new field in the variant.
+pub(crate) enum PrivateEnum {
+    #[non_exhaustive]
+    Foo {
+        x: i64,
+        y: usize,
+    }
+}
+
+// This enum's variant will become exhaustive while also gaining a field.
+// That should trigger a separate lint, and not this one.
+pub enum EnumWithNonExhaustiveVariant {
+    NonExhaustiveVariant {
+        x: i64,
+        y: usize,
+    }
+}

--- a/test_crates/enum_non_exhaustive_struct_variant_field_added/old/Cargo.toml
+++ b/test_crates/enum_non_exhaustive_struct_variant_field_added/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_non_exhaustive_struct_variant_field_added"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_non_exhaustive_struct_variant_field_added/old/src/lib.rs
+++ b/test_crates/enum_non_exhaustive_struct_variant_field_added/old/src/lib.rs
@@ -1,0 +1,26 @@
+#![no_std]
+
+pub enum PubEnum {
+    #[non_exhaustive]
+    Foo {
+        x: i64,
+    }
+}
+
+// This enum is not public, so it should not be reported by the lint,
+// regardless of the new field in the variant.
+pub(crate) enum PrivateEnum {
+    #[non_exhaustive]
+    Foo {
+        x: i64,
+    }
+}
+
+// This enum's variant will become exhaustive while also gaining a field.
+// That should trigger a separate lint, and not this one.
+pub enum EnumWithNonExhaustiveVariant {
+    #[non_exhaustive]
+    NonExhaustiveVariant {
+        x: i64,
+    }
+}

--- a/test_crates/enum_non_exhaustive_struct_variant_field_added/old/src/lib.rs
+++ b/test_crates/enum_non_exhaustive_struct_variant_field_added/old/src/lib.rs
@@ -1,26 +1,26 @@
 #![no_std]
 
-pub enum PubEnum {
+pub enum ExhaustiveEnum {
     #[non_exhaustive]
-    Foo {
-        x: i64,
-    }
+    Foo { x: i64 },
+}
+
+#[non_exhaustive]
+pub enum NonExhaustiveEnum {
+    #[non_exhaustive]
+    Foo { x: i64 },
 }
 
 // This enum is not public, so it should not be reported by the lint,
 // regardless of the new field in the variant.
 pub(crate) enum PrivateEnum {
     #[non_exhaustive]
-    Foo {
-        x: i64,
-    }
+    Foo { x: i64 },
 }
 
 // This enum's variant will become exhaustive while also gaining a field.
 // That should trigger a separate lint, and not this one.
 pub enum EnumWithNonExhaustiveVariant {
     #[non_exhaustive]
-    NonExhaustiveVariant {
-        x: i64,
-    }
+    NonExhaustiveVariant { x: i64 },
 }

--- a/test_crates/enum_non_exhaustive_struct_variant_field_added/old/src/lib.rs
+++ b/test_crates/enum_non_exhaustive_struct_variant_field_added/old/src/lib.rs
@@ -19,7 +19,7 @@ pub(crate) enum PrivateEnum {
 }
 
 // This enum's variant will become exhaustive while also gaining a field.
-// That should trigger a separate lint, and not this one.
+// It should trigger this lint.
 pub enum EnumWithNonExhaustiveVariant {
     #[non_exhaustive]
     NonExhaustiveVariant { x: i64 },

--- a/test_outputs/query_execution/enum_non_exhaustive_struct_variant_field_added.snap
+++ b/test_outputs/query_execution/enum_non_exhaustive_struct_variant_field_added.snap
@@ -5,16 +5,40 @@ expression: "&query_execution_results"
 {
   "./test_crates/enum_non_exhaustive_struct_variant_field_added/": [
     {
-      "enum_name": String("PubEnum"),
+      "enum_name": String("ExhaustiveEnum"),
       "field_name": String("y"),
       "path": List([
         String("enum_non_exhaustive_struct_variant_field_added"),
-        String("PubEnum"),
+        String("ExhaustiveEnum"),
       ]),
-      "span_begin_line": Uint64(7),
-      "span_end_line": Uint64(7),
+      "span_begin_line": Uint64(5),
+      "span_end_line": Uint64(5),
       "span_filename": String("src/lib.rs"),
       "variant_name": String("Foo"),
+    },
+    {
+      "enum_name": String("NonExhaustiveEnum"),
+      "field_name": String("y"),
+      "path": List([
+        String("enum_non_exhaustive_struct_variant_field_added"),
+        String("NonExhaustiveEnum"),
+      ]),
+      "span_begin_line": Uint64(11),
+      "span_end_line": Uint64(11),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("Foo"),
+    },
+    {
+      "enum_name": String("EnumWithNonExhaustiveVariant"),
+      "field_name": String("y"),
+      "path": List([
+        String("enum_non_exhaustive_struct_variant_field_added"),
+        String("EnumWithNonExhaustiveVariant"),
+      ]),
+      "span_begin_line": Uint64(24),
+      "span_end_line": Uint64(24),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("NonExhaustiveVariant"),
     },
   ],
   "./test_crates/enum_struct_field_hidden_from_public_api/": [

--- a/test_outputs/query_execution/enum_non_exhaustive_struct_variant_field_added.snap
+++ b/test_outputs/query_execution/enum_non_exhaustive_struct_variant_field_added.snap
@@ -1,0 +1,48 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+---
+{
+  "./test_crates/enum_non_exhaustive_struct_variant_field_added/": [
+    {
+      "enum_name": String("PubEnum"),
+      "field_name": String("y"),
+      "path": List([
+        String("enum_non_exhaustive_struct_variant_field_added"),
+        String("PubEnum"),
+      ]),
+      "span_begin_line": Uint64(7),
+      "span_end_line": Uint64(7),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("Foo"),
+    },
+  ],
+  "./test_crates/enum_struct_field_hidden_from_public_api/": [
+    {
+      "enum_name": String("AddedVariantField"),
+      "field_name": String("y"),
+      "path": List([
+        String("enum_struct_field_hidden_from_public_api"),
+        String("AddedVariantField"),
+      ]),
+      "span_begin_line": Uint64(50),
+      "span_end_line": Uint64(50),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("NonExhaustiveStructVariant"),
+    },
+  ],
+  "./test_crates/enum_struct_variant_field_added/": [
+    {
+      "enum_name": String("EnumWithNonExhaustiveVariant"),
+      "field_name": String("y"),
+      "path": List([
+        String("enum_struct_variant_field_added"),
+        String("EnumWithNonExhaustiveVariant"),
+      ]),
+      "span_begin_line": Uint64(26),
+      "span_end_line": Uint64(26),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("Variant"),
+    },
+  ],
+}

--- a/test_outputs/query_execution/enum_variant_no_longer_non_exhaustive.snap
+++ b/test_outputs/query_execution/enum_variant_no_longer_non_exhaustive.snap
@@ -17,6 +17,20 @@ expression: "&query_execution_results"
       "visibility_limit": String("public"),
     },
   ],
+  "./test_crates/enum_non_exhaustive_struct_variant_field_added/": [
+    {
+      "enum_name": String("EnumWithNonExhaustiveVariant"),
+      "path": List([
+        String("enum_non_exhaustive_struct_variant_field_added"),
+        String("EnumWithNonExhaustiveVariant"),
+      ]),
+      "span_begin_line": Uint64(24),
+      "span_end_line": Uint64(24),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("NonExhaustiveVariant"),
+      "visibility_limit": String("public"),
+    },
+  ],
   "./test_crates/enum_tuple_variant_field_added/": [
     {
       "enum_name": String("PublicEnum"),


### PR DESCRIPTION
Addresses the following checkbox in #949 -
adding a new field to an existing #[non_exhaustive] struct variant of a public API enum