### PR TITLE
feat: add witness hint for `function_marked_deprecated` lint

### DIFF
--- a/src/lints/function_marked_deprecated.ron
+++ b/src/lints/function_marked_deprecated.ron
@@ -38,6 +38,10 @@ SemverQuery(
                             path @filter(op: "=", value: ["%path"])
                             public_api @filter(op: "=", value: ["$true"])
                         }
+
+                        parameter @fold {
+                            parameters: name @output
+                        }
                     }
                 }
             }
@@ -49,4 +53,7 @@ SemverQuery(
     },
     error_message: "A function is now #[deprecated]. Downstream crates will get a compiler warning when using this function.",
     per_result_error_template: Some("function {{join \"::\" path}} in {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+        hint_template: r#"let witness = |{{join ", " parameters}}| {{join "::" path}}({{join ", " parameters}});"#,
+    ),
 )

--- a/test_outputs/query_execution/function_marked_deprecated.snap
+++ b/test_outputs/query_execution/function_marked_deprecated.snap
@@ -1,12 +1,12 @@
 ---
 source: src/query.rs
 expression: "&query_execution_results"
-snapshot_kind: text
 ---
 {
   "./test_crates/function_marked_deprecated/": [
     {
       "name": String("function_to_deprecated"),
+      "parameters": List([]),
       "path": List([
         String("function_marked_deprecated"),
         String("function_to_deprecated"),
@@ -18,6 +18,9 @@ snapshot_kind: text
     },
     {
       "name": String("function_to_deprecated_message"),
+      "parameters": List([
+        String("input"),
+      ]),
       "path": List([
         String("function_marked_deprecated"),
         String("function_to_deprecated_message"),

--- a/test_outputs/witnesses/function_marked_deprecated.snap
+++ b/test_outputs/witnesses/function_marked_deprecated.snap
@@ -1,0 +1,14 @@
+---
+source: src/query.rs
+description: "Lint `function_marked_deprecated` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+---
+[["./test_crates/function_marked_deprecated/"]]
+filename = 'src/lib.rs'
+begin_line = 7
+hint = 'let witness = || function_marked_deprecated::function_to_deprecated();'
+
+[["./test_crates/function_marked_deprecated/"]]
+filename = 'src/lib.rs'
+begin_line = 12
+hint = 'let witness = |input| function_marked_deprecated::function_to_deprecated_message(input);'


### PR DESCRIPTION
This adds a witness hint for `function_marked_deprecated` hint. 

## Witness Example
```rust
let witness = |a, b| function_marked_deprecated::function_to_deprecated(a, b);
```
calling the function should invoke the warning 
```
warning: use of deprecated function `function_to_deprecated`
 --> <file-path:line:column>
  |
  |     let witness = |a, b| function_to_deprecated(a, b);
  |             ^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(deprecated)]` on by default
```

## Comments
Had an idea to mark this as `#[deny(deprecated)]` so it would represent breakage by throwing an error. Since its already been discussed in #1209, skipping that. It becomes pretty much similar to #1194. 