### PR TITLE
Feat: Add custom `to_string` handlebars helper

### DIFF
--- a/src/templating.rs
+++ b/src/templating.rs
@@ -62,6 +62,17 @@ handlebars_helper!(multiple_spans: |files: Value, begin_line_numbers: Value| {
     }
 });
 
+// a helper to convert arg to a string, submitted as a number, string, or bool
+handlebars_helper!(to_string: |arg: Value| {
+    match arg {
+        Value::Number(num) => num.to_string(),
+        Value::String(already_string) => already_string.to_string(),
+        Value::Bool(boolean) => boolean.to_string(),
+
+        _ => unreachable!("non-stringifiable value provided: {arg:?}")
+    }
+});
+
 // a helper to loop n number of times. similar to #each, has @index, @first, and @last. does not set `this`
 // written without the handlebars_helper! for block access
 // this is largely based on the logic within #each itself
@@ -137,6 +148,7 @@ pub(crate) fn make_handlebars_registry() -> Handlebars<'static> {
     registry.register_helper("join", Box::new(join));
     registry.register_helper("unpack_if_singleton", Box::new(unpack_if_singleton));
     registry.register_helper("multiple_spans", Box::new(multiple_spans));
+    registry.register_helper("to_string", Box::new(to_string));
     registry.register_helper("repeat", Box::new(repeat));
     registry
 }

--- a/src/templating.rs
+++ b/src/templating.rs
@@ -68,7 +68,6 @@ handlebars_helper!(to_string: |arg: Value| {
         Value::Number(num) => num.to_string(),
         Value::String(already_string) => already_string.to_string(),
         Value::Bool(boolean) => boolean.to_string(),
-
         _ => unreachable!("non-stringifiable value provided: {arg:?}")
     }
 });


### PR DESCRIPTION
Adds a `to_string` custom handlebars helper.

## Comments
There's not much to show for this one, it just converts a Number or Bool to a String Value. This isn't useful most of the time, as templating converts a variable to a string anyways. It's main use case is for comparing a number and a string. This is currently needed in #1214 and #1216, as although we can now iterate using the `repeat` helper, it produces Number Values, while `field_name`, which `@index` is compared against, is a String Value, which will always fail the `eq` test. This helper exists to resolve that issue.