### PR TITLE
Fix Handlebars repeat helper context cleanup

### DIFF
--- a/src/templating.rs
+++ b/src/templating.rs
@@ -124,6 +124,8 @@ fn repeat<'reg, 'rc>(
                     template.render(registry, ctx, render_ctx, output)?;
                 }
 
+                render_ctx.pop_block();
+
                 Ok(())
             }
 
@@ -150,4 +152,28 @@ pub(crate) fn make_handlebars_registry() -> Handlebars<'static> {
     registry.register_helper("to_string", Box::new(to_string));
     registry.register_helper("repeat", Box::new(repeat));
     registry
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repeat_helper_does_not_leak_block_context() {
+        let registry = make_handlebars_registry();
+
+        // Basic rendering works as expected.
+        let rendered = registry
+            .render_template("{{#repeat 2}}{{@index}}{{/repeat}}", &serde_json::json!({}))
+            .expect("render failed");
+        assert_eq!(rendered, "01");
+
+        // Referencing `@index` outside the helper should be an error.
+        registry
+            .render_template(
+                "{{#repeat 1}}{{@index}}{{/repeat}}{{@index}}",
+                &serde_json::json!({}),
+            )
+            .expect_err("block context leaked outside of repeat helper");
+    }
 }


### PR DESCRIPTION
## Summary
- fix missing `pop_block()` in repeat helper
- add regression test for repeat helper

## Testing
- `cargo test -- --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684fa0b567f0832db84b17c8f3ae49a3