### PR TITLE
Chore: Add witness hint for `struct_missing` lint

### DIFF
--- a/src/lints/struct_missing.ron
+++ b/src/lints/struct_missing.ron
@@ -51,4 +51,7 @@ SemverQuery(
     },
     error_message: "A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.",
     per_result_error_template: Some("struct {{join \"::\" path}}, previously in file {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+        hint_template: r#"use {{ join "::" path }};"#,
+    ),
 )

--- a/test_outputs/witnesses/struct_missing.snap
+++ b/test_outputs/witnesses/struct_missing.snap
@@ -1,0 +1,70 @@
+---
+source: src/query.rs
+description: "Lint `struct_missing` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+snapshot_kind: text
+---
+[["./test_crates/move_item_and_reexport/"]]
+filename = 'src/lib.rs'
+begin_line = 40
+hint = 'use move_item_and_reexport::NonEquivalentReorderedGenerics;'
+
+[["./test_crates/move_item_and_reexport/"]]
+filename = 'src/lib.rs'
+begin_line = 44
+hint = 'use move_item_and_reexport::NonEquivalentRemovedLifetime;'
+
+[["./test_crates/move_item_and_reexport/"]]
+filename = 'src/lib.rs'
+begin_line = 48
+hint = 'use move_item_and_reexport::NonEquivalentRemovedConst;'
+
+[["./test_crates/move_item_and_reexport/"]]
+filename = 'src/lib.rs'
+begin_line = 52
+hint = 'use move_item_and_reexport::NonEquivalentRemovedType;'
+
+[["./test_crates/repr_packed_added_removed/"]]
+filename = 'src/lib.rs'
+begin_line = 11
+hint = 'use repr_packed_added_removed::StructBecomesPackedAndPrivate;'
+
+[["./test_crates/repr_packed_added_removed/"]]
+filename = 'src/lib.rs'
+begin_line = 15
+hint = 'use repr_packed_added_removed::StructBecomesUnpackedAndPrivate;'
+
+[["./test_crates/semver_trick_self_referential/"]]
+filename = 'src/lib.rs'
+begin_line = 3
+hint = 'use semver_trick_self_referential::Example;'
+
+[["./test_crates/struct_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 3
+hint = 'use struct_missing::WillBeRemovedStruct;'
+
+[["./test_crates/struct_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 6
+hint = 'use struct_missing::PubUseRemovedStruct;'
+
+[["./test_crates/struct_now_doc_hidden/"]]
+filename = 'src/lib.rs'
+begin_line = 36
+hint = 'use struct_now_doc_hidden::PublicStructThatGoesPrivate;'
+
+[["./test_crates/struct_pub_field_missing/"]]
+filename = 'src/lib.rs'
+begin_line = 13
+hint = 'use struct_pub_field_missing::StructRemoved;'
+
+[["./test_crates/struct_with_no_pub_fields_changed_type/"]]
+filename = 'src/lib.rs'
+begin_line = 91
+hint = 'use struct_with_no_pub_fields_changed_type::PubStructChangedToType;'
+
+[["./test_crates/switch_to_reexport_as_underscore/"]]
+filename = 'src/lib.rs'
+begin_line = 6
+hint = 'use switch_to_reexport_as_underscore::Struct;'


### PR DESCRIPTION
Adds a witness hint for the `struct_missing` lint.

## Example
`struct_missing` outputs the following witness hint for one of the `./test_crates/struct_missing/` tests.
```rust
use struct_missing::WillBeRemovedStruct;
```
This compiles on the old version, but not on the new as importing from a non-existant path is not possible.

## Commit Notes
+ Added witness hint for struct_missing

## Comments
I figured just using a `use` statement would be enough to get across that the breaking change is the now missing path. Do you think this would work fine, or would it be preferable to use a different form of hint?

