### PR TITLE
Add scripts and CI job for prebuilt test rustdocs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2068,3 +2068,55 @@ jobs:
           # pass-through mutually-exclusive features from our dependencies such as:
           # https://github.com/obi1kenobi/cargo-semver-checks/pull/824
           feature-group: default-features
+
+  upload-prebuilt-test-rustdocs:
+    needs: ci-everything
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain: ["1.85", "1.86", "stable"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install rust
+        id: toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          cache: false
+
+      - name: Restore test rustdocs
+        id: cache-test-rustdocs
+        uses: actions/cache/restore@v4
+        with:
+          path: localdata/test_data/
+          key: test-rustdocs-and-meta-${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('test_crates/**/*.rs') }}
+
+      - name: Compute hash
+        id: hash
+        run: echo "hash=$(./scripts/hash_test_rustdocs_inputs.sh)" >> "$GITHUB_OUTPUT"
+
+      - name: Regenerate test rustdocs
+        if: steps.cache-test-rustdocs.outputs.cache-hit != 'true'
+        run: ./scripts/regenerate_test_rustdocs.sh +${{ matrix.toolchain }}
+
+      - name: Package rustdocs
+        id: package
+        run: |
+          HASH="${{ steps.hash.outputs.hash }}"
+          TRIPLE="$(rustc -vV | grep '^host:' | awk '{print $2}')"
+          VERSION="$(rustc --version | awk '{print $2}')"
+          TAR="test-rustdocs-$HASH-$TRIPLE-$VERSION.tar.gz"
+          tar -czf "$TAR" -C localdata test_data
+          echo "artifact=$TAR" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.package.outputs.artifact }}
+          path: ${{ steps.package.outputs.artifact }}
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,9 @@ Testing this crate requires rustdoc JSON output data, which is too large and var
 to check into git. It has to be generated locally before `cargo test` will succeed,
 and will be saved in a `localdata` gitignored directory in the repo root.
 
-To generate this data, please run `./scripts/regenerate_test_rustdocs.sh`.
+You can quickly set up the needed data by running
+`./scripts/download_prebuilt_test_rustdocs.sh`.
+If you prefer to generate it yourself, run `./scripts/regenerate_test_rustdocs.sh`.
 To use a specific toolchain, like beta or nightly, pass it as
 an argument: `./scripts/regenerate_test_rustdocs.sh +nightly`.
 

--- a/scripts/download_prebuilt_test_rustdocs.sh
+++ b/scripts/download_prebuilt_test_rustdocs.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# check for bash
+if [ -z "$BASH_VERSION" ]; then
+    >&2 printf 'This script must be run using the bash shell.\n'
+    exit 1
+fi
+
+set -euo pipefail
+
+TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || { cd -- "$(dirname -- "${BASH_SOURCE[0]}")"/.. && pwd; })"
+cd "$TOPLEVEL"
+
+TRIPLE="$(rustc -vV | grep '^host:' | awk '{print $2}')"
+VERSION="$(rustc --version | awk '{print $2}')"
+HASH="$(scripts/hash_test_rustdocs_inputs.sh)"
+
+ARTIFACT_NAME="test-rustdocs-$HASH-$TRIPLE-$VERSION"
+
+RUNS_JSON="$(curl -s "https://api.github.com/repos/obi1kenobi/cargo-semver-checks/actions/runs?branch=main&status=success&per_page=1")"
+RUN_ID="$(echo "$RUNS_JSON" | jq -r '.workflow_runs[0].id')"
+
+ARTIFACT_URL="$(curl -s "https://api.github.com/repos/obi1kenobi/cargo-semver-checks/actions/runs/$RUN_ID/artifacts" | jq -r --arg NAME "$ARTIFACT_NAME" '.artifacts[] | select(.name==$NAME) | .archive_download_url' | head -n1)"
+
+if [[ -z "$ARTIFACT_URL" ]]; then
+    echo "No prebuilt test rustdocs found for artifact $ARTIFACT_NAME" >&2
+    echo "Run ./scripts/regenerate_test_rustdocs.sh to generate them locally." >&2
+    exit 1
+fi
+
+mkdir -p localdata/test_data
+rm -rf localdata/test_data
+
+curl -L "$ARTIFACT_URL" -o artifact.tgz
+
+tar -xzf artifact.tgz -C localdata
+rm artifact.tgz
+

--- a/scripts/hash_test_rustdocs_inputs.sh
+++ b/scripts/hash_test_rustdocs_inputs.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# check for bash using maximum compatibility sh syntax
+if [ -z "$BASH_VERSION" ]; then
+    >&2 printf 'This script must be run using the bash shell.\n'
+    exit 1
+fi
+
+set -euo pipefail
+
+# Go to repo root
+TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || { cd -- "$(dirname -- "${BASH_SOURCE[0]}")"/.. && pwd; })"
+cd "$TOPLEVEL"
+
+find test_crates \
+    -type f \( -name 'Cargo.toml' -o -name '*.rs' \) \
+    -not -path '*/target/*' \
+    -not -name 'Cargo.lock' \
+    -print0 | sort -z | while IFS= read -r -d '' file; do
+    printf '%s\n' "${file#./}"
+    cat "$file"
+done | sha256sum | cut -d' ' -f1
+


### PR DESCRIPTION
## Summary
- hash test rustdoc inputs deterministically
- fetch prebuilt test rustdocs from latest successful main CI run
- upload prebuilt test rustdocs from CI
- document that contributors can download prebuilt data
- address review feedback: matrix, caching, docs, script message

## Testing
- `cargo fmt -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684f230545a0832dbae0ce18fac5da57