### PR TITLE
new lint: `enum_tuple_variant_field_marked_deprecated`

### DIFF
--- a/src/lints/enum_tuple_variant_field_marked_deprecated.ron
+++ b/src/lints/enum_tuple_variant_field_marked_deprecated.ron
@@ -27,7 +27,7 @@ SemverQuery(
                                 deprecated @filter(op: "!=", value: ["$true"])
 
                                 field {
-                                    field_position: position @output @tag
+                                    field_name: name @output @tag
                                     public_api_eligible @filter(op: "=", value: ["$true"])
                                     deprecated @filter(op: "!=", value: ["$true"])
                                 }
@@ -56,7 +56,7 @@ SemverQuery(
                                 deprecated @filter(op: "!=", value: ["$true"])
 
                                 field {
-                                    position @filter(op: "=", value: ["%field_position"])
+                                    name @filter(op: "=", value: ["%field_name"])
                                     public_api_eligible @filter(op: "=", value: ["$true"])
                                     deprecated @filter(op: "=", value: ["$true"])
 
@@ -78,5 +78,5 @@ SemverQuery(
         "true": true,
     },
     error_message: "A field in an enum's tuple variant is now #[deprecated]. Downstream crates will get a compiler warning when accessing this field.",
-    per_result_error_template: Some("field at position {{field_position}} in enum variant {{enum_name}}::{{variant_name}} in {{span_filename}}:{{span_begin_line}}"),
+    per_result_error_template: Some("field {{enum_name}}::{{variant_name}}.{{field_name}} in {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/lints/enum_tuple_variant_field_marked_deprecated.ron
+++ b/src/lints/enum_tuple_variant_field_marked_deprecated.ron
@@ -1,0 +1,82 @@
+SemverQuery(
+    id: "enum_tuple_variant_field_marked_deprecated",
+    human_readable_name: "enum tuple variant field #[deprecated] added",
+    description: "A field in an enum's tuple variant has been newly marked with #[deprecated].",
+    required_update: Minor,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Enum {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        deprecated @filter(op: "!=", value: ["$true"])
+                        enum_name: name @output
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        variant {
+                            ... on TupleVariant {
+                                variant_name: name @output @tag
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+                                deprecated @filter(op: "!=", value: ["$true"])
+
+                                field {
+                                    field_position: position @output @tag
+                                    public_api_eligible @filter(op: "=", value: ["$true"])
+                                    deprecated @filter(op: "!=", value: ["$true"])
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Enum {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        # Filter out deprecated enums since rustdoc automatically marks their fields as deprecated.
+                        # This ensures we only detect fields that are explicitly marked with #[deprecated].
+                        deprecated @filter(op: "!=", value: ["$true"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        variant {
+                            ... on TupleVariant {
+                                name @filter(op: "=", value: ["%variant_name"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+                                deprecated @filter(op: "!=", value: ["$true"])
+
+                                field {
+                                    position @filter(op: "=", value: ["%field_position"])
+                                    public_api_eligible @filter(op: "=", value: ["$true"])
+                                    deprecated @filter(op: "=", value: ["$true"])
+
+                                    span_: span @optional {
+                                        filename @output
+                                        begin_line @output
+                                        end_line @output
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+    },
+    error_message: "A field in an enum's tuple variant is now #[deprecated]. Downstream crates will get a compiler warning when accessing this field.",
+    per_result_error_template: Some("field at position {{field_position}} in enum variant {{enum_name}}::{{variant_name}} in {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1244,6 +1244,7 @@ add_lints!(
     enum_struct_variant_field_now_doc_hidden,
     enum_tuple_variant_changed_kind,
     enum_tuple_variant_field_added,
+    enum_tuple_variant_field_marked_deprecated,
     enum_tuple_variant_field_missing,
     enum_tuple_variant_field_now_doc_hidden,
     enum_unit_variant_changed_kind,

--- a/test_crates/enum_tuple_variant_field_marked_deprecated/new/Cargo.toml
+++ b/test_crates/enum_tuple_variant_field_marked_deprecated/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_tuple_variant_field_marked_deprecated"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_tuple_variant_field_marked_deprecated/new/src/lib.rs
+++ b/test_crates/enum_tuple_variant_field_marked_deprecated/new/src/lib.rs
@@ -1,0 +1,73 @@
+#![no_std]
+
+// This enum has tuple variants with fields that will be marked as deprecated
+pub enum TupleVariantEnum {
+    // This variant has fields that will be marked as deprecated
+    TupleVariant(
+        #[deprecated] i32,
+        #[deprecated = "This field is deprecated, use something else"] u8,
+        bool,
+    ),
+
+    // This variant will have some fields marked as deprecated
+    AnotherTuple(u64, #[deprecated] i16, char),
+
+    // This will remain unchanged
+    NormalTuple(f64, f32),
+
+    // This variant will be entirely deprecated
+    #[deprecated]
+    VariantToBeDeprecated(#[deprecated] i32, u8, bool),
+
+    // This variant is already deprecated
+    #[deprecated]
+    VariantAlreadyDeprecated(#[deprecated] i32),
+
+    // Non-tuple variants for completeness
+    UnitVariant,
+    StructVariant {
+        field1: bool,
+        field2: u32,
+    },
+}
+
+// This enum will be marked as deprecated in the new version
+// Its tuple variant fields should not trigger the lint since the enum itself is deprecated
+#[deprecated]
+pub enum EnumToBeDeprecated {
+    TupleVariant(#[deprecated] i32, #[deprecated] u8),
+    UnitVariant,
+}
+
+// This enum is already deprecated
+// Changes to its tuple variant fields should not trigger the lint
+#[deprecated]
+pub enum AlreadyDeprecatedEnum {
+    TupleVariant(#[deprecated] i32, #[deprecated] u8),
+    UnitVariant,
+}
+
+// This enum is private and should not trigger the lint
+enum PrivateEnum {
+    TupleVariant(#[deprecated] i32, #[deprecated] u8),
+}
+
+// This enum has a hidden variant that should not trigger the lint
+pub enum EnumWithHiddenVariant {
+    NormalTuple(#[deprecated] i32, u8),
+    #[doc(hidden)]
+    HiddenTuple(#[deprecated] i32, #[deprecated] u8),
+}
+
+// This variant has already deprecated fields and should not trigger the lint
+pub enum EnumWithAlreadyDeprecatedFields {
+    NormalTuple(i32, u8),
+    TupleWithDeprecatedField(#[deprecated] i32, u8),
+    TupleWithDeprecatedFieldAndMessage(i32, #[deprecated = "Don't use this field"] u8),
+}
+
+// This enum is hidden with #[doc(hidden)] and should not trigger the lint
+#[doc(hidden)]
+pub enum HiddenEnum {
+    TupleVariant(#[deprecated] i32, #[deprecated] u8),
+}

--- a/test_crates/enum_tuple_variant_field_marked_deprecated/old/Cargo.toml
+++ b/test_crates/enum_tuple_variant_field_marked_deprecated/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_tuple_variant_field_marked_deprecated"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_tuple_variant_field_marked_deprecated/old/src/lib.rs
+++ b/test_crates/enum_tuple_variant_field_marked_deprecated/old/src/lib.rs
@@ -1,0 +1,67 @@
+#![no_std]
+
+// This enum has tuple variants with fields that will be marked as deprecated
+pub enum TupleVariantEnum {
+    // This variant has fields that will be marked as deprecated
+    TupleVariant(i32, u8, bool),
+
+    // This variant will have some fields marked as deprecated
+    AnotherTuple(u64, i16, char),
+
+    // This will remain unchanged
+    NormalTuple(f64, f32),
+
+    // This variant will be entirely deprecated
+    VariantToBeDeprecated(i32, u8, bool),
+
+    // This variant is already deprecated
+    #[deprecated]
+    VariantAlreadyDeprecated(#[deprecated] i32),
+
+    // Non-tuple variants for completeness
+    UnitVariant,
+    StructVariant {
+        field1: bool,
+        field2: u32,
+    },
+}
+
+// This enum will be marked as deprecated in the new version
+// Its tuple variant fields should not trigger the lint since the enum itself is deprecated
+pub enum EnumToBeDeprecated {
+    TupleVariant(i32, u8),
+    UnitVariant,
+}
+
+// This enum is already deprecated
+// Changes to its tuple variant fields should not trigger the lint
+#[deprecated]
+pub enum AlreadyDeprecatedEnum {
+    TupleVariant(i32, u8),
+    UnitVariant,
+}
+
+// This enum is private and should not trigger the lint
+enum PrivateEnum {
+    TupleVariant(i32, u8),
+}
+
+// This enum has a hidden variant that should not trigger the lint
+pub enum EnumWithHiddenVariant {
+    NormalTuple(i32, u8),
+    #[doc(hidden)]
+    HiddenTuple(i32, u8),
+}
+
+// This variant has already deprecated fields and should not trigger the lint
+pub enum EnumWithAlreadyDeprecatedFields {
+    NormalTuple(i32, u8),
+    TupleWithDeprecatedField(#[deprecated] i32, u8),
+    TupleWithDeprecatedFieldAndMessage(i32, #[deprecated = "Don't use this field"] u8),
+}
+
+// This enum is hidden with #[doc(hidden)] and should not trigger the lint
+#[doc(hidden)]
+pub enum HiddenEnum {
+    TupleVariant(i32, u8),
+}

--- a/test_outputs/query_execution/enum_tuple_variant_field_marked_deprecated.snap
+++ b/test_outputs/query_execution/enum_tuple_variant_field_marked_deprecated.snap
@@ -6,7 +6,7 @@ expression: "&query_execution_results"
   "./test_crates/enum_struct_variant_field_marked_deprecated/": [
     {
       "enum_name": String("NormalEnum"),
-      "field_position": Int64(1),
+      "field_name": String("0"),
       "path": List([
         String("enum_struct_variant_field_marked_deprecated"),
         String("NormalEnum"),
@@ -20,7 +20,7 @@ expression: "&query_execution_results"
   "./test_crates/enum_tuple_variant_field_marked_deprecated/": [
     {
       "enum_name": String("TupleVariantEnum"),
-      "field_position": Int64(1),
+      "field_name": String("0"),
       "path": List([
         String("enum_tuple_variant_field_marked_deprecated"),
         String("TupleVariantEnum"),
@@ -32,7 +32,7 @@ expression: "&query_execution_results"
     },
     {
       "enum_name": String("TupleVariantEnum"),
-      "field_position": Int64(2),
+      "field_name": String("1"),
       "path": List([
         String("enum_tuple_variant_field_marked_deprecated"),
         String("TupleVariantEnum"),
@@ -44,7 +44,7 @@ expression: "&query_execution_results"
     },
     {
       "enum_name": String("TupleVariantEnum"),
-      "field_position": Int64(2),
+      "field_name": String("1"),
       "path": List([
         String("enum_tuple_variant_field_marked_deprecated"),
         String("TupleVariantEnum"),
@@ -56,7 +56,7 @@ expression: "&query_execution_results"
     },
     {
       "enum_name": String("EnumWithHiddenVariant"),
-      "field_position": Int64(1),
+      "field_name": String("0"),
       "path": List([
         String("enum_tuple_variant_field_marked_deprecated"),
         String("EnumWithHiddenVariant"),

--- a/test_outputs/query_execution/enum_tuple_variant_field_marked_deprecated.snap
+++ b/test_outputs/query_execution/enum_tuple_variant_field_marked_deprecated.snap
@@ -1,0 +1,70 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+---
+{
+  "./test_crates/enum_struct_variant_field_marked_deprecated/": [
+    {
+      "enum_name": String("NormalEnum"),
+      "field_position": Int64(1),
+      "path": List([
+        String("enum_struct_variant_field_marked_deprecated"),
+        String("NormalEnum"),
+      ]),
+      "span_begin_line": Uint64(19),
+      "span_end_line": Uint64(19),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("TupleVariant"),
+    },
+  ],
+  "./test_crates/enum_tuple_variant_field_marked_deprecated/": [
+    {
+      "enum_name": String("TupleVariantEnum"),
+      "field_position": Int64(1),
+      "path": List([
+        String("enum_tuple_variant_field_marked_deprecated"),
+        String("TupleVariantEnum"),
+      ]),
+      "span_begin_line": Uint64(7),
+      "span_end_line": Uint64(7),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("TupleVariant"),
+    },
+    {
+      "enum_name": String("TupleVariantEnum"),
+      "field_position": Int64(2),
+      "path": List([
+        String("enum_tuple_variant_field_marked_deprecated"),
+        String("TupleVariantEnum"),
+      ]),
+      "span_begin_line": Uint64(8),
+      "span_end_line": Uint64(8),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("TupleVariant"),
+    },
+    {
+      "enum_name": String("TupleVariantEnum"),
+      "field_position": Int64(2),
+      "path": List([
+        String("enum_tuple_variant_field_marked_deprecated"),
+        String("TupleVariantEnum"),
+      ]),
+      "span_begin_line": Uint64(13),
+      "span_end_line": Uint64(13),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("AnotherTuple"),
+    },
+    {
+      "enum_name": String("EnumWithHiddenVariant"),
+      "field_position": Int64(1),
+      "path": List([
+        String("enum_tuple_variant_field_marked_deprecated"),
+        String("EnumWithHiddenVariant"),
+      ]),
+      "span_begin_line": Uint64(57),
+      "span_end_line": Uint64(57),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("NormalTuple"),
+    },
+  ],
+}

--- a/test_outputs/query_execution/enum_variant_marked_deprecated.snap
+++ b/test_outputs/query_execution/enum_variant_marked_deprecated.snap
@@ -17,6 +17,20 @@ expression: "&query_execution_results"
       "visibility_limit": String("public"),
     },
   ],
+  "./test_crates/enum_tuple_variant_field_marked_deprecated/": [
+    {
+      "name": String("TupleVariantEnum"),
+      "path": List([
+        String("enum_tuple_variant_field_marked_deprecated"),
+        String("TupleVariantEnum"),
+      ]),
+      "span_begin_line": Uint64(20),
+      "span_end_line": Uint64(20),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("VariantToBeDeprecated"),
+      "visibility_limit": String("public"),
+    },
+  ],
   "./test_crates/enum_variant_marked_deprecated/": [
     {
       "name": String("NormalEnum"),

--- a/test_outputs/query_execution/type_marked_deprecated.snap
+++ b/test_outputs/query_execution/type_marked_deprecated.snap
@@ -17,6 +17,20 @@ expression: "&query_execution_results"
       "visibility_limit": String("public"),
     },
   ],
+  "./test_crates/enum_tuple_variant_field_marked_deprecated/": [
+    {
+      "name": String("EnumToBeDeprecated"),
+      "owner_type": String("Enum"),
+      "path": List([
+        String("enum_tuple_variant_field_marked_deprecated"),
+        String("EnumToBeDeprecated"),
+      ]),
+      "span_begin_line": Uint64(37),
+      "span_end_line": Uint64(40),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
   "./test_crates/enum_variant_marked_deprecated/": [
     {
       "name": String("EnumToBeDeprecated"),


### PR DESCRIPTION
final part of: #57 