### PR TITLE
Chore: Add witness hint for `enum_struct_variant_field_marked_deprecated` lint

### DIFF
--- a/src/lints/enum_struct_variant_field_marked_deprecated.ron
+++ b/src/lints/enum_struct_variant_field_marked_deprecated.ron
@@ -80,8 +80,7 @@ SemverQuery(
     error_message: "A field in an enum's struct variant is now #[deprecated]. Downstream crates will get a compiler warning when accessing this field.",
     per_result_error_template: Some("field {{enum_name}}::{{variant_name}}.{{field_name}} in {{span_filename}}:{{span_begin_line}}"),
     witness: (
-        hint_template: r#"#[deny(deprecated)]
-match value {
+        hint_template: r#"match value {
     {{ join "::" path }}::{{ variant_name }} { {{ field_name }}, .. } => (),
     _ => (),
 }"#,

--- a/src/lints/enum_struct_variant_field_marked_deprecated.ron
+++ b/src/lints/enum_struct_variant_field_marked_deprecated.ron
@@ -79,4 +79,11 @@ SemverQuery(
     },
     error_message: "A field in an enum's struct variant is now #[deprecated]. Downstream crates will get a compiler warning when accessing this field.",
     per_result_error_template: Some("field {{enum_name}}::{{variant_name}}.{{field_name}} in {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+        hint_template: r#"#[deny(deprecated)]
+match value {
+    {{ join "::" path }}::{{ variant_name }} { {{ field_name }}, .. } => (),
+    _ => (),
+}"#,
+    )
 )

--- a/test_outputs/witnesses/enum_struct_variant_field_marked_deprecated.snap
+++ b/test_outputs/witnesses/enum_struct_variant_field_marked_deprecated.snap
@@ -8,7 +8,6 @@ snapshot_kind: text
 filename = 'src/lib.rs'
 begin_line = 9
 hint = '''
-#[deny(deprecated)]
 match value {
     enum_struct_variant_field_marked_deprecated::NormalEnum::StructVariant { field_to_be_deprecated, .. } => (),
     _ => (),
@@ -18,7 +17,6 @@ match value {
 filename = 'src/lib.rs'
 begin_line = 12
 hint = '''
-#[deny(deprecated)]
 match value {
     enum_struct_variant_field_marked_deprecated::NormalEnum::StructVariant { field_to_be_deprecated_with_message, .. } => (),
     _ => (),
@@ -28,7 +26,6 @@ match value {
 filename = 'src/lib.rs'
 begin_line = 112
 hint = '''
-#[deny(deprecated)]
 match value {
     enum_struct_variant_field_marked_deprecated::EnumWithAlreadyDeprecatedField::StructVariant { field_to_be_deprecated, .. } => (),
     _ => (),

--- a/test_outputs/witnesses/enum_struct_variant_field_marked_deprecated.snap
+++ b/test_outputs/witnesses/enum_struct_variant_field_marked_deprecated.snap
@@ -1,0 +1,35 @@
+---
+source: src/query.rs
+description: "Lint `enum_struct_variant_field_marked_deprecated` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+snapshot_kind: text
+---
+[["./test_crates/enum_struct_variant_field_marked_deprecated/"]]
+filename = 'src/lib.rs'
+begin_line = 9
+hint = '''
+#[deny(deprecated)]
+match value {
+    enum_struct_variant_field_marked_deprecated::NormalEnum::StructVariant { field_to_be_deprecated, .. } => (),
+    _ => (),
+}'''
+
+[["./test_crates/enum_struct_variant_field_marked_deprecated/"]]
+filename = 'src/lib.rs'
+begin_line = 12
+hint = '''
+#[deny(deprecated)]
+match value {
+    enum_struct_variant_field_marked_deprecated::NormalEnum::StructVariant { field_to_be_deprecated_with_message, .. } => (),
+    _ => (),
+}'''
+
+[["./test_crates/enum_struct_variant_field_marked_deprecated/"]]
+filename = 'src/lib.rs'
+begin_line = 112
+hint = '''
+#[deny(deprecated)]
+match value {
+    enum_struct_variant_field_marked_deprecated::EnumWithAlreadyDeprecatedField::StructVariant { field_to_be_deprecated, .. } => (),
+    _ => (),
+}'''


### PR DESCRIPTION
Adds a witness hint for the `enum_struct_variant_field_marked_deprecated` lint.

## Example
`enum_struct_variant_field_marked_deprecated` outputs the following witness hint for the `./test_crates/enum_struct_variant_field_marked_deprecated/` test.
```rust
#[deny(deprecated)]
match value {
    enum_struct_variant_field_marked_deprecated::NormalEnum::StructVariant { field_to_be_deprecated, .. } => (),
    _ => (),
}
```
This compiles on the old version, but not on the new due to the presence of `#[deny(deprecated)]`, as when`field_to_be_deprecated` becomes marked as `deprecated`, compilation fails.

## Comments
I hope using something like `#[deny(deprecated)]` is ok for witnesses, as that was the only practical way I could think of to display the issue in this case.