### PR TITLE
Share rustdoc's target dir across workspace

### DIFF
--- a/src/data_generation/generate.rs
+++ b/src/data_generation/generate.rs
@@ -45,6 +45,7 @@ impl GenerationSettings {
 pub(super) fn generate_rustdoc(
     request: &CrateDataRequest<'_>,
     build_dir: &Path,
+    target_dir: &Path,
     settings: GenerationSettings,
     callbacks: &mut CallbackHandler<'_>,
 ) -> Result<(PathBuf, cargo_metadata::Metadata), TerminalError> {
@@ -103,8 +104,6 @@ pub(super) fn generate_rustdoc(
     let metadata = cargo_metadata::MetadataCommand::new()
         .manifest_path(&placeholder_manifest_path)
         .exec()?;
-    let placeholder_target_directory = metadata.target_directory.as_path().as_std_path().to_owned();
-    let target_dir = placeholder_target_directory.as_path();
 
     let rustdoc_data = run_cargo_doc(
         request,

--- a/src/data_generation/request.rs
+++ b/src/data_generation/request.rs
@@ -331,9 +331,14 @@ impl<'a> CrateDataRequest<'a> {
 
         // Generate the data we need.
         let build_dir = target_root.join(self.build_path_slug().into_terminal_result()?);
+        // To reduce redundant dependency rebuilds, share the same target between builds
+        // of crates from the same workspace
+        let target_dir = target_root.join("target");
+
         let (data_path, metadata) = super::generate::generate_rustdoc(
             self,
             &build_dir,
+            &target_dir,
             generation_settings,
             &mut callbacks,
         )?;


### PR DESCRIPTION
This significantly improves speed of checking workspaces with multiple crates and many dependencies, especially when they have expensive-to-build dependencies like `-sys` crates built from source. 

Potential differences between dependencies and features of the workspace crates cause some dependency rebuilds, but that's still a fraction of what was otherwise rebuilt from scratch.

The shared `target` dir is placed alongside placeholder crates' dirs, but won't conflict with them, because placeholder dirs all have a `-` char.
