### PR TITLE
Add safe_inherent_method_requires_more_target_features lint

### DIFF
--- a/src/lints/safe_inherent_method_requires_more_target_features.ron
+++ b/src/lints/safe_inherent_method_requires_more_target_features.ron
@@ -81,7 +81,7 @@ SemverQuery(
         "false": false,
         "zero": 0,
     },
-    error_message: "A method or associated function now requires additional CPU target features to be enabled.",
+    error_message: "A method or associated function now requires additional CPU target features to be enabled. Calling it without an unsafe block now requires enabling that additional function.",
     per_result_error_template: Some("{{name}}::{{method_name}} requires {{new_feature}} in {{span_filename}}:{{span_begin_line}}"),
     witness: None,
 )

--- a/src/lints/safe_inherent_method_requires_more_target_features.ron
+++ b/src/lints/safe_inherent_method_requires_more_target_features.ron
@@ -1,0 +1,87 @@
+SemverQuery(
+    id: "safe_inherent_method_requires_more_target_features",
+    human_readable_name: "safe method requires more target features",
+    description: "A safe method or associated function now requires additional CPU target features compared to the previous version.",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/reference/attributes/codegen.html#the-target_feature-attribute"),
+    query: r#"
+    {
+        CrateDiff {
+            current {
+                item {
+                    ... on ImplOwner {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @output
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        inherent_impl {
+                            method {
+                                method_visibility: visibility_limit @filter(op: "=", value: ["$public"]) @output
+                                method_name: name @output @tag
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+
+                                # Don't trigger if the method became unsafe.
+                                unsafe @filter(op: "=", value: ["$false"])
+
+                                requires_feature {
+                                    explicit @filter(op: "=", value: ["$true"])
+                                    globally_enabled @filter(op: "=", value: ["$false"])
+                                    new_feature: name @output @tag
+                                }
+
+                                span_: span @optional {
+                                    filename @output
+                                    begin_line @output
+                                    end_line @output
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on ImplOwner {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        inherent_impl {
+                            method {
+                                visibility_limit @filter(op: "=", value: ["$public"])
+                                name @filter(op: "=", value: ["%method_name"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+                                unsafe @filter(op: "=", value: ["$false"])
+
+                                requires_feature @fold @transform(op: "count") @filter(op: ">", value: ["$zero"]) {
+                                    explicit @filter(op: "=", value: ["$true"])
+                                }
+
+                                requires_feature @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                                    name @filter(op: "=", value: ["%new_feature"])
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+        "false": false,
+        "zero": 0,
+    },
+    error_message: "A method or associated function now requires additional CPU target features to be enabled.",
+    per_result_error_template: Some("{{name}}::{{method_name}} requires {{new_feature}} in {{span_filename}}:{{span_begin_line}}"),
+    witness: None,
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -810,6 +810,7 @@ mod tests {
                 | "inherent_method_unsafe_added"
                 | "safe_function_target_feature_added"
                 | "safe_inherent_method_target_feature_added"
+                | "safe_inherent_method_requires_more_target_features"
                 | "unsafe_function_requires_more_target_features"
                 | "unsafe_function_target_feature_added"
                 | "unsafe_inherent_method_requires_more_target_features"
@@ -849,7 +850,9 @@ mod tests {
             // https://github.com/rust-lang/rust/issues/142655
             if matches!(
                 semver_query.id.as_str(),
-                "safe_function_target_feature_added" | "safe_inherent_method_target_feature_added"
+                "safe_function_target_feature_added"
+                    | "safe_inherent_method_target_feature_added"
+                    | "safe_inherent_method_requires_more_target_features"
             ) {
                 // These queries don't have any results currently,
                 // since their results are obscured by the bug above.
@@ -1345,6 +1348,7 @@ add_lints!(
     function_parameter_count_changed,
     function_requires_different_const_generic_params,
     function_requires_different_generic_type_params,
+    safe_inherent_method_requires_more_target_features,
     unsafe_function_requires_more_target_features,
     function_unsafe_added,
     global_value_marked_deprecated,

--- a/test_crates/safe_inherent_method_requires_more_target_features/new/Cargo.toml
+++ b/test_crates/safe_inherent_method_requires_more_target_features/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "safe_inherent_method_requires_more_target_features"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/safe_inherent_method_requires_more_target_features/new/src/lib.rs
+++ b/test_crates/safe_inherent_method_requires_more_target_features/new/src/lib.rs
@@ -1,0 +1,35 @@
+#![no_std]
+
+pub struct Foo;
+
+impl Foo {
+    // Should lint: safe method gains new feature
+    #[target_feature(enable = "avx")]
+    #[target_feature(enable = "avx2")]
+    pub fn safe_method(&self) {}
+
+    // Shouldn't lint: method is unsafe
+    #[target_feature(enable = "avx")]
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn unsafe_method(&self) {}
+
+    // Became unsafe and added feature; another lint handles this
+    #[target_feature(enable = "avx")]
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn becomes_unsafe(&self) {}
+
+    // New feature is implied by the existing one
+    #[target_feature(enable = "avx2")]
+    #[target_feature(enable = "avx")]
+    pub fn implied_feature_method(&self) {}
+
+    // New feature is already globally enabled
+    #[target_feature(enable = "fma")]
+    #[target_feature(enable = "sse2")]
+    pub fn globally_enabled_method(&self) {}
+
+    // Private method
+    #[target_feature(enable = "avx")]
+    #[target_feature(enable = "avx2")]
+    fn private_method(&self) {}
+}

--- a/test_crates/safe_inherent_method_requires_more_target_features/old/Cargo.toml
+++ b/test_crates/safe_inherent_method_requires_more_target_features/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "safe_inherent_method_requires_more_target_features"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/safe_inherent_method_requires_more_target_features/old/src/lib.rs
+++ b/test_crates/safe_inherent_method_requires_more_target_features/old/src/lib.rs
@@ -1,0 +1,23 @@
+#![no_std]
+
+pub struct Foo;
+
+impl Foo {
+    #[target_feature(enable = "avx")]
+    pub fn safe_method(&self) {}
+
+    #[target_feature(enable = "avx")]
+    pub unsafe fn unsafe_method(&self) {}
+
+    #[target_feature(enable = "avx")]
+    pub fn becomes_unsafe(&self) {}
+
+    #[target_feature(enable = "avx2")]
+    pub fn implied_feature_method(&self) {}
+
+    #[target_feature(enable = "fma")]
+    pub fn globally_enabled_method(&self) {}
+
+    #[target_feature(enable = "avx")]
+    fn private_method(&self) {}
+}

--- a/test_outputs/query_execution/safe_inherent_method_requires_more_target_features.snap
+++ b/test_outputs/query_execution/safe_inherent_method_requires_more_target_features.snap
@@ -1,0 +1,5 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+---
+{}

--- a/test_outputs/query_execution/unsafe_inherent_method_requires_more_target_features.snap
+++ b/test_outputs/query_execution/unsafe_inherent_method_requires_more_target_features.snap
@@ -3,6 +3,50 @@ source: src/query.rs
 expression: "&query_execution_results"
 ---
 {
+  "./test_crates/safe_inherent_method_requires_more_target_features/": [
+    {
+      "currently_unsafe": Boolean(true),
+      "method_name": String("safe_method"),
+      "method_visibility": String("public"),
+      "name": String("Foo"),
+      "new_feature": String("avx2"),
+      "path": List([
+        String("safe_inherent_method_requires_more_target_features"),
+        String("Foo"),
+      ]),
+      "span_begin_line": Uint64(9),
+      "span_end_line": Uint64(9),
+      "span_filename": String("src/lib.rs"),
+    },
+    {
+      "currently_unsafe": Boolean(true),
+      "method_name": String("unsafe_method"),
+      "method_visibility": String("public"),
+      "name": String("Foo"),
+      "new_feature": String("avx2"),
+      "path": List([
+        String("safe_inherent_method_requires_more_target_features"),
+        String("Foo"),
+      ]),
+      "span_begin_line": Uint64(14),
+      "span_end_line": Uint64(14),
+      "span_filename": String("src/lib.rs"),
+    },
+    {
+      "currently_unsafe": Boolean(true),
+      "method_name": String("becomes_unsafe"),
+      "method_visibility": String("public"),
+      "name": String("Foo"),
+      "new_feature": String("avx2"),
+      "path": List([
+        String("safe_inherent_method_requires_more_target_features"),
+        String("Foo"),
+      ]),
+      "span_begin_line": Uint64(19),
+      "span_end_line": Uint64(19),
+      "span_filename": String("src/lib.rs"),
+    },
+  ],
   "./test_crates/unsafe_inherent_method_requires_more_target_features/": [
     {
       "currently_unsafe": Boolean(true),


### PR DESCRIPTION
## Summary
- add new lint `safe_inherent_method_requires_more_target_features`
- create test crate to exercise the lint
- regenerate rustdoc and snapshots
- skip snapshot assertions until rustdoc bug is fixed
- register lint in `add_lints!()` and version gating

## Testing
- `cargo fmt`
- `cargo test -- --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6854c753145c832db189784f81b0edfd