### PR TITLE
Collect crates before running reports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,7 +429,7 @@ impl Check {
             };
         }
 
-        let crates_to_check: Vec<CrateToCheck> = match &self.current.source {
+        let crates_to_check: Vec<CrateToCheck<'_>> = match &self.current.source {
             RustdocSource::Rustdoc(_)
             | RustdocSource::Revision(_, _)
             | RustdocSource::VersionFromRegistry(_) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,15 +436,15 @@ impl Check {
             | RustdocSource::Revision(_, _)
             | RustdocSource::VersionFromRegistry(_) => {
                 let names = match &self.scope.mode {
-                    ScopeMode::DenyList(_) =>
-                        match &self.current.source {
-                            RustdocSource::Rustdoc(_) =>
-                                // This is a user-facing string.
-                                // For example, it appears when two pre-generated rustdoc files
-                                // are semver-checked against each other.
-                                vec!["<unknown>".to_string()],
-                            _ => panic!("couldn't deduce crate name, specify one through the package allow list")
+                    ScopeMode::DenyList(_) => match &self.current.source {
+                        RustdocSource::Rustdoc(_) => {
+                            // This is a user-facing string.
+                            // For example, it appears when two pre-generated rustdoc files
+                            // are semver-checked against each other.
+                            vec!["<unknown>".to_string()]
                         }
+                        _ => panic!("couldn't deduce crate name, specify one through the package allow list"),
+                    },
                     ScopeMode::AllowList(lst) => lst.clone(),
                 };
                 names
@@ -616,7 +616,7 @@ note: skipped the following crates since they have no library target: {skipped}"
                                     crate_name,
                                     self.release_type,
                                     &overrides,
-                                    &self.witness_generation
+                                    &self.witness_generation,
                                 )?),
                             ));
                             config.shell_status(
@@ -805,7 +805,7 @@ fn generate_crate_data(
                 baseline_crate.version(),
                 current_rustdoc_version,
                 "Deleting and regenerating the baseline JSON file did not resolve the rustdoc \
-                version mismatch."
+                 version mismatch."
             );
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,17 +457,17 @@ impl Check {
                             generation_settings,
                             &*current_loader,
                             &*baseline_loader,
-                            CrateDataForRustdoc {
+                            &CrateDataForRustdoc {
                                 crate_type: rustdoc_gen::CrateType::Current,
-                                name: &name,
+                                name: name.clone(),
                                 feature_config: &self.current_feature_config,
                                 build_target: self.build_target.as_deref(),
                             },
-                            CrateDataForRustdoc {
+                            &CrateDataForRustdoc {
                                 crate_type: rustdoc_gen::CrateType::Baseline {
                                     highest_allowed_version: version,
                                 },
-                                name: &name,
+                                name: name.clone(),
                                 feature_config: &self.baseline_feature_config,
                                 build_target: self.build_target.as_deref(),
                             },
@@ -549,17 +549,17 @@ note: skipped the following crates since they have no library target: {skipped}"
                                 generation_settings,
                                 &*current_loader,
                                 &*baseline_loader,
-                                CrateDataForRustdoc {
+                                &CrateDataForRustdoc {
                                     crate_type: rustdoc_gen::CrateType::Current,
-                                    name: crate_name,
+                                    name: crate_name.clone(),
                                     feature_config: &self.current_feature_config,
                                     build_target: self.build_target.as_deref(),
                                 },
-                                CrateDataForRustdoc {
+                                &CrateDataForRustdoc {
                                     crate_type: rustdoc_gen::CrateType::Baseline {
                                         highest_allowed_version: Some(version),
                                     },
-                                    name: crate_name,
+                                    name: crate_name.clone(),
                                     feature_config: &self.baseline_feature_config,
                                     build_target: self.build_target.as_deref(),
                                 },
@@ -764,17 +764,17 @@ fn generate_crate_data(
     generation_settings: data_generation::GenerationSettings,
     current_loader: &dyn rustdoc_gen::RustdocGenerator,
     baseline_loader: &dyn rustdoc_gen::RustdocGenerator,
-    current_crate_data: rustdoc_gen::CrateDataForRustdoc,
-    baseline_crate_data: rustdoc_gen::CrateDataForRustdoc,
+    current_crate_data: &rustdoc_gen::CrateDataForRustdoc<'_>,
+    baseline_crate_data: &rustdoc_gen::CrateDataForRustdoc<'_>,
 ) -> Result<DataStorage, TerminalError> {
     let current_crate = current_loader.load_rustdoc(
         config,
         generation_settings,
         data_generation::CacheSettings::ReadWrite(()),
-        current_crate_data,
+        &current_crate_data,
     )?;
 
-    let baseline_crate_name = baseline_crate_data.name;
+    let baseline_crate_name = &baseline_crate_data.name;
     let current_rustdoc_version = current_crate.version();
 
     let baseline_crate = {
@@ -782,7 +782,7 @@ fn generate_crate_data(
             config,
             generation_settings,
             data_generation::CacheSettings::ReadWrite(()),
-            baseline_crate_data.clone(),
+            &baseline_crate_data,
         )?;
 
         // The baseline rustdoc JSON may have been cached; ensure its rustdoc version matches
@@ -805,7 +805,7 @@ fn generate_crate_data(
                 config,
                 generation_settings,
                 data_generation::CacheSettings::WriteOnly(()),
-                baseline_crate_data,
+                &baseline_crate_data,
             )?;
 
             assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,7 +557,7 @@ note: skipped the following crates since they have no library target: {skipped}"
                                 },
                                 &CrateDataForRustdoc {
                                     crate_type: rustdoc_gen::CrateType::Baseline {
-                                        highest_allowed_version: Some(version),
+                                        highest_allowed_version: Some(version.clone()),
                                     },
                                     name: crate_name.clone(),
                                     feature_config: &self.baseline_feature_config,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,7 +443,7 @@ impl Check {
                             // are semver-checked against each other.
                             vec!["<unknown>".to_string()]
                         }
-                        _ => panic!("couldn't deduce crate name, specify one through the package allow list"),
+                        _ => anyhow::bail!("couldn't deduce crate name, specify one through the package allow list"),
                     },
                     ScopeMode::AllowList(lst) => lst.clone(),
                 };

--- a/src/rustdoc_gen.rs
+++ b/src/rustdoc_gen.rs
@@ -190,13 +190,13 @@ impl CrateSource<'_> {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum CrateType<'a> {
+pub(crate) enum CrateType {
     Current,
     Baseline {
         /// When the baseline is being generated from registry
         /// and no specific version was chosen, we want to select a version
         /// that is the same or older than the version of the current crate.
-        highest_allowed_version: Option<&'a semver::Version>,
+        highest_allowed_version: Option<semver::Version>,
     },
 }
 
@@ -240,7 +240,7 @@ impl FeatureConfig {
 
 #[derive(Debug, Clone)]
 pub(crate) struct CrateDataForRustdoc<'a> {
-    pub(crate) crate_type: CrateType<'a>,
+    pub(crate) crate_type: CrateType,
     pub(crate) name: String,
     pub(crate) feature_config: &'a FeatureConfig,
     pub(crate) build_target: Option<&'a str>,
@@ -709,11 +709,11 @@ impl RustdocGenerator for RustdocFromRegistry {
         } else {
             choose_baseline_version(
                 &crate_,
-                match crate_data.crate_type {
+                match &crate_data.crate_type {
                     CrateType::Current => None,
                     CrateType::Baseline {
                         highest_allowed_version,
-                    } => highest_allowed_version,
+                    } => highest_allowed_version.as_ref(),
                 },
             )
             .into_terminal_result()?

--- a/src/rustdoc_gen.rs
+++ b/src/rustdoc_gen.rs
@@ -241,7 +241,7 @@ impl FeatureConfig {
 #[derive(Debug, Clone)]
 pub(crate) struct CrateDataForRustdoc<'a> {
     pub(crate) crate_type: CrateType<'a>,
-    pub(crate) name: &'a str,
+    pub(crate) name: String,
     pub(crate) feature_config: &'a FeatureConfig,
     pub(crate) build_target: Option<&'a str>,
 }
@@ -252,7 +252,7 @@ fn generate_rustdoc(
     cache_settings: super::data_generation::CacheSettings<()>,
     target_root: PathBuf,
     crate_source: CrateSource,
-    crate_data: CrateDataForRustdoc,
+    crate_data: &CrateDataForRustdoc<'_>,
 ) -> Result<VersionedStorage, TerminalError> {
     let extra_features: BTreeSet<Cow<'_, str>> = crate_source
         .feature_list_from_config(config, crate_data.feature_config)
@@ -305,7 +305,7 @@ pub(crate) trait RustdocGenerator {
         config: &mut GlobalConfig,
         generation_settings: super::data_generation::GenerationSettings,
         cache_settings: super::data_generation::CacheSettings<()>,
-        crate_data: CrateDataForRustdoc,
+        crate_data: &CrateDataForRustdoc<'_>,
     ) -> Result<VersionedStorage, TerminalError>;
 }
 
@@ -326,7 +326,7 @@ impl RustdocGenerator for RustdocFromFile {
         _config: &mut GlobalConfig,
         _generation_settings: super::data_generation::GenerationSettings,
         _cache_settings: super::data_generation::CacheSettings<()>,
-        _crate_data: CrateDataForRustdoc,
+        _crate_data: &CrateDataForRustdoc<'_>,
     ) -> Result<VersionedStorage, TerminalError> {
         trustfall_rustdoc::load_rustdoc(&self.path, None)
             .map_err(anyhow::Error::from)
@@ -425,10 +425,10 @@ impl RustdocGenerator for RustdocFromProjectRoot {
         config: &mut GlobalConfig,
         generation_settings: super::data_generation::GenerationSettings,
         cache_settings: super::data_generation::CacheSettings<()>,
-        crate_data: CrateDataForRustdoc,
+        crate_data: &CrateDataForRustdoc<'_>,
     ) -> Result<VersionedStorage, TerminalError> {
-        let manifest: &Manifest = self.manifests.get(crate_data.name).ok_or_else(|| {
-            if let Some(duplicates) = self.duplicate_packages.get(crate_data.name) {
+        let manifest: &Manifest = self.manifests.get(&crate_data.name).ok_or_else(|| {
+            if let Some(duplicates) = self.duplicate_packages.get(&crate_data.name) {
                 let duplicates = duplicates.iter().map(|p| p.display()).join("\n  ");
                 let err = anyhow::anyhow!(
                     "package `{}` is ambiguous: it is defined by in multiple manifests within the root path {}\n\ndefined in:\n  {duplicates}",
@@ -523,7 +523,7 @@ impl RustdocGenerator for RustdocFromGitRevision {
         config: &mut GlobalConfig,
         generation_settings: super::data_generation::GenerationSettings,
         cache_settings: super::data_generation::CacheSettings<()>,
-        crate_data: CrateDataForRustdoc,
+        crate_data: &CrateDataForRustdoc<'_>,
     ) -> Result<VersionedStorage, TerminalError> {
         self.path
             .load_rustdoc(config, generation_settings, cache_settings, crate_data)
@@ -682,10 +682,15 @@ impl RustdocGenerator for RustdocFromRegistry {
         config: &mut GlobalConfig,
         generation_settings: super::data_generation::GenerationSettings,
         cache_settings: super::data_generation::CacheSettings<()>,
-        crate_data: CrateDataForRustdoc,
+        crate_data: &CrateDataForRustdoc<'_>,
     ) -> Result<VersionedStorage, TerminalError> {
         let lock = acquire_cargo_global_package_lock(config).into_terminal_result()?;
-        let crate_ = self.index.krate(crate_data.name.try_into().expect("this should be impossible"), false, &lock)
+        let validated_name = crate_data
+            .name
+            .as_str()
+            .try_into()
+            .expect("this should be impossible");
+        let crate_ = self.index.krate(validated_name, false, &lock)
             .with_context(|| {
                 format!("failed to read index metadata for crate '{}'", crate_data.name)
             }).into_terminal_result()?


### PR DESCRIPTION
This refactoring doesn't alter functionality, but deduplicates report-generation code in `check_release`. 

Previously, two kinds of data sources would run almost-identical report generation code. Now the reports are built in one place.

Moving some code to a couple of helper functions make the check loop less spaghettified.