### PR TITLE
feat: add a witness hint for `function_parameter_count_changed` lint

### DIFF
--- a/src/lints/function_parameter_count_changed.ron
+++ b/src/lints/function_parameter_count_changed.ron
@@ -51,4 +51,7 @@ SemverQuery(
     },
     error_message: "A publicly-visible function now takes a different number of parameters.",
     per_result_error_template: Some("{{join \"::\" path}} now takes {{current_parameter_count}} parameters instead of {{old_parameter_count}}, in {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+    hint_template: r#"{{join "::" path}}( #parameters != {{old_parameter_count}} );"#,
+    ),
 )

--- a/src/lints/function_parameter_count_changed.ron
+++ b/src/lints/function_parameter_count_changed.ron
@@ -19,6 +19,10 @@ SemverQuery(
                         }
 
                         old_parameter_: parameter @fold @transform(op: "count") @output @tag(name: "parameters")
+
+                        parameter @fold {
+                        old_parameter_names: name @output
+                        }
                     }
                 }
             }
@@ -52,6 +56,6 @@ SemverQuery(
     error_message: "A publicly-visible function now takes a different number of parameters.",
     per_result_error_template: Some("{{join \"::\" path}} now takes {{current_parameter_count}} parameters instead of {{old_parameter_count}}, in {{span_filename}}:{{span_begin_line}}"),
     witness: (
-    hint_template: r#"{{join "::" path}}( #parameters != {{old_parameter_count}} );"#,
+    hint_template: r#"let witness = |{{join " , " old_parameter_names}}| {{join "::" path}}({{join " , " old_parameter_names}});"#,
     ),
 )

--- a/src/lints/function_parameter_count_changed.ron
+++ b/src/lints/function_parameter_count_changed.ron
@@ -54,6 +54,6 @@ SemverQuery(
     error_message: "A publicly-visible function now takes a different number of parameters.",
     per_result_error_template: Some("{{join \"::\" path}} now takes {{current_parameter_count}} parameters instead of {{old_parameter_count}}, in {{span_filename}}:{{span_begin_line}}"),
     witness: (
-    hint_template: r#"let witness = |{{join ", " old_parameter_names}}| {{join "::" path}}({{join ", " old_parameter_names}});"#,
+        hint_template: r#"let witness = |{{join ", " old_parameter_names}}| {{join "::" path}}({{join ", " old_parameter_names}});"#,
     ),
 )

--- a/src/lints/function_parameter_count_changed.ron
+++ b/src/lints/function_parameter_count_changed.ron
@@ -18,10 +18,8 @@ SemverQuery(
                             public_api @filter(op: "=", value: ["$true"])
                         }
 
-                        old_parameter_: parameter @fold @transform(op: "count") @output @tag(name: "parameters")
-
-                        parameter @fold {
-                        old_parameter_names: name @output
+                        old_parameter_: parameter @fold @transform(op: "count") @output @tag(name: "parameters") {
+                            names: name @output
                         }
                     }
                 }
@@ -56,6 +54,6 @@ SemverQuery(
     error_message: "A publicly-visible function now takes a different number of parameters.",
     per_result_error_template: Some("{{join \"::\" path}} now takes {{current_parameter_count}} parameters instead of {{old_parameter_count}}, in {{span_filename}}:{{span_begin_line}}"),
     witness: (
-    hint_template: r#"let witness = |{{join " , " old_parameter_names}}| {{join "::" path}}({{join " , " old_parameter_names}});"#,
+    hint_template: r#"let witness = |{{join ", " old_parameter_names}}| {{join "::" path}}({{join ", " old_parameter_names}});"#,
     ),
 )

--- a/test_crates/parameter_count_changed/new/src/lib.rs
+++ b/test_crates/parameter_count_changed/new/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-pub fn function_with_a_parameter_added(_: (), _: ()) {}
+pub fn function_with_a_parameter_added(a: (), b: ()) {}
 
 pub fn function_with_parameters_removed() {}
 

--- a/test_crates/parameter_count_changed/old/src/lib.rs
+++ b/test_crates/parameter_count_changed/old/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-pub fn function_with_a_parameter_added(_: ()) {}
+pub fn function_with_a_parameter_added(a: ()) {}
 
-pub fn function_with_parameters_removed(_: (), _: ()) {}
+pub fn function_with_parameters_removed(a: (), b: ()) {}
 
 fn private_function_with_a_parameter_added(_: ()) {}
 

--- a/test_outputs/query_execution/function_parameter_count_changed.snap
+++ b/test_outputs/query_execution/function_parameter_count_changed.snap
@@ -1,7 +1,6 @@
 ---
 source: src/query.rs
 expression: "&query_execution_results"
-snapshot_kind: text
 ---
 {
   "./test_crates/parameter_count_changed/": [
@@ -9,6 +8,9 @@ snapshot_kind: text
       "current_parameter_count": Uint64(2),
       "name": String("function_with_a_parameter_added"),
       "old_parameter_count": Uint64(1),
+      "old_parameter_names": List([
+        String("_"),
+      ]),
       "path": List([
         String("parameter_count_changed"),
         String("function_with_a_parameter_added"),
@@ -22,6 +24,10 @@ snapshot_kind: text
       "current_parameter_count": Uint64(0),
       "name": String("function_with_parameters_removed"),
       "old_parameter_count": Uint64(2),
+      "old_parameter_names": List([
+        String("_"),
+        String("_"),
+      ]),
       "path": List([
         String("parameter_count_changed"),
         String("function_with_parameters_removed"),

--- a/test_outputs/query_execution/function_parameter_count_changed.snap
+++ b/test_outputs/query_execution/function_parameter_count_changed.snap
@@ -9,7 +9,7 @@ expression: "&query_execution_results"
       "name": String("function_with_a_parameter_added"),
       "old_parameter_count": Uint64(1),
       "old_parameter_names": List([
-        String("_"),
+        String("a"),
       ]),
       "path": List([
         String("parameter_count_changed"),
@@ -25,8 +25,8 @@ expression: "&query_execution_results"
       "name": String("function_with_parameters_removed"),
       "old_parameter_count": Uint64(2),
       "old_parameter_names": List([
-        String("_"),
-        String("_"),
+        String("a"),
+        String("b"),
       ]),
       "path": List([
         String("parameter_count_changed"),

--- a/test_outputs/witnesses/function_parameter_count_changed.snap
+++ b/test_outputs/witnesses/function_parameter_count_changed.snap
@@ -6,9 +6,9 @@ expression: "&actual_witnesses"
 [["./test_crates/parameter_count_changed/"]]
 filename = 'src/lib.rs'
 begin_line = 3
-hint = 'parameter_count_changed::function_with_a_parameter_added( #parameters != 1 );'
+hint = 'let witness = |_| parameter_count_changed::function_with_a_parameter_added(_);'
 
 [["./test_crates/parameter_count_changed/"]]
 filename = 'src/lib.rs'
 begin_line = 5
-hint = 'parameter_count_changed::function_with_parameters_removed( #parameters != 2 );'
+hint = 'let witness = |_ , _| parameter_count_changed::function_with_parameters_removed(_ , _);'

--- a/test_outputs/witnesses/function_parameter_count_changed.snap
+++ b/test_outputs/witnesses/function_parameter_count_changed.snap
@@ -1,0 +1,14 @@
+---
+source: src/query.rs
+description: "Lint `function_parameter_count_changed` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+---
+[["./test_crates/parameter_count_changed/"]]
+filename = 'src/lib.rs'
+begin_line = 3
+hint = 'parameter_count_changed::function_with_a_parameter_added( #parameters != 1 );'
+
+[["./test_crates/parameter_count_changed/"]]
+filename = 'src/lib.rs'
+begin_line = 5
+hint = 'parameter_count_changed::function_with_parameters_removed( #parameters != 2 );'

--- a/test_outputs/witnesses/function_parameter_count_changed.snap
+++ b/test_outputs/witnesses/function_parameter_count_changed.snap
@@ -6,9 +6,9 @@ expression: "&actual_witnesses"
 [["./test_crates/parameter_count_changed/"]]
 filename = 'src/lib.rs'
 begin_line = 3
-hint = 'let witness = |_| parameter_count_changed::function_with_a_parameter_added(_);'
+hint = 'let witness = |a| parameter_count_changed::function_with_a_parameter_added(a);'
 
 [["./test_crates/parameter_count_changed/"]]
 filename = 'src/lib.rs'
 begin_line = 5
-hint = 'let witness = |_ , _| parameter_count_changed::function_with_parameters_removed(_ , _);'
+hint = 'let witness = |a, b| parameter_count_changed::function_with_parameters_removed(a, b);'


### PR DESCRIPTION
I’ve tried to keep the hint simple and consistent with others(#978,#977): `parameter_count_changed::function_with_parameters_removed(#parameter != <old_count>);`

However, the syntax `(#parameter != <old_count>)` or as alternative `(|parameter| != <old_count>)` might be confusing when compared to standard Rust syntax. Would it be better to replace this with `(...)` or `(...,...,...)` where number of `...` be equal to old_parameter_count for clarity?

>I'm still getting used to reading and writing these, so please forgive any mistakes.