### PR TITLE
Don't change current_dir when running cargo

### DIFF
--- a/src/data_generation/generate.rs
+++ b/src/data_generation/generate.rs
@@ -84,7 +84,6 @@ pub(super) fn generate_rustdoc(
             crate_name,
             version,
             request,
-            build_dir,
             placeholder_manifest_path.as_path(),
             &settings,
         ) {
@@ -170,14 +169,12 @@ fn run_cargo_update(
     crate_name: &str,
     version: &str,
     request: &CrateDataRequest<'_>,
-    build_dir: &Path,
     placeholder_manifest_path: &Path,
     settings: &GenerationSettings,
 ) -> CargoUpdateResult {
     let mut cmd = std::process::Command::new("cargo");
     cmd.stdout(std::process::Stdio::null()) // Don't pollute output
         .stderr(settings.stderr())
-        .current_dir(build_dir)
         .arg("update")
         .arg("--manifest-path")
         .arg(placeholder_manifest_path);


### PR DESCRIPTION
Cargo has a quirk that search for `.cargo/config.toml` is relative to the current directory Cargo has been launched from, which may end up being completely unrelated to the workspace's or crate's directory.

Annoyingly, this means that `cargo build` and `cargo build --manifest-path=some/dir/elsewhere/Cargo.toml` can have a significantly different behavior.

Some projects take advantage of that, e.g. Linux distros may want to override build scripts without modifying the source tree, so they'll build from another dir with the desired config. This also can go the other way, and a project may require `rustflags` set in its `.cargo/config.toml` to build properly.

So it's safest to keep the current dir as-is. `cargo-semver-checks` mostly does this correctly, except this one.