### PR TITLE
Chore: Add witness hint for `module_missing` lint

### DIFF
--- a/src/lints/module_missing.ron
+++ b/src/lints/module_missing.ron
@@ -48,6 +48,6 @@ SemverQuery(
     error_message: "A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.",
     per_result_error_template: Some("mod {{join \"::\" path}}, previously in file {{span_filename}}:{{span_begin_line}}"),
     witness: (
-        hint_template: r#"use {{join "::" path}};"#,
+        hint_template: r#"use {{join "::" path}}::*;"#,
     ),
 )

--- a/src/lints/module_missing.ron
+++ b/src/lints/module_missing.ron
@@ -47,4 +47,7 @@ SemverQuery(
     },
     error_message: "A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.",
     per_result_error_template: Some("mod {{join \"::\" path}}, previously in file {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+        hint_template: r#"use {{join "::" path}};"#,
+    ),
 )

--- a/test_outputs/witnesses/module_missing.snap
+++ b/test_outputs/witnesses/module_missing.snap
@@ -6,19 +6,19 @@ expression: "&actual_witnesses"
 [["./test_crates/module_missing/"]]
 filename = 'src/lib.rs'
 begin_line = 10
-hint = 'use module_missing::bb::will_remove;'
+hint = 'use module_missing::bb::will_remove::*;'
 
 [["./test_crates/module_missing/"]]
 filename = 'src/lib.rs'
 begin_line = 13
-hint = 'use module_missing::will_make_private;'
+hint = 'use module_missing::will_make_private::*;'
 
 [["./test_crates/trait_missing/"]]
 filename = 'src/lib.rs'
 begin_line = 7
-hint = 'use trait_missing::my_pub_mod;'
+hint = 'use trait_missing::my_pub_mod::*;'
 
 [["./test_crates/trait_missing_with_major_bump/"]]
 filename = 'src/lib.rs'
 begin_line = 7
-hint = 'use trait_missing_with_major_bump::my_pub_mod;'
+hint = 'use trait_missing_with_major_bump::my_pub_mod::*;'

--- a/test_outputs/witnesses/module_missing.snap
+++ b/test_outputs/witnesses/module_missing.snap
@@ -1,0 +1,24 @@
+---
+source: src/query.rs
+description: "Lint `module_missing` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+---
+[["./test_crates/module_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 10
+hint = 'use module_missing::bb::will_remove;'
+
+[["./test_crates/module_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 13
+hint = 'use module_missing::will_make_private;'
+
+[["./test_crates/trait_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 7
+hint = 'use trait_missing::my_pub_mod;'
+
+[["./test_crates/trait_missing_with_major_bump/"]]
+filename = 'src/lib.rs'
+begin_line = 7
+hint = 'use trait_missing_with_major_bump::my_pub_mod;'


### PR DESCRIPTION
Add a witness hint for `module_missing`, addressing #937 

This witness hint is valid as `use removed_mod::func;` does not compile in Rust. 

However, there is an edge cases where `use removed_mod::inner_mod` exists in the old version code, but it was replaced by `use removed_mod::inner_function (but the function name is same as the previously removed inner_mod)`, then this witness hint may be a True Negative witness hint.