### PR TITLE
Weekly `cargo update` of dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2255,9 +2255,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "maplit"
@@ -3528,9 +3528,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "36.5.3"
+version = "36.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212fc299d765f1fded7d44f220f983f70f7197308721ef6bad94afa7f76c216c"
+checksum = "09d69f817e08e139786c61c85010ee03d5f43f15c2807629291923011d070f0b"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
@@ -3542,9 +3542,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "37.3.3"
+version = "37.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e245f3b2e086538f14f771a2604589b225d52fde5cab44079d5f6d467e27f0b3"
+checksum = "6c575fb2452dd70a5f09c84c786381349d0ae3cc5a30c778fe5766b92dd4bcd1"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
@@ -3556,9 +3556,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "39.1.3"
+version = "39.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9c73e2282ee236d77546d092c52882ecdab219ea8eb6bdf873bc6d4ede3635"
+checksum = "fee01298fdfa67b4f1378c1ca3a660564f37c5ea18ce028f0d22ae29231c8f63"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
@@ -3609,9 +3609,9 @@ dependencies = [
  "thiserror 2.0.12",
  "trustfall",
  "trustfall-rustdoc-adapter 35.5.3",
- "trustfall-rustdoc-adapter 36.5.3",
- "trustfall-rustdoc-adapter 37.3.3",
- "trustfall-rustdoc-adapter 39.1.3",
+ "trustfall-rustdoc-adapter 36.5.4",
+ "trustfall-rustdoc-adapter 37.3.4",
+ "trustfall-rustdoc-adapter 39.1.4",
 ]
 
 [[package]]


### PR DESCRIPTION
Automation to keep dependencies in `Cargo.lock` current.

The following is the output from `cargo update`:

```txt
     Locking 4 packages to latest compatible versions
    Updating log v0.4.26 -> v0.4.27
    Removing trustfall-rustdoc-adapter v36.5.3
    Removing trustfall-rustdoc-adapter v37.3.3
    Removing trustfall-rustdoc-adapter v39.1.3
      Adding trustfall-rustdoc-adapter v36.5.4
      Adding trustfall-rustdoc-adapter v37.3.4
      Adding trustfall-rustdoc-adapter v39.1.4
note: pass `--verbose` to see 3 unchanged dependencies behind latest
```
