### PR TITLE
Add `enum_non_exhaustive_tuple_variant_changed_kind` lint.

### DIFF
--- a/src/lints/enum_non_exhaustive_tuple_variant_changed_kind.ron
+++ b/src/lints/enum_non_exhaustive_tuple_variant_changed_kind.ron
@@ -1,0 +1,77 @@
+SemverQuery(
+    id: "enum_non_exhaustive_tuple_variant_changed_kind",
+    human_readable_name: "An enum non exhaustive tuple variant changed kind",
+    description: "A pub enum's #[non_exhaustive] tuple variant with at least one pub field changed kind",
+    required_update: Major,
+    lint_level: Deny,
+    // TODO: If the Rust reference gains a more detailed explanation of enum *variants*,
+    //       switch the explanation to point there instead. The current link isn't great.    
+    reference_link: Some("https://doc.rust-lang.org/reference/items/enumerations.html"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Enum {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        enum_name: name @output @tag
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        variant {
+                            ... on TupleVariant {
+                                kind: __typename @output @tag
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+                                attrs @filter(op: "contains", value: ["$non_exhaustive"])
+                                variant_name: name @output @tag
+
+                                field @fold @transform(op: "count") @filter(op: ">", value: ["$zero"]) {
+                                    public_api_eligible @filter(op: "=", value: ["$true"])
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Enum {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @filter(op: "=", value: ["%enum_name"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        # Don't check for exhaustiveness and public API eligibility here.
+                        # Variants that changed kind and gained `#[doc(hidden)]` should
+                        # report for both lints, since there is no implied continuity
+                        # between the old variant and the new one with the same name.
+                        variant {
+                            name @filter(op: "=", value: ["%variant_name"])
+                            new_kind: __typename @filter(op: "!=", value: ["%kind"]) @output
+
+                            span_: span @optional {
+                                filename @output
+                                begin_line @output
+                                end_line @output
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+        "zero": 0,
+        "non_exhaustive": "#[non_exhaustive]",
+    },
+    error_message: "A pub enum's #[non_exhaustive] tuple variant with at least one pub field has changed to a different kind of enum variant, breaking possible pattern matches and field accesses.",
+    per_result_error_template: Some("variant {{enum_name}}::{{variant_name}} in {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1235,6 +1235,7 @@ add_lints!(
     enum_no_longer_non_exhaustive,
     enum_no_repr_variant_discriminant_changed,
     enum_non_exhaustive_struct_variant_field_added,
+    enum_non_exhaustive_tuple_variant_changed_kind,
     enum_now_doc_hidden,
     enum_repr_int_added,
     enum_repr_int_changed,

--- a/test_crates/enum_non_exhaustive_tuple_variant_changed_kind/new/Cargo.toml
+++ b/test_crates/enum_non_exhaustive_tuple_variant_changed_kind/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_non_exhaustive_tuple_variant_changed_kind"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_non_exhaustive_tuple_variant_changed_kind/new/src/lib.rs
+++ b/test_crates/enum_non_exhaustive_tuple_variant_changed_kind/new/src/lib.rs
@@ -1,0 +1,70 @@
+// ---- Should be reported ----
+pub enum TestStruct {
+    #[non_exhaustive]
+    WillBecomeStructLike { f: i32 },
+}
+
+pub enum TestUnit {
+    #[non_exhaustive]
+    WillBecomeUnitLike,
+}
+
+pub enum MultipleTest {
+    #[non_exhaustive]
+    WillBecomeStructLike { f: i32 },
+    #[non_exhaustive]
+    WillBecomeUnitLike,
+    #[non_exhaustive]
+    WillStayTupleLike(i32),
+}
+
+pub enum TestBecomeDocHidden {
+    #[doc(hidden)]
+    #[non_exhaustive]
+    WillBecomeStructLike { f: i32 },
+}
+
+pub enum TestBecomeExhaustive {
+    WillBecomeStructLike { f: i32 },
+}
+
+// ---- Should not be reported ----
+pub enum TestTuple {
+    #[non_exhaustive]
+    WillStayTupleLike(()),
+}
+
+pub enum TestStructExhaustive {
+    WillBecomeStructLike { f: i32 },
+}
+
+pub enum TestUnitExhaustive {
+    WillBecomeUnitLike,
+}
+
+pub enum MultipleTestExhaustive {
+    WillBecomeStructLike { f: i32 },
+    WillBecomeUnitLike,
+    WillStayTupleLike(i32),
+}
+
+pub enum TestDocHidden {
+    #[doc(hidden)]
+    #[non_exhaustive]
+    WillBecomeStructLike { f: i32 },
+    #[doc(hidden)]
+    #[non_exhaustive]
+    WillBecomeUnitLike,
+    #[doc(hidden)]
+    #[non_exhaustive]
+    WillStayTupleLike(i32),
+}
+
+pub enum MultipleStayTheSame {
+    #[non_exhaustive]
+    StructLike {},
+    #[non_exhaustive]
+    TupleLike(i32),
+    #[non_exhaustive]
+    UnitLike,
+}

--- a/test_crates/enum_non_exhaustive_tuple_variant_changed_kind/old/Cargo.toml
+++ b/test_crates/enum_non_exhaustive_tuple_variant_changed_kind/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "enum_non_exhaustive_tuple_variant_changed_kind"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/enum_non_exhaustive_tuple_variant_changed_kind/old/src/lib.rs
+++ b/test_crates/enum_non_exhaustive_tuple_variant_changed_kind/old/src/lib.rs
@@ -1,0 +1,70 @@
+// ---- Should be reported ----
+pub enum TestStruct {
+    #[non_exhaustive]
+    WillBecomeStructLike(i32),
+}
+
+pub enum TestUnit {
+    #[non_exhaustive]
+    WillBecomeUnitLike(i32),
+}
+
+pub enum MultipleTest {
+    #[non_exhaustive]
+    WillBecomeStructLike(i32),
+    #[non_exhaustive]
+    WillBecomeUnitLike(i32),
+    #[non_exhaustive]
+    WillStayTupleLike(i32),
+}
+
+pub enum TestBecomeDocHidden {
+    #[non_exhaustive]
+    WillBecomeStructLike(i32),
+}
+
+pub enum TestBecomeExhaustive {
+    #[non_exhaustive]
+    WillBecomeStructLike(i32),
+}
+
+// ---- Should not be reported ----
+pub enum TestTuple {
+    #[non_exhaustive]
+    WillStayTupleLike(i32),
+}
+
+pub enum TestStructExhaustive {
+    WillBecomeStructLike(i32),
+}
+
+pub enum TestUnitExhaustive {
+    WillBecomeUnitLike(i32),
+}
+
+pub enum MultipleTestExhaustive {
+    WillBecomeStructLike(i32),
+    WillBecomeUnitLike(i32),
+    WillStayTupleLike(i32),
+}
+
+pub enum TestDocHidden {
+    #[doc(hidden)]
+    #[non_exhaustive]
+    WillBecomeStructLike(i32),
+    #[doc(hidden)]
+    #[non_exhaustive]
+    WillBecomeUnitLike(i32),
+    #[doc(hidden)]
+    #[non_exhaustive]
+    WillStayTupleLike(i32),
+}
+
+pub enum MultipleStayTheSame {
+    #[non_exhaustive]
+    StructLike {},
+    #[non_exhaustive]
+    TupleLike(i32),
+    #[non_exhaustive]
+    UnitLike,
+}

--- a/test_outputs/query_execution/enum_non_exhaustive_tuple_variant_changed_kind.snap
+++ b/test_outputs/query_execution/enum_non_exhaustive_tuple_variant_changed_kind.snap
@@ -1,0 +1,127 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+---
+{
+  "./test_crates/enum_non_exhaustive_tuple_variant_changed_kind/": [
+    {
+      "enum_name": String("TestStruct"),
+      "kind": String("TupleVariant"),
+      "new_kind": String("StructVariant"),
+      "path": List([
+        String("enum_non_exhaustive_tuple_variant_changed_kind"),
+        String("TestStruct"),
+      ]),
+      "span_begin_line": Uint64(4),
+      "span_end_line": Uint64(4),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("WillBecomeStructLike"),
+    },
+    {
+      "enum_name": String("TestUnit"),
+      "kind": String("TupleVariant"),
+      "new_kind": String("PlainVariant"),
+      "path": List([
+        String("enum_non_exhaustive_tuple_variant_changed_kind"),
+        String("TestUnit"),
+      ]),
+      "span_begin_line": Uint64(9),
+      "span_end_line": Uint64(9),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("WillBecomeUnitLike"),
+    },
+    {
+      "enum_name": String("MultipleTest"),
+      "kind": String("TupleVariant"),
+      "new_kind": String("StructVariant"),
+      "path": List([
+        String("enum_non_exhaustive_tuple_variant_changed_kind"),
+        String("MultipleTest"),
+      ]),
+      "span_begin_line": Uint64(14),
+      "span_end_line": Uint64(14),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("WillBecomeStructLike"),
+    },
+    {
+      "enum_name": String("MultipleTest"),
+      "kind": String("TupleVariant"),
+      "new_kind": String("PlainVariant"),
+      "path": List([
+        String("enum_non_exhaustive_tuple_variant_changed_kind"),
+        String("MultipleTest"),
+      ]),
+      "span_begin_line": Uint64(16),
+      "span_end_line": Uint64(16),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("WillBecomeUnitLike"),
+    },
+    {
+      "enum_name": String("TestBecomeDocHidden"),
+      "kind": String("TupleVariant"),
+      "new_kind": String("StructVariant"),
+      "path": List([
+        String("enum_non_exhaustive_tuple_variant_changed_kind"),
+        String("TestBecomeDocHidden"),
+      ]),
+      "span_begin_line": Uint64(24),
+      "span_end_line": Uint64(24),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("WillBecomeStructLike"),
+    },
+    {
+      "enum_name": String("TestBecomeExhaustive"),
+      "kind": String("TupleVariant"),
+      "new_kind": String("StructVariant"),
+      "path": List([
+        String("enum_non_exhaustive_tuple_variant_changed_kind"),
+        String("TestBecomeExhaustive"),
+      ]),
+      "span_begin_line": Uint64(28),
+      "span_end_line": Uint64(28),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("WillBecomeStructLike"),
+    },
+  ],
+  "./test_crates/enum_tuple_variant_changed_kind/": [
+    {
+      "enum_name": String("TestStructNonExhaustive"),
+      "kind": String("TupleVariant"),
+      "new_kind": String("StructVariant"),
+      "path": List([
+        String("enum_tuple_variant_changed_kind"),
+        String("TestStructNonExhaustive"),
+      ]),
+      "span_begin_line": Uint64(35),
+      "span_end_line": Uint64(35),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("WillBecomeStructLike"),
+    },
+    {
+      "enum_name": String("MultipleTestNonExhaustive"),
+      "kind": String("TupleVariant"),
+      "new_kind": String("StructVariant"),
+      "path": List([
+        String("enum_tuple_variant_changed_kind"),
+        String("MultipleTestNonExhaustive"),
+      ]),
+      "span_begin_line": Uint64(45),
+      "span_end_line": Uint64(45),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("WillBecomeStructLike"),
+    },
+    {
+      "enum_name": String("MultipleTestNonExhaustive"),
+      "kind": String("TupleVariant"),
+      "new_kind": String("PlainVariant"),
+      "path": List([
+        String("enum_tuple_variant_changed_kind"),
+        String("MultipleTestNonExhaustive"),
+      ]),
+      "span_begin_line": Uint64(47),
+      "span_end_line": Uint64(47),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("WillBecomeUnitLike"),
+    },
+  ],
+}

--- a/test_outputs/query_execution/enum_tuple_variant_changed_kind.snap
+++ b/test_outputs/query_execution/enum_tuple_variant_changed_kind.snap
@@ -1,9 +1,62 @@
 ---
 source: src/query.rs
 expression: "&query_execution_results"
-snapshot_kind: text
 ---
 {
+  "./test_crates/enum_non_exhaustive_tuple_variant_changed_kind/": [
+    {
+      "enum_name": String("TestStructExhaustive"),
+      "kind": String("TupleVariant"),
+      "new_kind": String("StructVariant"),
+      "path": List([
+        String("enum_non_exhaustive_tuple_variant_changed_kind"),
+        String("TestStructExhaustive"),
+      ]),
+      "span_begin_line": Uint64(38),
+      "span_end_line": Uint64(38),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("WillBecomeStructLike"),
+    },
+    {
+      "enum_name": String("TestUnitExhaustive"),
+      "kind": String("TupleVariant"),
+      "new_kind": String("PlainVariant"),
+      "path": List([
+        String("enum_non_exhaustive_tuple_variant_changed_kind"),
+        String("TestUnitExhaustive"),
+      ]),
+      "span_begin_line": Uint64(42),
+      "span_end_line": Uint64(42),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("WillBecomeUnitLike"),
+    },
+    {
+      "enum_name": String("MultipleTestExhaustive"),
+      "kind": String("TupleVariant"),
+      "new_kind": String("StructVariant"),
+      "path": List([
+        String("enum_non_exhaustive_tuple_variant_changed_kind"),
+        String("MultipleTestExhaustive"),
+      ]),
+      "span_begin_line": Uint64(46),
+      "span_end_line": Uint64(46),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("WillBecomeStructLike"),
+    },
+    {
+      "enum_name": String("MultipleTestExhaustive"),
+      "kind": String("TupleVariant"),
+      "new_kind": String("PlainVariant"),
+      "path": List([
+        String("enum_non_exhaustive_tuple_variant_changed_kind"),
+        String("MultipleTestExhaustive"),
+      ]),
+      "span_begin_line": Uint64(47),
+      "span_end_line": Uint64(47),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("WillBecomeUnitLike"),
+    },
+  ],
   "./test_crates/enum_tuple_variant_changed_kind/": [
     {
       "enum_name": String("TestStruct"),

--- a/test_outputs/query_execution/enum_variant_no_longer_non_exhaustive.snap
+++ b/test_outputs/query_execution/enum_variant_no_longer_non_exhaustive.snap
@@ -17,17 +17,17 @@ expression: "&query_execution_results"
       "visibility_limit": String("public"),
     },
   ],
-  "./test_crates/enum_non_exhaustive_struct_variant_field_added/": [
+  "./test_crates/enum_non_exhaustive_tuple_variant_changed_kind/": [
     {
-      "enum_name": String("EnumWithNonExhaustiveVariant"),
+      "enum_name": String("TestBecomeExhaustive"),
       "path": List([
-        String("enum_non_exhaustive_struct_variant_field_added"),
-        String("EnumWithNonExhaustiveVariant"),
+        String("enum_non_exhaustive_tuple_variant_changed_kind"),
+        String("TestBecomeExhaustive"),
       ]),
-      "span_begin_line": Uint64(24),
-      "span_end_line": Uint64(24),
+      "span_begin_line": Uint64(28),
+      "span_end_line": Uint64(28),
       "span_filename": String("src/lib.rs"),
-      "variant_name": String("NonExhaustiveVariant"),
+      "variant_name": String("WillBecomeStructLike"),
       "visibility_limit": String("public"),
     },
   ],

--- a/test_outputs/query_execution/enum_variant_no_longer_non_exhaustive.snap
+++ b/test_outputs/query_execution/enum_variant_no_longer_non_exhaustive.snap
@@ -17,6 +17,20 @@ expression: "&query_execution_results"
       "visibility_limit": String("public"),
     },
   ],
+  "./test_crates/enum_non_exhaustive_struct_variant_field_added/": [
+    {
+      "enum_name": String("EnumWithNonExhaustiveVariant"),
+      "path": List([
+        String("enum_non_exhaustive_struct_variant_field_added"),
+        String("EnumWithNonExhaustiveVariant"),
+      ]),
+      "span_begin_line": Uint64(24),
+      "span_end_line": Uint64(24),
+      "span_filename": String("src/lib.rs"),
+      "variant_name": String("NonExhaustiveVariant"),
+      "visibility_limit": String("public"),
+    },
+  ],
   "./test_crates/enum_non_exhaustive_tuple_variant_changed_kind/": [
     {
       "enum_name": String("TestBecomeExhaustive"),

--- a/test_outputs/witnesses/enum_tuple_variant_changed_kind.snap
+++ b/test_outputs/witnesses/enum_tuple_variant_changed_kind.snap
@@ -1,9 +1,44 @@
 ---
 source: src/query.rs
-assertion_line: 847
 description: "Lint `enum_tuple_variant_changed_kind` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
 expression: "&actual_witnesses"
 ---
+[["./test_crates/enum_non_exhaustive_tuple_variant_changed_kind/"]]
+filename = 'src/lib.rs'
+begin_line = 38
+hint = '''
+match value {
+    enum_non_exhaustive_tuple_variant_changed_kind::TestStructExhaustive::WillBecomeStructLike(..) => (),
+    _ => (),
+}'''
+
+[["./test_crates/enum_non_exhaustive_tuple_variant_changed_kind/"]]
+filename = 'src/lib.rs'
+begin_line = 42
+hint = '''
+match value {
+    enum_non_exhaustive_tuple_variant_changed_kind::TestUnitExhaustive::WillBecomeUnitLike(..) => (),
+    _ => (),
+}'''
+
+[["./test_crates/enum_non_exhaustive_tuple_variant_changed_kind/"]]
+filename = 'src/lib.rs'
+begin_line = 46
+hint = '''
+match value {
+    enum_non_exhaustive_tuple_variant_changed_kind::MultipleTestExhaustive::WillBecomeStructLike(..) => (),
+    _ => (),
+}'''
+
+[["./test_crates/enum_non_exhaustive_tuple_variant_changed_kind/"]]
+filename = 'src/lib.rs'
+begin_line = 47
+hint = '''
+match value {
+    enum_non_exhaustive_tuple_variant_changed_kind::MultipleTestExhaustive::WillBecomeUnitLike(..) => (),
+    _ => (),
+}'''
+
 [["./test_crates/enum_tuple_variant_changed_kind/"]]
 filename = 'src/lib.rs'
 begin_line = 5


### PR DESCRIPTION
Addresses the following checkbox in #884 -
public API #[non_exhaustive] tuple variant that has at least one public API field changes to another kind