### PR TITLE
Add trait_method_target_feature_removed lint

### DIFF
--- a/src/lints/trait_method_target_feature_removed.ron
+++ b/src/lints/trait_method_target_feature_removed.ron
@@ -1,0 +1,73 @@
+SemverQuery(
+    id: "trait_method_target_feature_removed",
+    human_readable_name: "pub trait method target feature removed",
+    description: "A method in a public, non-sealed trait no longer requires a #[target_feature] attribute.",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/reference/attributes/codegen.html#the-target_feature-attribute"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        public_api_sealed @filter(op: "!=", value: ["$true"])
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        method {
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+                            method_name: name @output @tag
+
+                            requires_feature {
+                                explicit @filter(op: "=", value: ["$true"])
+                                globally_enabled @filter(op: "=", value: ["$false"])
+                                feature: name @output @tag
+                            }
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        method {
+                            name @filter(op: "=", value: ["%method_name"])
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+
+                            requires_feature @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                                name @filter(op: "=", value: ["%feature"])
+                            }
+
+                            span_: span @optional {
+                                filename @output
+                                begin_line @output
+                                end_line @output
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+        "false": false,
+        "zero": 0,
+    },
+    error_message: "A trait method no longer requires the CPU target features it previously needed.",
+    per_result_error_template: Some(r#"{{join "::" path}}::{{method_name}} removed requirement for {{feature}} in {{span_filename}}:{{span_begin_line}}"#),
+    witness: None,
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1345,6 +1345,7 @@ add_lints!(
     function_parameter_count_changed,
     function_requires_different_const_generic_params,
     function_requires_different_generic_type_params,
+    trait_method_target_feature_removed,
     unsafe_function_requires_more_target_features,
     function_unsafe_added,
     global_value_marked_deprecated,

--- a/test_crates/trait_method_target_feature_removed/new/Cargo.toml
+++ b/test_crates/trait_method_target_feature_removed/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_method_target_feature_removed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_method_target_feature_removed/new/src/lib.rs
+++ b/test_crates/trait_method_target_feature_removed/new/src/lib.rs
@@ -1,0 +1,36 @@
+#![no_std]
+
+mod private {
+    pub trait Sealed {}
+}
+
+pub trait TraitA {
+    unsafe fn feature_removed(&self) {}
+}
+
+pub trait TraitB {
+    #[target_feature(enable = "avx2")]
+    unsafe fn still_featured(&self) {}
+}
+
+pub trait TraitE {
+    #[target_feature(enable = "sse2")]
+    unsafe fn partial_feature_removed(&self) {}
+}
+
+pub trait TraitF {
+    #[target_feature(enable = "avx2")]
+    unsafe fn consolidated(&self) {}
+}
+
+pub trait TraitC {
+    unsafe fn remove_globally_enabled_feature(&self) {}
+}
+
+pub trait TraitD: private::Sealed {
+    unsafe fn sealed_trait_feature_removed(&self) {}
+}
+
+trait PrivateTrait {
+    unsafe fn private_feature_removed(&self) {}
+}

--- a/test_crates/trait_method_target_feature_removed/old/Cargo.toml
+++ b/test_crates/trait_method_target_feature_removed/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "trait_method_target_feature_removed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/trait_method_target_feature_removed/old/src/lib.rs
+++ b/test_crates/trait_method_target_feature_removed/old/src/lib.rs
@@ -1,0 +1,40 @@
+#![no_std]
+
+mod private {
+    pub trait Sealed {}
+}
+
+pub trait TraitA {
+    #[target_feature(enable = "avx2")]
+    unsafe fn feature_removed(&self) {}
+}
+
+pub trait TraitB {
+    #[target_feature(enable = "avx2")]
+    unsafe fn still_featured(&self) {}
+}
+
+pub trait TraitE {
+    #[target_feature(enable = "avx", enable = "sse2")]
+    unsafe fn partial_feature_removed(&self) {}
+}
+
+pub trait TraitF {
+    #[target_feature(enable = "avx", enable = "avx2")]
+    unsafe fn consolidated(&self) {}
+}
+
+pub trait TraitC {
+    #[target_feature(enable = "sse2")]
+    unsafe fn remove_globally_enabled_feature(&self) {}
+}
+
+pub trait TraitD: private::Sealed {
+    #[target_feature(enable = "avx2")]
+    unsafe fn sealed_trait_feature_removed(&self) {}
+}
+
+trait PrivateTrait {
+    #[target_feature(enable = "avx2")]
+    unsafe fn private_feature_removed(&self) {}
+}

--- a/test_outputs/query_execution/trait_method_target_feature_removed.snap
+++ b/test_outputs/query_execution/trait_method_target_feature_removed.snap
@@ -1,0 +1,33 @@
+---
+source: src/query.rs
+assertion_line: 829
+expression: "&query_execution_results"
+---
+{
+  "./test_crates/trait_method_target_feature_removed/": [
+    {
+      "feature": String("avx2"),
+      "method_name": String("feature_removed"),
+      "path": List([
+        String("trait_method_target_feature_removed"),
+        String("TraitA"),
+      ]),
+      "span_begin_line": Uint64(8),
+      "span_end_line": Uint64(8),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "feature": String("avx"),
+      "method_name": String("partial_feature_removed"),
+      "path": List([
+        String("trait_method_target_feature_removed"),
+        String("TraitE"),
+      ]),
+      "span_begin_line": Uint64(18),
+      "span_end_line": Uint64(18),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+}


### PR DESCRIPTION
## Summary
- detect when a target feature requirement is removed from a trait method
- test cases for target feature removal in trait methods
- add the lint to the registry and update snapshots

## Testing
- `cargo fmt`
- `cargo test -- --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6854c92f0064832d890cfeb89f2cbb66