### PR TITLE
Chore: Add witness hint for `trait_unsafe_added` lint

### DIFF
--- a/src/lints/trait_unsafe_added.ron
+++ b/src/lints/trait_unsafe_added.ron
@@ -52,6 +52,6 @@ SemverQuery(
     per_result_error_template: Some("trait {{join \"::\" path}} in file {{span_filename}}:{{span_begin_line}}"),
     witness: (
         hint_template: r#"struct MyStruct;
-impl {{join "::" path}} for MyStruct {...};"#,
+impl {{join "::" path}} for MyStruct {...}"#,
     ),
 )

--- a/src/lints/trait_unsafe_added.ron
+++ b/src/lints/trait_unsafe_added.ron
@@ -51,7 +51,7 @@ SemverQuery(
     error_message: "A publicly-visible trait became `unsafe`, so implementing it now requires an `unsafe impl` block.",
     per_result_error_template: Some("trait {{join \"::\" path}} in file {{span_filename}}:{{span_begin_line}}"),
     witness: (
-        hint_template: r#"struct MyStruct;
-impl {{join "::" path}} for MyStruct {...}"#,
+        hint_template: r#"struct Witness;
+impl {{join "::" path}} for Witness {...}"#,
     ),
 )

--- a/src/lints/trait_unsafe_added.ron
+++ b/src/lints/trait_unsafe_added.ron
@@ -50,4 +50,8 @@ SemverQuery(
     },
     error_message: "A publicly-visible trait became `unsafe`, so implementing it now requires an `unsafe impl` block.",
     per_result_error_template: Some("trait {{join \"::\" path}} in file {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+        hint_template: r#"struct MyStruct;
+impl {{join "::" path}} for MyStruct {...};"#,
+    ),
 )

--- a/test_outputs/witnesses/trait_unsafe_added.snap
+++ b/test_outputs/witnesses/trait_unsafe_added.snap
@@ -7,26 +7,26 @@ expression: "&actual_witnesses"
 filename = 'src/lib.rs'
 begin_line = 25
 hint = '''
-struct MyStruct;
-impl trait_method_unsafe_added::TraitBecomesUnsafe for MyStruct {...};'''
+struct Witness;
+impl trait_method_unsafe_added::TraitBecomesUnsafe for Witness {...}'''
 
 [["./test_crates/trait_missing/"]]
 filename = 'src/lib.rs'
 begin_line = 11
 hint = '''
-struct MyStruct;
-impl trait_missing::TraitBecomesUnsafe for MyStruct {...};'''
+struct Witness;
+impl trait_missing::TraitBecomesUnsafe for Witness {...}'''
 
 [["./test_crates/trait_missing_with_major_bump/"]]
 filename = 'src/lib.rs'
 begin_line = 11
 hint = '''
-struct MyStruct;
-impl trait_missing_with_major_bump::TraitBecomesUnsafe for MyStruct {...};'''
+struct Witness;
+impl trait_missing_with_major_bump::TraitBecomesUnsafe for Witness {...}'''
 
 [["./test_crates/trait_unsafe_added/"]]
 filename = 'src/lib.rs'
 begin_line = 4
 hint = '''
-struct MyStruct;
-impl trait_unsafe_added::TraitBecomesUnsafe for MyStruct {...};'''
+struct Witness;
+impl trait_unsafe_added::TraitBecomesUnsafe for Witness {...}'''

--- a/test_outputs/witnesses/trait_unsafe_added.snap
+++ b/test_outputs/witnesses/trait_unsafe_added.snap
@@ -1,0 +1,32 @@
+---
+source: src/query.rs
+description: "Lint `trait_unsafe_added` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+---
+[["./test_crates/trait_method_unsafe_added/"]]
+filename = 'src/lib.rs'
+begin_line = 25
+hint = '''
+struct MyStruct;
+impl trait_method_unsafe_added::TraitBecomesUnsafe for MyStruct {...};'''
+
+[["./test_crates/trait_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 11
+hint = '''
+struct MyStruct;
+impl trait_missing::TraitBecomesUnsafe for MyStruct {...};'''
+
+[["./test_crates/trait_missing_with_major_bump/"]]
+filename = 'src/lib.rs'
+begin_line = 11
+hint = '''
+struct MyStruct;
+impl trait_missing_with_major_bump::TraitBecomesUnsafe for MyStruct {...};'''
+
+[["./test_crates/trait_unsafe_added/"]]
+filename = 'src/lib.rs'
+begin_line = 4
+hint = '''
+struct MyStruct;
+impl trait_unsafe_added::TraitBecomesUnsafe for MyStruct {...};'''


### PR DESCRIPTION
Add witness hint for `trait_unsafe_added` lint, addressing #937 

This should be a valid witness hint as only `unsafe impl` can implement unsafe trait