### PR TITLE
chore: Add witness hint for `function_abi_no_longer_unwind` lint

### DIFF
--- a/src/lints/function_abi_no_longer_unwind.ron
+++ b/src/lints/function_abi_no_longer_unwind.ron
@@ -60,4 +60,7 @@ SemverQuery(
     },
     error_message: "A pub fn changed from an unwind-capable ABI to the same-named ABI without unwind. If that function causes an unwind (e.g. by panicking), its behavior is now undefined.",
     per_result_error_template: Some("pub fn {{name}} changed ABI from {{abi_raw_name}} to {{new_abi_raw_name}} in {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+        hint_template: r#"let witness = {{join "::" path}}(...);"#,
+    ),
 )

--- a/test_outputs/witnesses/function_abi_no_longer_unwind.snap.new
+++ b/test_outputs/witnesses/function_abi_no_longer_unwind.snap.new
@@ -1,0 +1,10 @@
+---
+source: src/query.rs
+assertion_line: 847
+description: "Lint `function_abi_no_longer_unwind` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+---
+[["./test_crates/function_abi_no_longer_unwind/"]]
+filename = 'src/lib.rs'
+begin_line = 3
+hint = 'let witness = function_abi_no_longer_unwind::unwind_function_becomes_non_unwind(...);'


### PR DESCRIPTION
Related to #937 

Hi, I tried to add a witness hint for `function_abi_no_longer_unwind` lint. I've checked #977 , #978 and tried to keep the syntax consistent. 

There are two potential options for the witness hint:
1. Option 1 (Concise): 
```let witness = function_abi_no_longer_unwind::unwind_function_becomes_non_unwind(...);```

	This option is cleaner and shorter. It directly indicates which function violates the semver rules, with the violation type already detailed in the err_message section.
	
2. Option 2 (Verbose):
```let witness = pub extern "C" fn function_abi_no_longer_unwind::unwind_function_becomes_non_unwind(...);```

	This version provides richer information in the witness, allowing the user to easily identify where and what is violating the semver rules by just looking at the witness hint. However, it is a bit longer and includes some redundant details that are also present in the err_message. Additionally, I'm not completely certain if the syntax `pub extern "C" fn {{long_function_path}}` is legit.
	
Please let me know which one suites better for this lint :)
