### PR TITLE
Add trait_method_requires_more_target_features lint

### DIFF
--- a/src/lints/trait_method_requires_more_target_features.ron
+++ b/src/lints/trait_method_requires_more_target_features.ron
@@ -1,0 +1,79 @@
+SemverQuery(
+    id: "trait_method_requires_more_target_features",
+    human_readable_name: "pub trait method requires more target features",
+    description: "A trait method now requires additional CPU target features compared to the previous version.",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/reference/attributes/codegen.html#the-target_feature-attribute"),
+    query: r#"
+    {
+        CrateDiff {
+            current {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @output
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        method {
+                            unsafe @filter(op: "=", value: ["$true"])
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+                            method_name: name @output @tag
+
+                            requires_feature {
+                                explicit @filter(op: "=", value: ["$true"])
+                                globally_enabled @filter(op: "=", value: ["$false"])
+                                new_feature: name @output @tag
+                            }
+
+                            span_: span @optional {
+                                filename @output
+                                begin_line @output
+                                end_line @output
+                            }
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        method {
+                            unsafe @filter(op: "=", value: ["$true"])
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+                            name @filter(op: "=", value: ["%method_name"])
+
+                            requires_feature @fold @transform(op: "count") @filter(op: ">", value: ["$zero"]) {
+                                explicit @filter(op: "=", value: ["$true"])
+                            }
+
+                            requires_feature @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                                name @filter(op: "=", value: ["%new_feature"])
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+        "false": false,
+        "zero": 0,
+    },
+    error_message: "A trait method now requires additional CPU target features to be enabled.",
+    per_result_error_template: Some("{{name}}::{{method_name}} requires {{new_feature}} in {{span_filename}}:{{span_begin_line}}"),
+    witness: None,
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1361,6 +1361,7 @@ add_lints!(
     trait_method_parameter_count_changed,
     trait_method_requires_different_const_generic_params,
     trait_method_requires_different_generic_type_params,
+    trait_method_requires_more_target_features,
     trait_method_unsafe_added,
     trait_method_unsafe_removed,
     trait_mismatched_generic_lifetimes,

--- a/test_crates/trait_method_requires_more_target_features/new/Cargo.toml
+++ b/test_crates/trait_method_requires_more_target_features/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_method_requires_more_target_features"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_method_requires_more_target_features/new/src/lib.rs
+++ b/test_crates/trait_method_requires_more_target_features/new/src/lib.rs
@@ -1,0 +1,29 @@
+#![no_std]
+
+mod private {
+    pub trait Sealed {}
+}
+
+pub trait TraitA {
+    #[target_feature(enable = "avx")]
+    #[target_feature(enable = "avx2")]
+    unsafe fn safe_method(&self) {}
+}
+
+pub trait TraitSealed: private::Sealed {
+    #[target_feature(enable = "avx")]
+    #[target_feature(enable = "avx2")]
+    unsafe fn sealed_method(&self) {}
+}
+
+pub trait TraitImpliedFeature {
+    #[target_feature(enable = "avx2")]
+    #[target_feature(enable = "avx")]
+    unsafe fn implied_feature_method(&self) {}
+}
+
+pub trait TraitGloballyEnabled {
+    #[target_feature(enable = "bmi1")]
+    #[target_feature(enable = "sse2")]
+    unsafe fn globally_enabled_method(&self) {}
+}

--- a/test_crates/trait_method_requires_more_target_features/old/Cargo.toml
+++ b/test_crates/trait_method_requires_more_target_features/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_method_requires_more_target_features"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_method_requires_more_target_features/old/src/lib.rs
+++ b/test_crates/trait_method_requires_more_target_features/old/src/lib.rs
@@ -1,0 +1,25 @@
+#![no_std]
+
+mod private {
+    pub trait Sealed {}
+}
+
+pub trait TraitA {
+    #[target_feature(enable = "avx")]
+    unsafe fn safe_method(&self) {}
+}
+
+pub trait TraitSealed: private::Sealed {
+    #[target_feature(enable = "avx")]
+    unsafe fn sealed_method(&self) {}
+}
+
+pub trait TraitImpliedFeature {
+    #[target_feature(enable = "avx2")]
+    unsafe fn implied_feature_method(&self) {}
+}
+
+pub trait TraitGloballyEnabled {
+    #[target_feature(enable = "bmi1")]
+    unsafe fn globally_enabled_method(&self) {}
+}

--- a/test_outputs/query_execution/trait_method_requires_more_target_features.snap
+++ b/test_outputs/query_execution/trait_method_requires_more_target_features.snap
@@ -1,0 +1,20 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+---
+{
+  "./test_crates/trait_method_requires_more_target_features/": [
+    {
+      "method_name": String("safe_method"),
+      "name": String("TraitA"),
+      "new_feature": String("avx2"),
+      "path": List([
+        String("trait_method_requires_more_target_features"),
+        String("TraitA"),
+      ]),
+      "span_begin_line": Uint64(10),
+      "span_end_line": Uint64(10),
+      "span_filename": String("src/lib.rs"),
+    },
+  ],
+}


### PR DESCRIPTION
## Summary
- implement lint `trait_method_requires_more_target_features`
- add test crate covering feature additions on trait methods
- document expected query results

## Testing
- `cargo fmt`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684f8c862428832db2a946b6de934160