### PR TITLE
Enable environment variable overrides for git repo discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1473,6 +1473,96 @@ jobs:
           key: ${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('semver/**/Cargo.lock') }}-${{ github.job }}-rustdoc
           path: subject-current/target/semver-checks/cache
 
+  run-on-bare-repository:
+    # Test that overwriting the git repository detection with `GIT_DIR` works as expected by
+    # running on a bare clone of a repository.
+    name: "Semver: bare repository"
+    runs-on: ubuntu-latest
+    needs:
+      - build-binary
+    steps:
+      - name: Checkout cargo-semver-checks
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+          path: "semver"
+
+      - name: Checkout ref-slice fork major change
+        uses: actions/checkout@v4
+        with:
+          # NOTE: We cannot checkout a bare repository with the actions/checkout action
+          # (https://github.com/actions/checkout/issues/603), so we checkout a "normal" version
+          # and clone the local checkout into a bare repository.
+          fetch-depth: 0
+          persist-credentials: false
+          repository: "mgr0dzicki/cargo-semver-action-ref-slice"
+          ref: "major_change"
+          path: "subject-checkout"
+
+      - name: Setup bare repository worktree
+        run: |
+          set -euo pipefail
+          git clone --bare subject-checkout subject-bare
+          mkdir subject
+          git --git-dir subject-bare --work-tree subject checkout major_change .
+          test ! -e subject/.git
+
+      - name: Install rust
+        id: toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+          rustflags: ""
+
+      - name: Restore binary
+        id: cache-binary
+        uses: actions/cache/restore@v4
+        with:
+          path: bins/
+          key: bins-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          fail-on-cache-miss: true
+
+      - name: Restore rustdoc
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('semver/**/Cargo.lock') }}-${{ github.job }}-rustdoc
+          path: subject/target/semver-checks/cache
+
+      - name: Restore cargo index and rustdoc target dir
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            subject/target/semver-checks/git-v1_2_1/
+            subject/target/semver-checks/local-ref_slice-1_2_1-01666ec060466c14/
+
+      - name: Run semver-checks with --baseline-rev
+        continue-on-error: true
+        run: |
+          cd semver
+          set -euo pipefail
+          GIT_DIR=../subject-bare ../bins/cargo-semver-checks semver-checks check-release --manifest-path="../subject/Cargo.toml" --baseline-rev=v1.2.1 --verbose | tee output
+          touch unexpectedly_did_not_fail
+
+      - name: Check whether it failed
+        run: |
+          cd semver
+          if [ -f unexpectedly_did_not_fail ]; then exit 1; else exit 0; fi
+
+      - name: Check output
+        run: |
+          cd semver
+          EXPECTED="$(echo -e "--- failure function_missing: pub fn removed or renamed ---")"
+          RESULT="$(grep failure output | sort)"
+          diff <(echo "$RESULT") <(echo "$EXPECTED")
+
+      - name: Save rustdoc
+        uses: actions/cache/save@v4
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          key: ${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('semver/**/Cargo.lock') }}-${{ github.job }}-rustdoc
+          path: subject/target/semver-checks/cache
+
   run-on-ref-slice-fork:
     # Simulate testing an as-yet-unreleased crate version without an explicit baseline,
     # i.e. with the expectation that the largest crates.io version is used as a baseline.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,38 @@ Custom registries are not currently supported
 ([#160](https://github.com/obi1kenobi/cargo-semver-checks/issues/160)), so crates published on
 registries other than crates.io should use one of the other approaches of generating the baseline.
 
+#### Git repository detection
+
+When looking up a git revision with `--baseline-rev`,
+`cargo-semver-checks` will walk up the current directory until it finds a `.git/` directory to resolve the revision and extract the corresponding worktree.
+You can use the following environment variables to influence the git repository detection:
+
+- [`GIT_CEILING_DIRECTORIES`]: a colon (`:`) separated list of absolute paths which `cargo-semver-checks` should not search for the `.git/` directory.
+  This can be used to prevent `cargo-semver-checks` from searching slow network mounted directories.
+  This environment variable cannot be used to prevent searching the current working directory,
+  or a directory explicitly set with [`GIT_DIR`].
+  If this is not set,
+  `cargo-semver-checks` will search the current working directory and any of its parents (up to the root directory).
+- [`GIT_DIR`]: explicitly set the location of the `.git/` directory
+  (if the value is a relative path, it is resolved from the current working directory).
+  If this is not set,
+  `cargo-semver-checks` will search the current working directory and any of its parents for the `.git/` directory.
+- [`GIT_DISCOVERY_ACROSS_FILESYSTEM`]: enable git repository detection across filesystems.
+  When automatically searching for the `.git/` directory,
+  `cargo-semver-checks` will not cross filesystem boundaries.
+  Set this environment variable to `true` to enable cross-filesystem detection.
+  This environment variable has no effect when setting [`GIT_DIR`] explicitly.
+
+[`GIT_CEILING_DIRECTORIES`]: https://git-scm.com/docs/git.html#Documentation/git.txt-codeGITCEILINGDIRECTORIEScode
+[`GIT_DIR`]: https://git-scm.com/docs/git.html#Documentation/git.txt-codeGITDIRcode
+[`GIT_DISCOVERY_ACROSS_FILESYSTEM`]: https://git-scm.com/docs/git.html#Documentation/git.txt-codeGITDISCOVERYACROSSFILESYSTEMcode
+
+Setting the `GIT_DIR` allows using `cargo-semver-checks` with a non-colocated [jujutsu](https://jj-vcs.github.io/jj/latest/) repository.
+
+```console
+GIT_DIR="$(jj root)/.jj/repo/store/git" cargo semver-checks --package "foo" --baseline-rev "foo/v0.1.0"
+```
+
 ### What features does `cargo-semver-checks` enable in the tested crates?
 
 By default, checking is done on all features except features named `unstable`, `nightly`, `bench`, `no_std`, or ones with prefix `_`, `unstable-`, or `unstable_`, as such names are commonly used for private or unstable features.

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ You can use the following environment variables to influence the git repository 
   If this is not set,
   `cargo-semver-checks` will search the current working directory and any of its parents for the `.git/` directory.
 - [`GIT_DISCOVERY_ACROSS_FILESYSTEM`]: enable git repository detection across filesystems.
-  When automatically searching for the `.git/` directory,
-  `cargo-semver-checks` will not cross filesystem boundaries.
+  By default, `cargo-semver-checks` will not cross filesystem
+  boundaries when searching for the `.git/` directory.
   Set this environment variable to `true` to enable cross-filesystem detection.
   This environment variable has no effect when setting [`GIT_DIR`] explicitly.
 

--- a/README.md
+++ b/README.md
@@ -153,11 +153,12 @@ You can use the following environment variables to influence the git repository 
 [`GIT_DIR`]: https://git-scm.com/docs/git.html#Documentation/git.txt-codeGITDIRcode
 [`GIT_DISCOVERY_ACROSS_FILESYSTEM`]: https://git-scm.com/docs/git.html#Documentation/git.txt-codeGITDISCOVERYACROSSFILESYSTEMcode
 
+#### Use with jujutsu
+
 Setting the `GIT_DIR` allows using `cargo-semver-checks` with a non-colocated [jujutsu](https://jj-vcs.github.io/jj/latest/) repository.
 
 ```console
 GIT_DIR="$(jj root)/.jj/repo/store/git" cargo semver-checks --package "foo" --baseline-rev "foo/v0.1.0"
-```
 
 ### What features does `cargo-semver-checks` enable in the tested crates?
 

--- a/src/rustdoc_gen.rs
+++ b/src/rustdoc_gen.rs
@@ -479,7 +479,8 @@ impl RustdocFromGitRevision {
         config: &mut GlobalConfig,
     ) -> anyhow::Result<Self> {
         config.shell_status("Cloning", rev)?;
-        let repo = gix::discover(source)?;
+        let repo = gix::ThreadSafeRepository::discover_with_environment_overrides(source)
+            .map(gix::Repository::from)?;
 
         let tree_id = repo.rev_parse_single(&*format!("{rev}^{{tree}}"))?;
         let tree_dir = target.join(tree_id.to_string());


### PR DESCRIPTION
This enables overriding the git repository with the `GIT_DIR` environment variable. I was looking for this feature when working on a repository cloned with [jujutsu][], though I am sure there are other workflows for which overriding the git repository path can be useful.

[jujutsu]: https://github.com/jj-vcs/jj

This enables use with [jujutsu][] without a colocated repository.

```console
GIT_DIR="$(jj root)/.jj/repo/store/git" cargo semver-checks --package "foo" --baseline-rev "foo/v0.1.0"
```