### PR TITLE
Chore: Add witness hint for `enum_tuple_variant_changed_kind` lint

### DIFF
--- a/src/lints/enum_tuple_variant_changed_kind.ron
+++ b/src/lints/enum_tuple_variant_changed_kind.ron
@@ -69,4 +69,10 @@ SemverQuery(
     },
     error_message: "A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.",
     per_result_error_template: Some("variant {{enum_name}}::{{variant_name}} in {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+        hint_template: r#"match value {
+    {{ join "::" path }}::{{ variant_name }}(..) => (),
+    _ => (),
+}"#,
+    )
 )

--- a/test_outputs/witnesses/enum_tuple_variant_changed_kind.snap
+++ b/test_outputs/witnesses/enum_tuple_variant_changed_kind.snap
@@ -1,0 +1,77 @@
+---
+source: src/query.rs
+assertion_line: 847
+description: "Lint `enum_tuple_variant_changed_kind` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+---
+[["./test_crates/enum_tuple_variant_changed_kind/"]]
+filename = 'src/lib.rs'
+begin_line = 5
+hint = '''
+match value {
+    enum_tuple_variant_changed_kind::TestStruct::WillBecomeStructLike(..) => (),
+    _ => (),
+}'''
+
+[["./test_crates/enum_tuple_variant_changed_kind/"]]
+filename = 'src/lib.rs'
+begin_line = 9
+hint = '''
+match value {
+    enum_tuple_variant_changed_kind::TestUnit::WillBecomeUnitLike(..) => (),
+    _ => (),
+}'''
+
+[["./test_crates/enum_tuple_variant_changed_kind/"]]
+filename = 'src/lib.rs'
+begin_line = 13
+hint = '''
+match value {
+    enum_tuple_variant_changed_kind::MultipleTest::WillBecomeStructLike(..) => (),
+    _ => (),
+}'''
+
+[["./test_crates/enum_tuple_variant_changed_kind/"]]
+filename = 'src/lib.rs'
+begin_line = 14
+hint = '''
+match value {
+    enum_tuple_variant_changed_kind::MultipleTest::WillBecomeUnitLike(..) => (),
+    _ => (),
+}'''
+
+[["./test_crates/enum_tuple_variant_changed_kind/"]]
+filename = 'src/lib.rs'
+begin_line = 20
+hint = '''
+match value {
+    enum_tuple_variant_changed_kind::TestBecomeDocHidden::WillBecomeStructLike(..) => (),
+    _ => (),
+}'''
+
+[["./test_crates/enum_tuple_variant_changed_kind/"]]
+filename = 'src/lib.rs'
+begin_line = 25
+hint = '''
+match value {
+    enum_tuple_variant_changed_kind::TestBecomeNonExhaustive::WillBecomeStructLike(..) => (),
+    _ => (),
+}'''
+
+[["./test_crates/enum_tuple_variant_field_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 7
+hint = '''
+match value {
+    enum_tuple_variant_field_missing::PublicEnum::TupleVariantBecomesPlain(..) => (),
+    _ => (),
+}'''
+
+[["./test_crates/enum_tuple_variant_field_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 9
+hint = '''
+match value {
+    enum_tuple_variant_field_missing::PublicEnum::TupleVariantBecomesStruct(..) => (),
+    _ => (),
+}'''


### PR DESCRIPTION
Adds a witness hint for the `enum_tuple_variant_changed_kind` lint.

## Example
`enum_tuple_variant_changed_kind` outputs the following witness hint for one of the `./test_crates/enum_tuple_variant_changed_kind/` tests.
```rust
match value {
    enum_tuple_variant_changed_kind::MultipleTest::WillBecomeStructLike(..) => (),
    _ => (),
}
```
This compiles on the old version, but not on the new due to the presence of tuple destructuring, as when it changes type (to struct-like or unit-like), it can no longer be destructured as a tuple.