### PR TITLE
Fix typo in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ an argument: `./scripts/regenerate_test_rustdocs.sh +nightly`.
 ## What are those `.snap` or `.snap.new` files generated via `cargo test`
 
 As part of our overall testing strategy, we use a technique called "snapshot testing."
-The tool we use for this ([`insta`](https://insta.rs/docs/)) is user friendly and has mutliple ways to interact with it:
+The tool we use for this ([`insta`](https://insta.rs/docs/)) is user friendly and has multiple ways to interact with it:
 
 These snapshots are by default written to `.snap.new` files (because `INSTA_UPDATE` explained below defaults to `auto`) if they differ and fail the testcase.
 Reviewing them is possible via these options:


### PR DESCRIPTION
## Summary
- fix a minor spelling mistake in `CONTRIBUTING.md`

## Testing
- `./scripts/regenerate_test_rustdocs.sh`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684ed036b5a8832d8664c20999c5fef0