### PR TITLE
Add `function_requires_more_target_features` lint

### DIFF
--- a/src/lints/function_requires_more_target_features.ron
+++ b/src/lints/function_requires_more_target_features.ron
@@ -1,0 +1,67 @@
+SemverQuery(
+    id: "function_requires_more_target_features",
+    human_readable_name: "fn requires more target features",
+    description: "A function now requires additional CPU target features compared to the previous version.",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/reference/attributes/codegen.html#the-target_feature-attribute"),
+    query: r#"
+    {
+        CrateDiff {
+            current {
+                item {
+                    ... on Function {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        fn_name: name @output
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        requires_feature {
+                            explicit @filter(op: "=", value: ["$true"])
+                            globally_enabled @filter(op: "=", value: ["$false"])
+                            new_feature: name @output @tag
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                            end_line @output
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on Function {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        requires_feature @fold @transform(op: "count") @filter(op: ">", value: ["$zero"]) {
+                            explicit @filter(op: "=", value: ["$true"])
+                        }
+
+                        requires_feature @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            name @filter(op: "=", value: ["%new_feature"])
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+        "false": false,
+        "zero": 0,
+    },
+    error_message: "A function now requires additional CPU target features to be enabled.",
+    per_result_error_template: Some("{{fn_name}} requires {{new_feature}} in {{span_filename}}:{{span_begin_line}}"),
+    witness: None,
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1291,6 +1291,7 @@ add_lints!(
     function_parameter_count_changed,
     function_requires_different_const_generic_params,
     function_requires_different_generic_type_params,
+    function_requires_more_target_features,
     function_unsafe_added,
     global_value_marked_deprecated,
     inherent_associated_const_now_doc_hidden,

--- a/test_crates/function_requires_more_target_features/new/Cargo.toml
+++ b/test_crates/function_requires_more_target_features/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "function_requires_more_target_features"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/function_requires_more_target_features/new/src/lib.rs
+++ b/test_crates/function_requires_more_target_features/new/src/lib.rs
@@ -1,0 +1,33 @@
+#![no_std]
+// ^^^^^^^ This is used to massively decrease the generated rustdoc JSON size.
+// You can remove it if your test specifically requires `std` functionality.
+//
+// Usually, you can avoid depending on `std` by importing the same types from `core` instead:
+// `std::fmt::Debug` is the same as `core::fmt::Debug`,
+// `std::marker::PhantomData` is the same as `core::marker::PhantomData` etc.
+//
+// Similarly, unless you specifically need `String` for a test,
+// you can usually avoid it by using `&'static str` instead.
+
+#[target_feature(enable = "avx")]
+#[target_feature(enable = "avx2")]
+pub fn safe_function() {}
+
+#[target_feature(enable = "avx")]
+#[target_feature(enable = "avx2")]
+pub unsafe fn unsafe_function() {}
+
+#[target_feature(enable = "avx")]
+#[target_feature(enable = "avx2")]
+fn private_function() {}
+
+#[target_feature(enable = "avx2")]
+#[target_feature(enable = "avx")]
+pub fn implied_feature_function() {}
+
+#[target_feature(enable = "fma")]
+#[target_feature(enable = "sse2")]
+pub fn globally_enabled_function() {}
+
+#[target_feature(enable = "avx2")]
+pub fn replaced_feature_function() {}

--- a/test_crates/function_requires_more_target_features/new/src/lib.rs
+++ b/test_crates/function_requires_more_target_features/new/src/lib.rs
@@ -25,9 +25,9 @@ fn private_function() {}
 #[target_feature(enable = "avx")]
 pub fn implied_feature_function() {}
 
-#[target_feature(enable = "fma")]
+#[target_feature(enable = "bmi1")]
 #[target_feature(enable = "sse2")]
 pub fn globally_enabled_function() {}
 
-#[target_feature(enable = "avx2")]
+#[target_feature(enable = "avx")]
 pub fn replaced_feature_function() {}

--- a/test_crates/function_requires_more_target_features/old/Cargo.toml
+++ b/test_crates/function_requires_more_target_features/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "function_requires_more_target_features"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/function_requires_more_target_features/old/src/lib.rs
+++ b/test_crates/function_requires_more_target_features/old/src/lib.rs
@@ -21,8 +21,8 @@ fn private_function() {}
 #[target_feature(enable = "avx2")]
 pub fn implied_feature_function() {}
 
-#[target_feature(enable = "fma")]
+#[target_feature(enable = "bmi1")]
 pub fn globally_enabled_function() {}
 
-#[target_feature(enable = "avx")]
+#[target_feature(enable = "avx2")]
 pub fn replaced_feature_function() {}

--- a/test_crates/function_requires_more_target_features/old/src/lib.rs
+++ b/test_crates/function_requires_more_target_features/old/src/lib.rs
@@ -1,0 +1,28 @@
+#![no_std]
+// ^^^^^^^ This is used to massively decrease the generated rustdoc JSON size.
+// You can remove it if your test specifically requires `std` functionality.
+//
+// Usually, you can avoid depending on `std` by importing the same types from `core` instead:
+// `std::fmt::Debug` is the same as `core::fmt::Debug`,
+// `std::marker::PhantomData` is the same as `core::marker::PhantomData` etc.
+//
+// Similarly, unless you specifically need `String` for a test,
+// you can usually avoid it by using `&'static str` instead.
+
+#[target_feature(enable = "avx")]
+pub fn safe_function() {}
+
+#[target_feature(enable = "avx")]
+pub unsafe fn unsafe_function() {}
+
+#[target_feature(enable = "avx")]
+fn private_function() {}
+
+#[target_feature(enable = "avx2")]
+pub fn implied_feature_function() {}
+
+#[target_feature(enable = "fma")]
+pub fn globally_enabled_function() {}
+
+#[target_feature(enable = "avx")]
+pub fn replaced_feature_function() {}

--- a/test_outputs/query_execution/function_requires_more_target_features.snap
+++ b/test_outputs/query_execution/function_requires_more_target_features.snap
@@ -26,16 +26,5 @@ expression: "&query_execution_results"
       "span_end_line": Uint64(18),
       "span_filename": String("src/lib.rs"),
     },
-    {
-      "fn_name": String("replaced_feature_function"),
-      "new_feature": String("avx2"),
-      "path": List([
-        String("function_requires_more_target_features"),
-        String("replaced_feature_function"),
-      ]),
-      "span_begin_line": Uint64(33),
-      "span_end_line": Uint64(33),
-      "span_filename": String("src/lib.rs"),
-    },
   ],
 }

--- a/test_outputs/query_execution/function_requires_more_target_features.snap
+++ b/test_outputs/query_execution/function_requires_more_target_features.snap
@@ -1,0 +1,41 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+---
+{
+  "./test_crates/function_requires_more_target_features/": [
+    {
+      "fn_name": String("safe_function"),
+      "new_feature": String("avx2"),
+      "path": List([
+        String("function_requires_more_target_features"),
+        String("safe_function"),
+      ]),
+      "span_begin_line": Uint64(14),
+      "span_end_line": Uint64(14),
+      "span_filename": String("src/lib.rs"),
+    },
+    {
+      "fn_name": String("unsafe_function"),
+      "new_feature": String("avx2"),
+      "path": List([
+        String("function_requires_more_target_features"),
+        String("unsafe_function"),
+      ]),
+      "span_begin_line": Uint64(18),
+      "span_end_line": Uint64(18),
+      "span_filename": String("src/lib.rs"),
+    },
+    {
+      "fn_name": String("replaced_feature_function"),
+      "new_feature": String("avx2"),
+      "path": List([
+        String("function_requires_more_target_features"),
+        String("replaced_feature_function"),
+      ]),
+      "span_begin_line": Uint64(33),
+      "span_end_line": Uint64(33),
+      "span_filename": String("src/lib.rs"),
+    },
+  ],
+}


### PR DESCRIPTION
## Summary
- register new `function_requires_more_target_features` lint
- implement the query detecting extra explicit target features on public functions
- add old/new test crates for the new lint
- update query snapshot and regenerate rustdoc json

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684f95a740cc832d810088d7af325695