### PR TITLE
Add lint for inherent methods gaining target features

### DIFF
--- a/src/lints/inherent_method_requires_more_target_features.ron
+++ b/src/lints/inherent_method_requires_more_target_features.ron
@@ -1,0 +1,84 @@
+SemverQuery(
+    id: "inherent_method_requires_more_target_features",
+    human_readable_name: "method requires more target features",
+    description: "A method or associated function now requires additional CPU target features compared to the previous version.",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/reference/attributes/codegen.html#the-target_feature-attribute"),
+    query: r#"
+    {
+        CrateDiff {
+            current {
+                item {
+                    ... on ImplOwner {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @output
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        inherent_impl {
+                            method {
+                                method_visibility: visibility_limit @filter(op: "=", value: ["$public"]) @output
+                                method_name: name @output @tag
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+
+                                requires_feature {
+                                    explicit @filter(op: "=", value: ["$true"])
+                                    globally_enabled @filter(op: "=", value: ["$false"])
+                                    new_feature: name @output @tag
+                                }
+
+                                span_: span @optional {
+                                    filename @output
+                                    begin_line @output
+                                    end_line @output
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on ImplOwner {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        inherent_impl {
+                            method {
+                                visibility_limit @filter(op: "=", value: ["$public"])
+                                name @filter(op: "=", value: ["%method_name"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+
+                                requires_feature @fold @transform(op: "count") @filter(op: ">", value: ["$zero"]) {
+                                    explicit @filter(op: "=", value: ["$true"])
+                                    globally_enabled @filter(op: "=", value: ["$false"])
+                                }
+
+                                requires_feature @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                                    name @filter(op: "=", value: ["%new_feature"])
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+        "false": false,
+        "zero": 0,
+    },
+    error_message: "A method or associated function now requires additional CPU target features to be enabled.",
+    per_result_error_template: Some("{{name}}::{{method_name}} requires {{new_feature}} in {{span_filename}}:{{span_begin_line}}"),
+    witness: None,
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1299,6 +1299,7 @@ add_lints!(
     inherent_method_missing,
     inherent_method_must_use_added,
     inherent_method_now_doc_hidden,
+    inherent_method_requires_more_target_features,
     inherent_method_unsafe_added,
     macro_marked_deprecated,
     macro_no_longer_exported,

--- a/test_crates/inherent_method_requires_more_target_features/new/Cargo.toml
+++ b/test_crates/inherent_method_requires_more_target_features/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "inherent_method_requires_more_target_features"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/inherent_method_requires_more_target_features/new/src/lib.rs
+++ b/test_crates/inherent_method_requires_more_target_features/new/src/lib.rs
@@ -1,0 +1,25 @@
+#![no_std]
+
+pub struct Foo;
+
+impl Foo {
+    #[target_feature(enable = "avx")]
+    #[target_feature(enable = "avx2")]
+    pub fn safe_method() {}
+
+    #[target_feature(enable = "avx")]
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn unsafe_method() {}
+
+    #[target_feature(enable = "avx")]
+    #[target_feature(enable = "avx2")]
+    fn private_method() {}
+
+    #[target_feature(enable = "avx2")]
+    #[target_feature(enable = "avx")]
+    pub fn implied_feature_method() {}
+
+    #[target_feature(enable = "fma")]
+    #[target_feature(enable = "sse2")]
+    pub fn globally_enabled_method() {}
+}

--- a/test_crates/inherent_method_requires_more_target_features/old/Cargo.toml
+++ b/test_crates/inherent_method_requires_more_target_features/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "inherent_method_requires_more_target_features"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/inherent_method_requires_more_target_features/old/src/lib.rs
+++ b/test_crates/inherent_method_requires_more_target_features/old/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+
+pub struct Foo;
+
+impl Foo {
+    #[target_feature(enable = "avx")]
+    pub fn safe_method() {}
+
+    #[target_feature(enable = "avx")]
+    pub unsafe fn unsafe_method() {}
+
+    #[target_feature(enable = "avx")]
+    fn private_method() {}
+
+    #[target_feature(enable = "avx2")]
+    pub fn implied_feature_method() {}
+
+    #[target_feature(enable = "fma")]
+    pub fn globally_enabled_method() {}
+}

--- a/test_outputs/query_execution/inherent_method_requires_more_target_features.snap
+++ b/test_outputs/query_execution/inherent_method_requires_more_target_features.snap
@@ -1,0 +1,35 @@
+---
+source: src/query.rs
+assertion_line: 785
+expression: "&query_execution_results"
+---
+{
+  "./test_crates/inherent_method_requires_more_target_features/": [
+    {
+      "method_name": String("safe_method"),
+      "method_visibility": String("public"),
+      "name": String("Foo"),
+      "new_feature": String("avx2"),
+      "path": List([
+        String("inherent_method_requires_more_target_features"),
+        String("Foo"),
+      ]),
+      "span_begin_line": Uint64(8),
+      "span_end_line": Uint64(8),
+      "span_filename": String("src/lib.rs"),
+    },
+    {
+      "method_name": String("unsafe_method"),
+      "method_visibility": String("public"),
+      "name": String("Foo"),
+      "new_feature": String("avx2"),
+      "path": List([
+        String("inherent_method_requires_more_target_features"),
+        String("Foo"),
+      ]),
+      "span_begin_line": Uint64(12),
+      "span_end_line": Uint64(12),
+      "span_filename": String("src/lib.rs"),
+    },
+  ],
+}


### PR DESCRIPTION
## Summary
- detect when an inherent method adds a new explicit target feature
- test cases for safe/unsafe methods and negative scenarios
- fix globally-enabled feature example

## Testing
- `cargo fmt`
- `cargo test -- --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684f5c38ae74832d8957c00cefbf4bd1