### PR TITLE
feat: add a witness hint for struct_missing lint

### DIFF
--- a/src/lints/struct_missing.ron
+++ b/src/lints/struct_missing.ron
@@ -51,4 +51,7 @@ SemverQuery(
     },
     error_message: "A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.",
     per_result_error_template: Some("struct {{join \"::\" path}}, previously in file {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+    hint_template: r#"let witness = {{join "::" path}}{};"#,
+    ),
 )

--- a/test_outputs/witnesses/struct_missing.snap
+++ b/test_outputs/witnesses/struct_missing.snap
@@ -1,0 +1,69 @@
+---
+source: src/query.rs
+description: "Lint `struct_missing` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+---
+[["./test_crates/move_item_and_reexport/"]]
+filename = 'src/lib.rs'
+begin_line = 40
+hint = 'let witness = move_item_and_reexport::NonEquivalentReorderedGenerics{};'
+
+[["./test_crates/move_item_and_reexport/"]]
+filename = 'src/lib.rs'
+begin_line = 44
+hint = 'let witness = move_item_and_reexport::NonEquivalentRemovedLifetime{};'
+
+[["./test_crates/move_item_and_reexport/"]]
+filename = 'src/lib.rs'
+begin_line = 48
+hint = 'let witness = move_item_and_reexport::NonEquivalentRemovedConst{};'
+
+[["./test_crates/move_item_and_reexport/"]]
+filename = 'src/lib.rs'
+begin_line = 52
+hint = 'let witness = move_item_and_reexport::NonEquivalentRemovedType{};'
+
+[["./test_crates/repr_packed_added_removed/"]]
+filename = 'src/lib.rs'
+begin_line = 11
+hint = 'let witness = repr_packed_added_removed::StructBecomesPackedAndPrivate{};'
+
+[["./test_crates/repr_packed_added_removed/"]]
+filename = 'src/lib.rs'
+begin_line = 15
+hint = 'let witness = repr_packed_added_removed::StructBecomesUnpackedAndPrivate{};'
+
+[["./test_crates/semver_trick_self_referential/"]]
+filename = 'src/lib.rs'
+begin_line = 3
+hint = 'let witness = semver_trick_self_referential::Example{};'
+
+[["./test_crates/struct_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 3
+hint = 'let witness = struct_missing::WillBeRemovedStruct{};'
+
+[["./test_crates/struct_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 6
+hint = 'let witness = struct_missing::PubUseRemovedStruct{};'
+
+[["./test_crates/struct_now_doc_hidden/"]]
+filename = 'src/lib.rs'
+begin_line = 36
+hint = 'let witness = struct_now_doc_hidden::PublicStructThatGoesPrivate{};'
+
+[["./test_crates/struct_pub_field_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 13
+hint = 'let witness = struct_pub_field_missing::StructRemoved{};'
+
+[["./test_crates/struct_with_no_pub_fields_changed_type/"]]
+filename = 'src/lib.rs'
+begin_line = 91
+hint = 'let witness = struct_with_no_pub_fields_changed_type::PubStructChangedToType{};'
+
+[["./test_crates/switch_to_reexport_as_underscore/"]]
+filename = 'src/lib.rs'
+begin_line = 6
+hint = 'let witness = switch_to_reexport_as_underscore::Struct{};'


### PR DESCRIPTION
(PR for Idea Verification) Though given the current test_crates for struct_missing this should work. Yet I feel that it should also cover the cases when the struct contains fields? And if it does it should have witness output that  would be something like `let witness = |a: <type>, b: <type>| struct_missing::WillBeRemovedStruct{foo: a, bar: b};`  for a struct `pub struct WillBeRemovedStruct{foo: <type>, bar:<type>}` that is being completely removed. Shouldn't it?

Also, extracting field names seems/is straightforward but field types is something I can't figure out how to extract. Any help?
