### PR TITLE
Chore: Add witness hint for `function_unsafe_added` lint

### DIFF
--- a/src/lints/function_unsafe_added.ron
+++ b/src/lints/function_unsafe_added.ron
@@ -49,4 +49,7 @@ SemverQuery(
     },
     error_message: "A publicly-visible function became `unsafe`, so calling it now requires an `unsafe` block.",
     per_result_error_template: Some("function {{join \"::\" path}} in file {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+        hint_template: r#"let witness = {{join "::" path}}(...);"#,
+    ),
 )

--- a/test_outputs/witnesses/function_unsafe_added.snap
+++ b/test_outputs/witnesses/function_unsafe_added.snap
@@ -1,6 +1,5 @@
 ---
 source: src/query.rs
-assertion_line: 847
 description: "Lint `function_unsafe_added` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
 expression: "&actual_witnesses"
 ---

--- a/test_outputs/witnesses/function_unsafe_added.snap.new
+++ b/test_outputs/witnesses/function_unsafe_added.snap.new
@@ -1,0 +1,25 @@
+---
+source: src/query.rs
+assertion_line: 847
+description: "Lint `function_unsafe_added` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+---
+[["./test_crates/function_unsafe_added/"]]
+filename = 'src/lib.rs'
+begin_line = 3
+hint = 'let witness = function_unsafe_added::add(...);'
+
+[["./test_crates/safe_vs_unsafe_extern_fn/"]]
+filename = 'src/lib.rs'
+begin_line = 18
+hint = 'let witness = safe_vs_unsafe_extern_fn::originally_safe_now_implicit_unsafe(...);'
+
+[["./test_crates/safe_vs_unsafe_extern_fn/"]]
+filename = 'src/lib.rs'
+begin_line = 20
+hint = 'let witness = safe_vs_unsafe_extern_fn::originally_safe_now_explicit_unsafe(...);'
+
+[["./test_crates/safe_vs_unsafe_extern_fn/"]]
+filename = 'src/lib.rs'
+begin_line = 30
+hint = 'let witness = safe_vs_unsafe_extern_fn::originally_safe_now_legacy(...);'


### PR DESCRIPTION
Added a witness hint for `function_unsafe_added` lint for #937 .

This witness hint should be valid as the function is not enclosed in a `unsafe{ }` block