### PR TITLE
[Witness Generation] Add witness query system & witness text generation

### DIFF
--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -8,10 +8,9 @@ use anyhow::Context;
 use clap::crate_version;
 use itertools::Itertools;
 use rayon::prelude::*;
-use trustfall::TransparentValue;
+use trustfall::{FieldValue, TransparentValue};
 
 use crate::data_generation::DataStorage;
-use crate::query::QueryResults;
 use crate::witness_gen;
 use crate::{
     query::{ActualSemverUpdate, LintLevel, OverrideStack, RequiredSemverUpdate, SemverQuery},
@@ -121,7 +120,7 @@ fn get_minimum_version_change(version: &semver::Version) -> VersionChange {
 fn print_triggered_lint(
     config: &mut GlobalConfig,
     semver_query: &SemverQuery,
-    results: Vec<QueryResults>,
+    results: Vec<BTreeMap<Arc<str>, FieldValue>>,
     witness_generation: &WitnessGeneration,
 ) -> anyhow::Result<()> {
     if let Some(ref_link) = semver_query.reference_link.as_deref() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod query;
 mod rustdoc_gen;
 mod templating;
 mod util;
+mod witness_gen;
 
 use anyhow::Context;
 use cargo_metadata::PackageId;

--- a/src/query.rs
+++ b/src/query.rs
@@ -321,7 +321,7 @@ impl WitnessQuery {
     pub fn inherit_arguments_from(
         &self,
         source_map: &BTreeMap<std::sync::Arc<str>, FieldValue>,
-    ) -> anyhow::Result<BTreeMap<String, TransparentValue>> {
+    ) -> anyhow::Result<BTreeMap<String, FieldValue>> {
         let mut mapped = BTreeMap::new();
 
         for (key, value) in self.arguments.iter() {
@@ -330,12 +330,11 @@ impl WitnessQuery {
                 InheritedValue::Inherited { inherit } => source_map
                     .get(inherit.as_str())
                     .cloned()
-                    .map(Into::into)
                     .ok_or(anyhow::anyhow!(
                         "inherited output key `{inherit}` does not exist"
                     ))?,
                 // Set a constant
-                InheritedValue::Constant(value) => value.clone(),
+                InheritedValue::Constant(value) => value.clone().into(),
             };
             mapped.insert(key.clone(), mapped_value);
         }

--- a/src/query.rs
+++ b/src/query.rs
@@ -6,6 +6,8 @@ use trustfall::{FieldValue, TransparentValue};
 
 use crate::ReleaseType;
 
+pub(crate) type QueryResults = BTreeMap<std::sync::Arc<str>, FieldValue>;
+
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum RequiredSemverUpdate {
@@ -331,7 +333,7 @@ impl WitnessQuery {
                     .get(inherit.as_str())
                     .cloned()
                     .ok_or(anyhow::anyhow!(
-                        "inherited output key `{inherit}` does not exist"
+                        "inherited output key `{inherit}` does not exist in {source_map:?}"
                     ))?,
                 // Set a constant
                 InheritedValue::Constant(value) => value.clone().into(),

--- a/src/query.rs
+++ b/src/query.rs
@@ -6,8 +6,6 @@ use trustfall::{FieldValue, TransparentValue};
 
 use crate::ReleaseType;
 
-pub(crate) type QueryResults = BTreeMap<std::sync::Arc<str>, FieldValue>;
-
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum RequiredSemverUpdate {

--- a/src/witness_gen.rs
+++ b/src/witness_gen.rs
@@ -148,6 +148,7 @@ fn map_to_witness_text<'query>(
     }
 }
 
+#[expect(clippy::type_complexity)]
 pub(crate) fn run_witness_checks(
     config: &GlobalConfig,
     _witness_dir: &Path,

--- a/src/witness_gen.rs
+++ b/src/witness_gen.rs
@@ -21,7 +21,7 @@ use crate::{
 /// results with the existing lint results. Each query must match exactly once, and will fail with an
 /// [`anyhow::Error`] otherwise.
 ///
-/// Overlapping output keys between the [`WitnessQuery`] and the [`SemverQuery`](crate::query::SemverQuery)
+/// Overlapping output keys between the [`WitnessQuery`] and the [`SemverQuery`]
 /// will result in an error.
 fn run_witness_query(
     adapter: &VersionedRustdocAdapter,

--- a/src/witness_gen.rs
+++ b/src/witness_gen.rs
@@ -1,9 +1,16 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, path::Path, sync::Arc, time::Duration};
 
-use trustfall::FieldValue;
+use anyhow::{Context, Result};
+use handlebars::Handlebars;
+use itertools::Itertools;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use trustfall::TransparentValue;
 use trustfall_rustdoc::VersionedRustdocAdapter;
 
-use crate::query::WitnessQuery;
+use crate::{
+    query::{QueryResults, Witness, WitnessQuery},
+    GlobalConfig, SemverQuery,
+};
 
 /// Runs the witness query of a given [`WitnessQuery`] a given lint query match, and merges the witness query
 /// results with the existing lint results. Each query must match exactly once, and will fail with an
@@ -12,21 +19,23 @@ use crate::query::WitnessQuery;
 /// Overlapping output keys between the [`WitnessQuery`] and the [`SemverQuery`](crate::query::SemverQuery)
 /// will result in the result from the [`WitnessQuery`] silently overriding the same key from the
 /// [`SemverQuery`](crate::query::SemverQuery).
-pub(crate) fn run_witness_query(
+fn run_witness_query(
     adapter: &VersionedRustdocAdapter,
     witness_query: &WitnessQuery,
-    mut lint_result: BTreeMap<Arc<str>, FieldValue>,
-) -> anyhow::Result<BTreeMap<Arc<str>, FieldValue>> {
-    let arguments = witness_query.inherit_arguments_from(&lint_result)?;
+    mut lint_result: QueryResults,
+) -> Result<QueryResults> {
+    let arguments = witness_query
+        .inherit_arguments_from(&lint_result)
+        .context("Error inheriting arguments in witness query")?;
 
     let witness_results = adapter
-        .run_query(&witness_query.query, arguments)
+        .run_query(&witness_query.query, arguments.clone())
         .and_then(|mut query_results| {
             if let Some(query_result) = query_results.next() {
                 match query_results.next() {
                     // If there is an extra query match, we don't know which is the "correct one"
-                    Some(_) => Err(anyhow::anyhow!(
-                        "witness query should match exactly one time, matched multiple times"
+                    Some(extra_match) => Err(anyhow::anyhow!(
+                        "witness query should match exactly one time, query matched producing both {:?} and {:?}", query_result, extra_match
                     )),
                     None => Ok(query_result),
                 }
@@ -36,8 +45,107 @@ pub(crate) fn run_witness_query(
                     "witness query should match exactly one time, matched zero times"
                 ))
             }
+        })
+        .with_context(|| {
+            format!(
+                "Error running witness query with input arguments {:?}",
+                arguments
+            )
         })?;
 
     lint_result.extend(witness_results);
     Ok(lint_result)
+}
+
+fn generate_witness_text(
+    handlebars: &Handlebars,
+    witness_template: &str,
+    witness_results: QueryResults,
+) -> Result<String> {
+    let pretty_witness_data: BTreeMap<Arc<str>, TransparentValue> = witness_results
+        .into_iter()
+        .map(|(k, v)| (k, v.into()))
+        .collect();
+
+    handlebars
+        .render_template(witness_template, &pretty_witness_data)
+        .context("Error instantiating witness template.")
+}
+
+fn map_to_witness_text<'query>(
+    handlebars: &Handlebars,
+    semver_query: &'query SemverQuery,
+    lint_results: &[QueryResults],
+    adapter: &VersionedRustdocAdapter,
+) -> Option<(&'query SemverQuery, Vec<Result<String>>)> {
+    match semver_query.witness {
+        // Don't bother running the witness query unless both a witness query and template exist
+        Some(Witness {
+            witness_template: Some(ref witness_template),
+            witness_query: Some(ref witness_query),
+            ..
+        }) => {
+            let witness_results = lint_results
+                .iter()
+                .cloned()
+                .map(|lint_result| {
+                    let witness_results = run_witness_query(adapter, witness_query, lint_result)
+                        .with_context(|| {
+                            format!(
+                                "Error running witness query for {}: {}",
+                                semver_query.id, semver_query.human_readable_name
+                            )
+                        })?;
+                    generate_witness_text(handlebars, witness_template, witness_results)
+                        .with_context(|| {
+                            format!(
+                                "Error generating witness text for witness {}: {}",
+                                semver_query.id, semver_query.human_readable_name
+                            )
+                        })
+                })
+                .collect_vec();
+            Some((semver_query, witness_results))
+        }
+
+        // If no witness query exists, we still want to forward the existing output
+        Some(Witness {
+            witness_template: Some(ref witness_template),
+            witness_query: None,
+            ..
+        }) => Some((
+            semver_query,
+            lint_results
+                .iter()
+                .cloned()
+                .map(|lint_result| {
+                    generate_witness_text(handlebars, witness_template, lint_result).with_context(
+                        || {
+                            format!(
+                                "Error generating witness text for queryless witness {}: {}",
+                                semver_query.id, semver_query.human_readable_name
+                            )
+                        },
+                    )
+                })
+                .collect_vec(),
+        )),
+        _ => None,
+    }
+}
+
+pub(crate) fn run_witness_checks(
+    config: &GlobalConfig,
+    _witness_dir: &Path,
+    adapter: &VersionedRustdocAdapter,
+    lint_results: &[(&SemverQuery, Duration, Vec<QueryResults>)],
+) {
+    // Have to pull out handlebars, since &GlobalConfig cannot be shared across threads
+    let handlebars = config.handlebars();
+
+    let _ = lint_results
+        .par_iter()
+        .filter_map(|(semver_query, _, query_results)| {
+            map_to_witness_text(handlebars, semver_query, query_results, adapter)
+        });
 }

--- a/src/witness_gen.rs
+++ b/src/witness_gen.rs
@@ -1,0 +1,48 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use itertools::Itertools;
+use trustfall::FieldValue;
+use trustfall_rustdoc::VersionedRustdocAdapter;
+
+use crate::query::WitnessQuery;
+
+/// Runs the witness query of a given [`WitnessQuery`] for each lint query match, and merges the witness query
+/// results with the existing lint results. Each query must match exactly once, and will fail with an
+/// [`anyhow::Error`] otherwise.
+///
+/// Overlapping output keys between the [`WitnessQuery`] and the [`SemverQuery`](crate::query::SemverQuery)
+/// will result in the result from the [`WitnessQuery`] silently overriding the same key from the
+/// [`SemverQuery`](crate::query::SemverQuery).
+pub(crate) fn run_witness_queries(
+    adapter: &VersionedRustdocAdapter,
+    witness_query: &WitnessQuery,
+    lint_results: &Vec<BTreeMap<Arc<str>, FieldValue>>,
+) -> Vec<anyhow::Result<BTreeMap<Arc<str>, FieldValue>>> {
+    lint_results
+        .clone()
+        .into_iter()
+        .map(|mut single_result| {
+            let arguments = witness_query.inherit_arguments_from(&single_result)?;
+
+            let witness_results = adapter
+                .run_query(&witness_query.query, arguments)
+                .and_then(|mut query_results| {
+                    let query_result = query_results.next();
+
+                    match query_results.next() {
+                        // If there is an extra query match, we don't know which is the "correct one"
+                        Some(_) => Err(anyhow::anyhow!(
+                            "witness query should match exactly one time, matched multiple times"
+                        )),
+                        // If there is no query match, something has gone very wrong
+                        None => query_result.ok_or(anyhow::anyhow!(
+                            "witness query should match exactly one time, matched zero times"
+                        )),
+                    }
+                })?;
+
+            single_result.extend(witness_results);
+            Ok(single_result)
+        })
+        .collect_vec()
+}

--- a/src/witness_gen.rs
+++ b/src/witness_gen.rs
@@ -1,48 +1,43 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use itertools::Itertools;
 use trustfall::FieldValue;
 use trustfall_rustdoc::VersionedRustdocAdapter;
 
 use crate::query::WitnessQuery;
 
-/// Runs the witness query of a given [`WitnessQuery`] for each lint query match, and merges the witness query
+/// Runs the witness query of a given [`WitnessQuery`] a given lint query match, and merges the witness query
 /// results with the existing lint results. Each query must match exactly once, and will fail with an
 /// [`anyhow::Error`] otherwise.
 ///
 /// Overlapping output keys between the [`WitnessQuery`] and the [`SemverQuery`](crate::query::SemverQuery)
 /// will result in the result from the [`WitnessQuery`] silently overriding the same key from the
 /// [`SemverQuery`](crate::query::SemverQuery).
-pub(crate) fn run_witness_queries(
+pub(crate) fn run_witness_query(
     adapter: &VersionedRustdocAdapter,
     witness_query: &WitnessQuery,
-    lint_results: &Vec<BTreeMap<Arc<str>, FieldValue>>,
-) -> Vec<anyhow::Result<BTreeMap<Arc<str>, FieldValue>>> {
-    lint_results
-        .clone()
-        .into_iter()
-        .map(|mut single_result| {
-            let arguments = witness_query.inherit_arguments_from(&single_result)?;
+    mut lint_result: BTreeMap<Arc<str>, FieldValue>,
+) -> anyhow::Result<BTreeMap<Arc<str>, FieldValue>> {
+    let arguments = witness_query.inherit_arguments_from(&lint_result)?;
 
-            let witness_results = adapter
-                .run_query(&witness_query.query, arguments)
-                .and_then(|mut query_results| {
-                    let query_result = query_results.next();
+    let witness_results = adapter
+        .run_query(&witness_query.query, arguments)
+        .and_then(|mut query_results| {
+            if let Some(query_result) = query_results.next() {
+                match query_results.next() {
+                    // If there is an extra query match, we don't know which is the "correct one"
+                    Some(_) => Err(anyhow::anyhow!(
+                        "witness query should match exactly one time, matched multiple times"
+                    )),
+                    None => Ok(query_result),
+                }
+            } else {
+                // If there is no query match, something has gone very wrong
+                Err(anyhow::anyhow!(
+                    "witness query should match exactly one time, matched zero times"
+                ))
+            }
+        })?;
 
-                    match query_results.next() {
-                        // If there is an extra query match, we don't know which is the "correct one"
-                        Some(_) => Err(anyhow::anyhow!(
-                            "witness query should match exactly one time, matched multiple times"
-                        )),
-                        // If there is no query match, something has gone very wrong
-                        None => query_result.ok_or(anyhow::anyhow!(
-                            "witness query should match exactly one time, matched zero times"
-                        )),
-                    }
-                })?;
-
-            single_result.extend(witness_results);
-            Ok(single_result)
-        })
-        .collect_vec()
+    lint_result.extend(witness_results);
+    Ok(lint_result)
 }

--- a/src/witness_gen.rs
+++ b/src/witness_gen.rs
@@ -47,10 +47,7 @@ fn run_witness_query(
             }
         })
         .with_context(|| {
-            format!(
-                "Error running witness query with input arguments {:?}",
-                arguments
-            )
+            format!("Error running witness query with input arguments {arguments:?}")
         })?;
 
     lint_result.extend(witness_results);


### PR DESCRIPTION
# Commit Notes
+ Add new `witness_gen` module
+ Add logic to run witness queries
+ Witness query data is unused as of right now

# Comments
This took longer than I thought it would. Not the programming itself but life has not been on the side of my time lately.

Either way, this adds a new `witness_gen` module which I plan to use for a lot more of the witness generation system. Here, I just wanted it to separate things out a little bit. Currently, I'm not doing anything with the query result, and in fact, I haven't had the opportunity to test if it even does *anything* but I'll try to quickly test that next, I'd like to know it's working before going on to generating the actual witnesses from this data. Also, witness queries that fail for some reason or another currently keep their own errors, I'd rather design the system to allow as many witnesses to be generated as possible, and then simply report error/gather diagnostics for any query or witness that fails. Unlike the lint queries themselves, it arguably should not fail hard, and should allow the rest of `c-s-c` to complete, it should just report any errors that occur to the user, and prompt them to report it as an issue. At least, that's my opinion on it, thoughts?

Additionally, as I state in one of the comments, if no witness query exists, we ideally want to forward existing lint_results, so those values can still be used in a witness that may not need a query. Though looking at this now, it might be optimal to add another case to the `match` for specifically where there *is* a witness to generate and *not* a witness query present to do that, and then on the catchall, instead just get filtered out (switching to filter_map instead of just map would allow this). However, this does still work, it's just a possible improvement for later.