### PR TITLE
[Witness Generation] Update `InheritedValue` key to an `Arc<str>`

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 use ron::extensions::Extensions;
 use serde::{Deserialize, Serialize};
@@ -310,7 +310,7 @@ pub struct WitnessQuery {
     /// These can be inherited from a previous query ([`InheritedValue::Inherited`]) or
     /// specified as [`InheritedValue::Constant`]s.
     #[serde(default)]
-    pub arguments: BTreeMap<String, InheritedValue>,
+    pub arguments: BTreeMap<Arc<str>, InheritedValue>,
 }
 
 impl WitnessQuery {
@@ -321,7 +321,7 @@ impl WitnessQuery {
     pub fn inherit_arguments_from(
         &self,
         source_map: &BTreeMap<std::sync::Arc<str>, FieldValue>,
-    ) -> anyhow::Result<BTreeMap<String, TransparentValue>> {
+    ) -> anyhow::Result<BTreeMap<Arc<str>, TransparentValue>> {
         let mut mapped = BTreeMap::new();
 
         for (key, value) in self.arguments.iter() {
@@ -337,7 +337,7 @@ impl WitnessQuery {
                 // Set a constant
                 InheritedValue::Constant(value) => value.clone(),
             };
-            mapped.insert(key.clone(), mapped_value);
+            mapped.insert(Arc::clone(key), mapped_value);
         }
 
         Ok(mapped)


### PR DESCRIPTION
As per the suggestion [here](https://github.com/obi1kenobi/cargo-semver-checks/pull/1342#discussion_r2173572696), this just updates the keys for the `InheritedValue` arguments to use `Arc<str>`, allowing for use of `Arc::clone`, rather than cloning the key strings.

# Commit Notes

+ Allows for less `String` cloning by just cloning `Arc`s instead