### PR TITLE
Add workflow to automate snapshot updates

### DIFF
--- a/.github/workflows/update_snapshots.yml
+++ b/.github/workflows/update_snapshots.yml
@@ -1,0 +1,117 @@
+name: Update insta snapshots
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to update snapshots on
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-snapshots:
+    if: github.repository_owner == 'obi1kenobi'
+    runs-on: ubuntu-latest
+    env:
+      TARGET_BRANCH: "${{ github.event.inputs.branch }}"
+      BRANCH_NAME: "auto/update_snapshots_${{ github.event.inputs.branch }}"
+      PR_TITLE: "chore: updating snapshots for branch ${{ github.event.inputs.branch }}"
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v4
+        with:
+          # We have to use a Personal Access Token (PAT) here.
+          # PRs opened from a workflow using the standard `GITHUB_TOKEN` in GitHub Actions
+          # do not automatically trigger more workflows:
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          token: ${{ secrets.RUST_UPDATER_GITHUB_TOKEN }}
+          ref: ${{ env.TARGET_BRANCH }}
+          persist-credentials: true
+
+      - name: Install rust
+        id: toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          rustflags: ""
+          cache: false
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: restore test rustdocs
+        id: cache-test-rustdocs
+        uses: actions/cache@v4
+        with:
+          path: localdata/test_data/
+          key: test-rustdocs-and-meta-${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('test_crates/**/*.rs') }}
+
+      - name: Regenerate test data
+        if: steps.cache-test-rustdocs.outputs.cache-hit != 'true'
+        run: ./scripts/regenerate_test_rustdocs.sh
+
+      - name: Fake rustdoc mtime on cache hit
+        if: steps.cache-test-rustdocs.outputs.cache-hit == 'true'
+        run: find localdata/test_data -exec touch {} \;
+
+      - name: Update snapshots
+        run: |
+          set -euxo pipefail
+          INSTA_UPDATE=always cargo test -- --quiet
+
+      - name: Prepare commit
+        run: |
+          set -euo pipefail
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git switch --force-create "$BRANCH_NAME"
+          git add test_outputs/**/*.snap
+          CHANGED="$(git diff --staged --name-only)"
+          if [ -z "$CHANGED" ]; then
+            echo "No snapshot updates" >&2
+            exit 1
+          fi
+          { echo "$PR_TITLE"; echo; echo "$CHANGED"; } > body.md
+          git commit --no-verify -F body.md
+
+      - name: Push branch
+        run: |
+          set -euo pipefail
+          git push --no-verify --force --set-upstream origin "$BRANCH_NAME"
+
+      - name: Edit existing open pull request
+        id: edit
+        continue-on-error: true
+        env:
+          # We have to use a Personal Access Token (PAT) here.
+          # PRs opened from a workflow using the standard `GITHUB_TOKEN` in GitHub Actions
+          # do not automatically trigger more workflows:
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          GITHUB_TOKEN: ${{ secrets.RUST_UPDATER_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          STATE="$(gh pr view "$BRANCH_NAME" --repo "$GITHUB_REPOSITORY" --json state --jq '.state')"
+          if [[ "$STATE" != "OPEN" ]]; then
+            exit 1
+          fi
+          gh pr edit "$BRANCH_NAME" --title "$PR_TITLE" --body-file body.md --repo "$GITHUB_REPOSITORY" --base "$TARGET_BRANCH"
+
+      - name: Open new pull request
+        if: steps.edit.outcome != 'success'
+        env:
+          # We have to use a Personal Access Token (PAT) here.
+          # PRs opened from a workflow using the standard `GITHUB_TOKEN` in GitHub Actions
+          # do not automatically trigger more workflows:
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          GITHUB_TOKEN: ${{ secrets.RUST_UPDATER_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh pr create --title "$PR_TITLE" --body-file body.md --repo "$GITHUB_REPOSITORY" --base "$TARGET_BRANCH"
+
+      - name: Set PR to auto-merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --squash --auto --delete-branch


### PR DESCRIPTION
## Summary
- add `update_snapshots.yml` workflow for updating `insta` snapshots
- address review comments: use PAT token, add caching for test rustdocs, use standard toolchain action

## Testing
- `cargo fmt --all -- --check`
- `./actionlint -color -ignore 'SC2016'`
- `cargo test -- --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684f403e4a8c832dbe15ed1b797f2497