### PR TITLE
Chore: Add witness hint for `enum_variant_added` lint

### DIFF
--- a/src/lints/enum_variant_added.ron
+++ b/src/lints/enum_variant_added.ron
@@ -46,6 +46,12 @@ SemverQuery(
                         variant @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                             name @filter(op: "=", value: ["%variant_name"])
                         }
+
+                        variant @fold {
+                            baseline_variant_kinds: __typename @output
+
+                            baseline_variant_names: name @output
+                        }
                     }
                 }
             }
@@ -59,4 +65,9 @@ SemverQuery(
     },
     error_message: "A publicly-visible enum without #[non_exhaustive] has a new variant.",
     per_result_error_template: Some("variant {{enum_name}}:{{variant_name}} in {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+        hint_template: r#"match value { {{#each baseline_variant_kinds }}
+    {{ join "::" ../path }}::{{lookup ../baseline_variant_names @index}}{{#if (eq this "StructVariant")}} { .. }{{/if}}{{#if (eq this "TupleVariant")}}(..){{/if}} => (),{{/each}}
+}"#,
+    ),
 )

--- a/test_crates/enum_variant_added/new/src/lib.rs
+++ b/test_crates/enum_variant_added/new/src/lib.rs
@@ -2,6 +2,12 @@
 
 pub enum EnumWithNewVariant {
     OldVariant,
+    
+    OldStructVariant {
+        x: i64,
+    },
+
+    OldTupleVariant(i64),
 
     NewVariant,
 }

--- a/test_crates/enum_variant_added/old/src/lib.rs
+++ b/test_crates/enum_variant_added/old/src/lib.rs
@@ -2,6 +2,12 @@
 
 pub enum EnumWithNewVariant {
     OldVariant,
+
+    OldStructVariant {
+        x: i64,
+    },
+
+    OldTupleVariant(i64)
 }
 
 /// This enum should not be reported by the `enum_variant_added` rule,

--- a/test_outputs/query_execution/enum_variant_added.snap
+++ b/test_outputs/query_execution/enum_variant_added.snap
@@ -6,6 +6,12 @@ snapshot_kind: text
 {
   "./test_crates/enum_discriminant_no_longer_defined/": [
     {
+      "baseline_variant_kinds": List([
+        String("PlainVariant"),
+      ]),
+      "baseline_variant_names": List([
+        String("None"),
+      ]),
       "enum_name": String("GainsStructVariant"),
       "path": List([
         String("enum_discriminant_no_longer_defined"),
@@ -20,13 +26,23 @@ snapshot_kind: text
   ],
   "./test_crates/enum_variant_added/": [
     {
+      "baseline_variant_kinds": List([
+        String("PlainVariant"),
+        String("StructVariant"),
+        String("TupleVariant"),
+      ]),
+      "baseline_variant_names": List([
+        String("OldVariant"),
+        String("OldStructVariant"),
+        String("OldTupleVariant"),
+      ]),
       "enum_name": String("EnumWithNewVariant"),
       "path": List([
         String("enum_variant_added"),
         String("EnumWithNewVariant"),
       ]),
-      "span_begin_line": Uint64(6),
-      "span_end_line": Uint64(6),
+      "span_begin_line": Uint64(12),
+      "span_end_line": Uint64(12),
       "span_filename": String("src/lib.rs"),
       "variant_name": String("NewVariant"),
       "visibility_limit": String("public"),
@@ -34,6 +50,14 @@ snapshot_kind: text
   ],
   "./test_crates/enum_variant_hidden_from_public_api/": [
     {
+      "baseline_variant_kinds": List([
+        String("PlainVariant"),
+        String("PlainVariant"),
+      ]),
+      "baseline_variant_names": List([
+        String("First"),
+        String("Second"),
+      ]),
       "enum_name": String("AddedVariant"),
       "path": List([
         String("enum_variant_hidden_from_public_api"),

--- a/test_outputs/witnesses/enum_variant_added.snap
+++ b/test_outputs/witnesses/enum_variant_added.snap
@@ -1,0 +1,32 @@
+---
+source: src/query.rs
+description: "Lint `enum_variant_added` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+snapshot_kind: text
+---
+[["./test_crates/enum_discriminant_no_longer_defined/"]]
+filename = 'src/lib.rs'
+begin_line = 69
+hint = '''
+match value { 
+    enum_discriminant_no_longer_defined::GainsStructVariant::None => (),
+}'''
+
+[["./test_crates/enum_variant_added/"]]
+filename = 'src/lib.rs'
+begin_line = 12
+hint = '''
+match value { 
+    enum_variant_added::EnumWithNewVariant::OldVariant => (),
+    enum_variant_added::EnumWithNewVariant::OldStructVariant { .. } => (),
+    enum_variant_added::EnumWithNewVariant::OldTupleVariant(..) => (),
+}'''
+
+[["./test_crates/enum_variant_hidden_from_public_api/"]]
+filename = 'src/lib.rs'
+begin_line = 18
+hint = '''
+match value { 
+    enum_variant_hidden_from_public_api::AddedVariant::First => (),
+    enum_variant_hidden_from_public_api::AddedVariant::Second => (),
+}'''


### PR DESCRIPTION
Adds a witness hint for the `enum_variant_added` lint.

## Example
`enum_variant_added` outputs the following witness hint for the `./test_crates/enum_variant_added/` test.
```rust
match value { 
    enum_variant_added::EnumWithNewVariant::OldVariant => (),
    enum_variant_added::EnumWithNewVariant::OldStructVariant { .. } => (),
    enum_variant_added::EnumWithNewVariant::OldTupleVariant(..) => (),
}
```
This compiles on the old version, but not on the new due to the lack of exhaustiveness on the match cases. The lack of a catch-all case causes the addition of a new variant to cause a compilation error.

## Commit Notes
+ Added witness hint for enum_variant_added
+ Added new parts to query for enum_variant_added to fetch relevant data for the witness
+ Update test crates to allow for more exhaustive witness format testing

## Comments
Two questions and possible areas for bigger improvements:
1. Is there a better way to combine `baseline_variant_names` and `baseline_variant_kinds`? They both form lists, but each list is separate from the other. Now, each should still always form the same length of list as the other, as they are tied to the same `variant` query, but if there is a way to combine/tuple them together, that would be good to know so I can make that adjustment.
2. Is it okay to modify tests like I've done here? It doesn't change the final result of the test, it all runs the same, I just added some new variants to the tested enum so that I can test the witness printing unit-like, struct-like, and tuple-like enum variants.