### PR TITLE
[Witness Generation] Add unstable witness program flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -339,6 +339,10 @@ struct UnstableOptions {
     /// Enable printing witness hints, examples of potentially-broken downstream code.
     #[arg(long, hide = true)]
     witness_hints: bool,
+
+    /// Enable generating and testing witness programs, full examples of potentially-broken downstream code.
+    #[arg(long, id = "OUTPUT_DIR", hide = true)]
+    witnesses: Option<PathBuf>,
 }
 
 impl UnstableOptions {
@@ -360,10 +364,17 @@ impl UnstableOptions {
 
         // If this has a compilation error from adding or removing fields, see this function's
         // docstring for how to fix this function's implementation.
-        let Self { witness_hints } = self;
+        let Self {
+            witness_hints,
+            witnesses,
+        } = self;
 
         if *witness_hints {
             list.push("--witness-hints".into());
+        }
+
+        if witnesses.is_some() {
+            list.push("--witnesses <OUTPUT_DIR>".into())
         }
 
         list

--- a/test_outputs/integration_snapshots__z_help.snap
+++ b/test_outputs/integration_snapshots__z_help.snap
@@ -6,6 +6,9 @@ info:
     - semver-checks
     - "-Z"
     - help
+  env:
+    CARGO_TERM_COLOR: never
+    RUST_BACKTRACE: "0"
 ---
 success: true
 exit_code: 0
@@ -18,5 +21,8 @@ unstable-options    Enables the use of unstable CLI flags.
 Unstable options:
       --witness-hints
           Enable printing witness hints, examples of potentially-broken downstream code
+
+      --witnesses <OUTPUT_DIR>
+          Enable generating and testing witness programs, full examples of potentially-broken downstream code
 
 ----- stderr -----


### PR DESCRIPTION
# Commit Notes
+ Added new unstable flag `witnesses`
+ Flag requires output path `PathBuf` for target witness output

# Comments
Feels good to get started! This just adds an unstable flag as was suggested on the rust-lang Zulip to gate the witness generation system. Decided to make the flag require an output directory, since that is mandatory for the witness system to work anyways. 

Nothing is done with the flag as of right now, it just exists.