### PR TITLE
Fix artifact retrieval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2104,19 +2104,17 @@ jobs:
         if: steps.cache-test-rustdocs.outputs.cache-hit != 'true'
         run: ./scripts/regenerate_test_rustdocs.sh +${{ matrix.toolchain }}
 
-      - name: Package rustdocs
-        id: package
+      - name: Compute artifact name
+        id: artifact
         run: |
           HASH="${{ steps.hash.outputs.hash }}"
           TRIPLE="$(rustc -vV | grep '^host:' | awk '{print $2}')"
           VERSION="$(rustc --version | awk '{print $2}')"
-          TAR="test-rustdocs-$HASH-$TRIPLE-$VERSION.tar.gz"
-          tar -czf "$TAR" -C localdata test_data
-          echo "artifact=$TAR" >> "$GITHUB_OUTPUT"
+          echo "name=test-rustdocs-$HASH-$TRIPLE-$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.package.outputs.artifact }}
-          path: ${{ steps.package.outputs.artifact }}
+          name: ${{ steps.artifact.outputs.name }}
+          path: localdata/test_data
 

--- a/scripts/download_prebuilt_test_rustdocs.sh
+++ b/scripts/download_prebuilt_test_rustdocs.sh
@@ -17,7 +17,7 @@ HASH="$(scripts/hash_test_rustdocs_inputs.sh)"
 
 ARTIFACT_NAME="test-rustdocs-$HASH-$TRIPLE-$VERSION"
 
-RUNS_JSON="$(curl -s "https://api.github.com/repos/obi1kenobi/cargo-semver-checks/actions/runs?branch=main&status=success&per_page=1")"
+RUNS_JSON="$(curl -s "https://api.github.com/repos/obi1kenobi/cargo-semver-checks/actions/workflows/ci.yml/runs?branch=main&status=success&per_page=1")"
 RUN_ID="$(echo "$RUNS_JSON" | jq -r '.workflow_runs[0].id')"
 
 ARTIFACT_URL="$(curl -s "https://api.github.com/repos/obi1kenobi/cargo-semver-checks/actions/runs/$RUN_ID/artifacts" | jq -r --arg NAME "$ARTIFACT_NAME" '.artifacts[] | select(.name==$NAME) | .archive_download_url' | head -n1)"
@@ -28,11 +28,11 @@ if [[ -z "$ARTIFACT_URL" ]]; then
     exit 1
 fi
 
-mkdir -p localdata/test_data
+mkdir -p localdata
+
+curl -L "$ARTIFACT_URL" -o localdata/artifact.zip
+
 rm -rf localdata/test_data
-
-curl -L "$ARTIFACT_URL" -o artifact.tgz
-
-tar -xzf artifact.tgz -C localdata
-rm artifact.tgz
+unzip -q localdata/artifact.zip -d localdata
+rm localdata/artifact.zip
 


### PR DESCRIPTION
## Summary
- ensure `download_prebuilt_test_rustdocs.sh` selects a successful run of `ci.yml`
- use GitHub artifact zip instead of creating a tarball
- unpack artifact zip in `download_prebuilt_test_rustdocs.sh`

## Testing
- `cargo test -- --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684f5f4c4d84832dbd53de8048685360