### PR TITLE
Chore: Add witness hint for `enum_struct_variant_field_added` lint

### DIFF
--- a/src/lints/enum_struct_variant_field_added.ron
+++ b/src/lints/enum_struct_variant_field_added.ron
@@ -68,14 +68,6 @@ SemverQuery(
                                 field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                                     name @filter(op: "=", value: ["%field_name"])
                                 }
-                            }
-                        }
-
-                        variant {
-                            ... on StructVariant {
-                                name @filter(op: "=", value: ["%variant_name"])
-                                attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
-                                public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 field @fold {
                                     baseline_field_names: name @output

--- a/src/lints/enum_struct_variant_field_added.ron
+++ b/src/lints/enum_struct_variant_field_added.ron
@@ -70,6 +70,18 @@ SemverQuery(
                                 }
                             }
                         }
+
+                        variant {
+                            ... on StructVariant {
+                                name @filter(op: "=", value: ["%variant_name"])
+                                attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+
+                                field @fold {
+                                    old_field_names: name @output
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -83,4 +95,10 @@ SemverQuery(
     },
     error_message: "An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.",
     per_result_error_template: Some("field {{field_name}} of variant {{enum_name}}::{{variant_name}} in {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+        hint_template: r#"match value {
+    {{ join "::" path }}::{{ variant_name }} { {{ join ", " old_field_names }} } => (),
+    _ => (),
+}"#,
+    )
 )

--- a/src/lints/enum_struct_variant_field_added.ron
+++ b/src/lints/enum_struct_variant_field_added.ron
@@ -78,7 +78,7 @@ SemverQuery(
                                 public_api_eligible @filter(op: "=", value: ["$true"])
 
                                 field @fold {
-                                    old_field_names: name @output
+                                    baseline_field_names: name @output
                                 }
                             }
                         }
@@ -97,7 +97,7 @@ SemverQuery(
     per_result_error_template: Some("field {{field_name}} of variant {{enum_name}}::{{variant_name}} in {{span_filename}}:{{span_begin_line}}"),
     witness: (
         hint_template: r#"match value {
-    {{ join "::" path }}::{{ variant_name }} { {{ join ", " old_field_names }} } => (),
+    {{ join "::" path }}::{{ variant_name }} { {{ join ", " baseline_field_names }} } => (),
     _ => (),
 }"#,
     )

--- a/test_outputs/query_execution/enum_struct_variant_field_added.snap
+++ b/test_outputs/query_execution/enum_struct_variant_field_added.snap
@@ -6,9 +6,9 @@ snapshot_kind: text
 {
   "./test_crates/enum_no_repr_variant_discriminant_changed/": [
     {
+      "baseline_field_names": List([]),
       "enum_name": String("UnitOnlyBecomesUndefined"),
       "field_name": String("a"),
-      "baseline_field_names": List([]),
       "path": List([
         String("enum_no_repr_variant_discriminant_changed"),
         String("UnitOnlyBecomesUndefined"),
@@ -21,11 +21,11 @@ snapshot_kind: text
   ],
   "./test_crates/enum_struct_field_hidden_from_public_api/": [
     {
-      "enum_name": String("AddedVariantField"),
-      "field_name": String("y"),
       "baseline_field_names": List([
         String("x"),
       ]),
+      "enum_name": String("AddedVariantField"),
+      "field_name": String("y"),
       "path": List([
         String("enum_struct_field_hidden_from_public_api"),
         String("AddedVariantField"),
@@ -38,11 +38,11 @@ snapshot_kind: text
   ],
   "./test_crates/enum_struct_variant_field_added/": [
     {
-      "enum_name": String("PubEnum"),
-      "field_name": String("y"),
       "baseline_field_names": List([
         String("x"),
       ]),
+      "enum_name": String("PubEnum"),
+      "field_name": String("y"),
       "path": List([
         String("enum_struct_variant_field_added"),
         String("PubEnum"),
@@ -55,12 +55,12 @@ snapshot_kind: text
   ],
   "./test_crates/repr_c_enum_struct_variant_fields_reordered/": [
     {
-      "enum_name": String("EnumWithAddition"),
-      "field_name": String("c"),
       "baseline_field_names": List([
         String("a"),
         String("b"),
       ]),
+      "enum_name": String("EnumWithAddition"),
+      "field_name": String("c"),
       "path": List([
         String("repr_c_enum_struct_variant_fields_reordered"),
         String("EnumWithAddition"),

--- a/test_outputs/query_execution/enum_struct_variant_field_added.snap
+++ b/test_outputs/query_execution/enum_struct_variant_field_added.snap
@@ -8,6 +8,7 @@ snapshot_kind: text
     {
       "enum_name": String("UnitOnlyBecomesUndefined"),
       "field_name": String("a"),
+      "old_field_names": List([]),
       "path": List([
         String("enum_no_repr_variant_discriminant_changed"),
         String("UnitOnlyBecomesUndefined"),
@@ -22,6 +23,9 @@ snapshot_kind: text
     {
       "enum_name": String("AddedVariantField"),
       "field_name": String("y"),
+      "old_field_names": List([
+        String("x"),
+      ]),
       "path": List([
         String("enum_struct_field_hidden_from_public_api"),
         String("AddedVariantField"),
@@ -36,6 +40,9 @@ snapshot_kind: text
     {
       "enum_name": String("PubEnum"),
       "field_name": String("y"),
+      "old_field_names": List([
+        String("x"),
+      ]),
       "path": List([
         String("enum_struct_variant_field_added"),
         String("PubEnum"),
@@ -50,6 +57,10 @@ snapshot_kind: text
     {
       "enum_name": String("EnumWithAddition"),
       "field_name": String("c"),
+      "old_field_names": List([
+        String("a"),
+        String("b"),
+      ]),
       "path": List([
         String("repr_c_enum_struct_variant_fields_reordered"),
         String("EnumWithAddition"),

--- a/test_outputs/query_execution/enum_struct_variant_field_added.snap
+++ b/test_outputs/query_execution/enum_struct_variant_field_added.snap
@@ -8,7 +8,7 @@ snapshot_kind: text
     {
       "enum_name": String("UnitOnlyBecomesUndefined"),
       "field_name": String("a"),
-      "old_field_names": List([]),
+      "baseline_field_names": List([]),
       "path": List([
         String("enum_no_repr_variant_discriminant_changed"),
         String("UnitOnlyBecomesUndefined"),
@@ -23,7 +23,7 @@ snapshot_kind: text
     {
       "enum_name": String("AddedVariantField"),
       "field_name": String("y"),
-      "old_field_names": List([
+      "baseline_field_names": List([
         String("x"),
       ]),
       "path": List([
@@ -40,7 +40,7 @@ snapshot_kind: text
     {
       "enum_name": String("PubEnum"),
       "field_name": String("y"),
-      "old_field_names": List([
+      "baseline_field_names": List([
         String("x"),
       ]),
       "path": List([
@@ -57,7 +57,7 @@ snapshot_kind: text
     {
       "enum_name": String("EnumWithAddition"),
       "field_name": String("c"),
-      "old_field_names": List([
+      "baseline_field_names": List([
         String("a"),
         String("b"),
       ]),

--- a/test_outputs/witnesses/enum_struct_variant_field_added.snap
+++ b/test_outputs/witnesses/enum_struct_variant_field_added.snap
@@ -1,0 +1,41 @@
+---
+source: src/query.rs
+description: "Lint `enum_struct_variant_field_added` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+snapshot_kind: text
+---
+[["./test_crates/enum_no_repr_variant_discriminant_changed/"]]
+filename = 'src/lib.rs'
+begin_line = 87
+hint = '''
+match value {
+    enum_no_repr_variant_discriminant_changed::UnitOnlyBecomesUndefined::Struct {  } => (),
+    _ => (),
+}'''
+
+[["./test_crates/enum_struct_field_hidden_from_public_api/"]]
+filename = 'src/lib.rs'
+begin_line = 40
+hint = '''
+match value {
+    enum_struct_field_hidden_from_public_api::AddedVariantField::StructVariant { x } => (),
+    _ => (),
+}'''
+
+[["./test_crates/enum_struct_variant_field_added/"]]
+filename = 'src/lib.rs'
+begin_line = 6
+hint = '''
+match value {
+    enum_struct_variant_field_added::PubEnum::Foo { x } => (),
+    _ => (),
+}'''
+
+[["./test_crates/repr_c_enum_struct_variant_fields_reordered/"]]
+filename = 'src/lib.rs'
+begin_line = 65
+hint = '''
+match value {
+    repr_c_enum_struct_variant_fields_reordered::EnumWithAddition::StructVariant { a, b } => (),
+    _ => (),
+}'''


### PR DESCRIPTION
Adds a witness hint for the `enum_struct_variant_field_added` lint.

## Example
`enum_struct_variant_field_added` outputs the following witness hint for the `./test_crates/enum_struct_variant_field_added/` test.
```rust
match value {
    enum_struct_variant_field_added::PubEnum::Foo { x } => (),
    _ => (),
}
```
This compiles on the old version, but not on the new due to the lack of exhaustiveness in the destructuring of the enum variant.

## Commit Notes
+ Added witness hint for `enum_struct_variant_field_added`
+ Added new parts to query for `enum_struct_variant_field_added` to fetch relevant data for the witness

## Comments
I had to add more to the `trustfall` query for `enum_struct_variant_field_added`, which took a little bit to figure out, but I'm starting to get the hang of it. Is there anywhere that would be good to read up on the syntax and whatnot for `trustfall`? I've found a few myself, but more resources are always welcome. 

Aditionally, feel free to give me any feedback on this one, especially surrounding the new parts of the query. This is what I found that worked, but if there's a better, or more idiomatic way to do this, I would appreciate knowing!
