### PR TITLE
Chore: Add witness hint for `unit_struct_changed_kind` lint

### DIFF
--- a/src/lints/unit_struct_changed_kind.ron
+++ b/src/lints/unit_struct_changed_kind.ron
@@ -59,5 +59,8 @@ SemverQuery(
         "true": true,
     },
     error_message: "A public unit struct has been changed to a normal (curly-braces) struct, which cannot be constructed using the same struct literal syntax.",
-    per_result_error_template: Some("struct {{name}} in {{span_filename}}:{{span_begin_line}}"),
+    // per_result_error_template: Some("struct {{name}} in {{span_filename}}:{{span_begin_line}}"),
+    witness: (
+            hint_template: r#"let witness = {{ join "::" path }};"#,
+        ),
 )

--- a/test_outputs/witnesses/unit_struct_changed_kind.snap
+++ b/test_outputs/witnesses/unit_struct_changed_kind.snap
@@ -1,0 +1,10 @@
+---
+source: src/query.rs
+description: "Lint `unit_struct_changed_kind` did not have the expected witness output.\nSee https://github.com/obi1kenobi/cargo-semver-checks/blob/main/CONTRIBUTING.md#testing-witnesses\nfor more information."
+expression: "&actual_witnesses"
+snapshot_kind: text
+---
+[["./test_crates/unit_struct_changed_kind/"]]
+filename = 'src/lib.rs'
+begin_line = 3
+hint = 'let witness = unit_struct_changed_kind::UnitStructToPlain;'


### PR DESCRIPTION
Adds a witness hint for the `unit_struct_changed_kind ` lint.

## Example
`unit_struct_changed_kind ` outputs the following witness hint for the `./test_crates/unit_struct_changed_kind/` test.
```rust
let witness = unit_struct_changed_kind::UnitStructToPlain;
```
This compiles on the old version, but not on the new as the struct can no longer be constructed as a unit struct;

## Commit Notes
+ Added witness hint for `unit_struct_changed_kind`

## Comments
I'm using this just to make sure my workspace is all working well, which it seems to be. Excited to start working on the witness system soon!