### PR TITLE
Fix color choice for stderr

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,7 @@ impl GlobalConfig {
     /// `cargo-semver-checks`'s color output
     pub fn new() -> Self {
         let stdout_choice = anstream::stdout().current_choice();
-        let stderr_choice = anstream::stdout().current_choice();
+        let stderr_choice = anstream::stderr().current_choice();
 
         Self {
             level: None,


### PR DESCRIPTION
## Summary
- fix bug where `stderr` color choice was read from `stdout`

## Testing
- `cargo check`
- `cargo test config::tests::test_get_color_choice -- --test-threads=1` *(fails: running 0 tests)*

------
https://chatgpt.com/codex/tasks/task_e_684ece345d44832db4a4c29e4002f33c