### PR TITLE
Chore: Add witness hint for `enum_struct_variant_field_missing` lint

### DIFF
--- a/src/lints/enum_struct_variant_field_missing.ron
+++ b/src/lints/enum_struct_variant_field_missing.ron
@@ -71,4 +71,10 @@ SemverQuery(
     },
     error_message: "A publicly-visible enum has a struct variant whose field is no longer available under its prior name. It may have been renamed or removed entirely.",
     per_result_error_template: Some("field {{field_name}} of variant {{enum_name}}::{{variant_name}}, previously in file {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+        hint_template: r#"match value {
+    {{ join "::" path }}::{{ variant_name }}{ {{ field_name }}, .. } => (),
+    _ => (),
+}"#,
+    )
 )

--- a/src/lints/enum_struct_variant_field_missing.ron
+++ b/src/lints/enum_struct_variant_field_missing.ron
@@ -73,7 +73,7 @@ SemverQuery(
     per_result_error_template: Some("field {{field_name}} of variant {{enum_name}}::{{variant_name}}, previously in file {{span_filename}}:{{span_begin_line}}"),
     witness: (
         hint_template: r#"match value {
-    {{ join "::" path }}::{{ variant_name }}{ {{ field_name }}, .. } => (),
+    {{ join "::" path }}::{{ variant_name }} { {{ field_name }}, .. } => (),
     _ => (),
 }"#,
     )

--- a/test_outputs/witnesses/enum_struct_variant_field_missing.snap
+++ b/test_outputs/witnesses/enum_struct_variant_field_missing.snap
@@ -9,7 +9,7 @@ filename = 'src/lib.rs'
 begin_line = 8
 hint = '''
 match value {
-    enum_struct_variant_field_missing::Enum::FieldWillBeMissing{ bar, .. } => (),
+    enum_struct_variant_field_missing::Enum::FieldWillBeMissing { bar, .. } => (),
     _ => (),
 }'''
 
@@ -18,6 +18,6 @@ filename = 'src/lib.rs'
 begin_line = 68
 hint = '''
 match value {
-    repr_c_enum_struct_variant_fields_reordered::EnumWithRemoval::StructVariant{ a, .. } => (),
+    repr_c_enum_struct_variant_fields_reordered::EnumWithRemoval::StructVariant { a, .. } => (),
     _ => (),
 }'''

--- a/test_outputs/witnesses/enum_struct_variant_field_missing.snap
+++ b/test_outputs/witnesses/enum_struct_variant_field_missing.snap
@@ -1,0 +1,23 @@
+---
+source: src/query.rs
+description: "Lint `enum_struct_variant_field_missing` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+snapshot_kind: text
+---
+[["./test_crates/enum_struct_variant_field_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 8
+hint = '''
+match value {
+    enum_struct_variant_field_missing::Enum::FieldWillBeMissing{ bar, .. } => (),
+    _ => (),
+}'''
+
+[["./test_crates/repr_c_enum_struct_variant_fields_reordered/"]]
+filename = 'src/lib.rs'
+begin_line = 68
+hint = '''
+match value {
+    repr_c_enum_struct_variant_fields_reordered::EnumWithRemoval::StructVariant{ a, .. } => (),
+    _ => (),
+}'''


### PR DESCRIPTION
Adds a witness hint for the `enum_struct_variant_field_missing` lint. 

## Example
`enum_struct_variant_field_missing` outputs the following witness hint for the `./test_crates/enum_struct_variant_field_missing` test.
```rust
match value {
    enum_struct_variant_field_missing::Enum::FieldWillBeMissing{ bar, .. } => (),
    _ => (),
}
```

As far as I know, this should cover it, but please let me know if there is more I can improve on here.