### PR TITLE
Refactor rustdoc generation, replacing dynamic dispatch system

### DIFF
--- a/src/data_generation/request.rs
+++ b/src/data_generation/request.rs
@@ -13,8 +13,8 @@ use super::generate::GenerationSettings;
 use super::progress::{CallbackHandler, ProgressCallbacks};
 
 #[derive(Debug, Clone)]
-pub(super) struct RegistryRequest {
-    index_entry: tame_index::IndexVersion,
+pub(super) struct RegistryRequest<'a> {
+    index_entry: &'a tame_index::IndexVersion,
 }
 
 #[derive(Debug, Clone)]
@@ -24,7 +24,7 @@ pub(super) struct ProjectRequest<'a> {
 
 #[derive(Debug, Clone)]
 pub(super) enum RequestKind<'a> {
-    Registry(RegistryRequest),
+    Registry(RegistryRequest<'a>),
     LocalProject(ProjectRequest<'a>),
 }
 
@@ -212,7 +212,7 @@ pub(crate) struct CrateDataRequest<'a> {
 
 impl<'a> CrateDataRequest<'a> {
     pub(crate) fn from_index(
-        index_entry: tame_index::IndexVersion,
+        index_entry: &'a tame_index::IndexVersion,
         default_features: bool,
         extra_features: BTreeSet<Cow<'a, str>>,
         build_target: Option<&'a str>,

--- a/src/data_generation/request.rs
+++ b/src/data_generation/request.rs
@@ -13,8 +13,8 @@ use super::generate::GenerationSettings;
 use super::progress::{CallbackHandler, ProgressCallbacks};
 
 #[derive(Debug, Clone)]
-pub(super) struct RegistryRequest<'a> {
-    index_entry: &'a tame_index::IndexVersion,
+pub(super) struct RegistryRequest {
+    index_entry: tame_index::IndexVersion,
 }
 
 #[derive(Debug, Clone)]
@@ -24,7 +24,7 @@ pub(super) struct ProjectRequest<'a> {
 
 #[derive(Debug, Clone)]
 pub(super) enum RequestKind<'a> {
-    Registry(RegistryRequest<'a>),
+    Registry(RegistryRequest),
     LocalProject(ProjectRequest<'a>),
 }
 
@@ -212,7 +212,7 @@ pub(crate) struct CrateDataRequest<'a> {
 
 impl<'a> CrateDataRequest<'a> {
     pub(crate) fn from_index(
-        index_entry: &'a tame_index::IndexVersion,
+        index_entry: tame_index::IndexVersion,
         default_features: bool,
         extra_features: BTreeSet<Cow<'a, str>>,
         build_target: Option<&'a str>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,24 +371,20 @@ impl Check {
         &self,
         config: &mut GlobalConfig,
         source: &RustdocSource,
-    ) -> anyhow::Result<Box<dyn rustdoc_gen::RustdocGenerator>> {
+    ) -> anyhow::Result<rustdoc_gen::RustdocGenerator> {
         let target_dir = self.get_target_dir(source)?;
         Ok(match source {
             RustdocSource::Rustdoc(path) => {
-                Box::new(rustdoc_gen::RustdocFromFile::new(path.to_owned()))
+                rustdoc_gen::RustdocFromFile::new(path.to_owned()).into()
             }
             RustdocSource::Root(root) => {
-                Box::new(rustdoc_gen::RustdocFromProjectRoot::new(root, &target_dir)?)
+                rustdoc_gen::RustdocFromProjectRoot::new(root, &target_dir)?.into()
             }
             RustdocSource::Revision(root, rev) => {
                 let metadata = manifest_metadata_no_deps(root)?;
                 let source = metadata.workspace_root.as_std_path();
-                Box::new(rustdoc_gen::RustdocFromGitRevision::with_rev(
-                    source,
-                    &target_dir,
-                    rev,
-                    config,
-                )?)
+                rustdoc_gen::RustdocFromGitRevision::with_rev(source, &target_dir, rev, config)?
+                    .into()
             }
             RustdocSource::VersionFromRegistry(version) => {
                 let mut registry = rustdoc_gen::RustdocFromRegistry::new(&target_dir, config)?;
@@ -396,7 +392,7 @@ impl Check {
                     let semver = semver::Version::parse(ver)?;
                     registry.set_version(semver);
                 }
-                Box::new(registry)
+                registry.into()
             }
         })
     }
@@ -556,18 +552,31 @@ note: skipped the following crates since they have no library target: {skipped}"
                 let start = std::time::Instant::now();
                 let name = selected.current_crate_data.name.clone();
 
-                let current_data_request =
-                    generate_data_request(config, &*current_loader, &selected.current_crate_data)
-                        .map_err(|err| log_terminal_error(config, err))?;
-                let baseline_data_request =
-                    generate_data_request(config, &*baseline_loader, &selected.baseline_crate_data)
-                        .map_err(|err| log_terminal_error(config, err))?;
+                let current_loader = rustdoc_gen::CoupledRustdocGenerator::couple_data(
+                    &current_loader,
+                    config,
+                    &selected.current_crate_data,
+                )
+                .map_err(|err| log_terminal_error(config, err))?;
+                let baseline_loader = rustdoc_gen::CoupledRustdocGenerator::couple_data(
+                    &baseline_loader,
+                    config,
+                    &selected.baseline_crate_data,
+                )
+                .map_err(|err| log_terminal_error(config, err))?;
+
+                let current_data_request = current_loader
+                    .generate_data_request(config)
+                    .map_err(|err| log_terminal_error(config, err))?;
+                let baseline_data_request = baseline_loader
+                    .generate_data_request(config)
+                    .map_err(|err| log_terminal_error(config, err))?;
 
                 let data_storage = generate_crate_data(
                     config,
                     generation_settings,
-                    &*current_loader,
-                    &*baseline_loader,
+                    &current_loader,
+                    &baseline_loader,
                     &selected.current_crate_data,
                     &selected.baseline_crate_data,
                     &current_data_request,
@@ -754,20 +763,12 @@ impl WitnessGeneration {
     }
 }
 
-fn generate_data_request<'a>(
-    config: &mut GlobalConfig,
-    loader: &'a dyn rustdoc_gen::RustdocGenerator,
-    crate_data: &rustdoc_gen::CrateDataForRustdoc<'a>,
-) -> Result<Option<data_generation::CrateDataRequest<'a>>, TerminalError> {
-    loader.generate_data_request(config, crate_data)
-}
-
 #[expect(clippy::too_many_arguments)]
 fn generate_crate_data(
     config: &mut GlobalConfig,
     generation_settings: data_generation::GenerationSettings,
-    current_loader: &dyn rustdoc_gen::RustdocGenerator,
-    baseline_loader: &dyn rustdoc_gen::RustdocGenerator,
+    current_loader: &rustdoc_gen::CoupledRustdocGenerator<'_>,
+    baseline_loader: &rustdoc_gen::CoupledRustdocGenerator<'_>,
     current_crate_data: &rustdoc_gen::CrateDataForRustdoc<'_>,
     baseline_crate_data: &rustdoc_gen::CrateDataForRustdoc<'_>,
     current_data_request: &Option<data_generation::CrateDataRequest<'_>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -566,10 +566,10 @@ note: skipped the following crates since they have no library target: {skipped}"
                 .map_err(|err| log_terminal_error(config, err))?;
 
                 let current_loader = current_loader
-                    .ready_generator(config)
+                    .prepare_generator(config)
                     .map_err(|err| log_terminal_error(config, err))?;
                 let baseline_loader = baseline_loader
-                    .ready_generator(config)
+                    .prepare_generator(config)
                     .map_err(|err| log_terminal_error(config, err))?;
 
                 let data_storage = generate_crate_data(

--- a/src/rustdoc_gen.rs
+++ b/src/rustdoc_gen.rs
@@ -398,7 +398,7 @@ pub(crate) enum ReadyState<'a> {
     },
 }
 
-impl<'a, S> StatefulRustdocGenerator<'a, S> {
+impl<S> StatefulRustdocGenerator<'_, S> {
     /// Retrieve the crate data for this generator
     pub(crate) fn get_crate_data(&self) -> &CrateDataForRustdoc<'_> {
         self.crate_data
@@ -436,9 +436,9 @@ impl<'a> StatefulRustdocGenerator<'a, CoupledState<'a>> {
         })
     }
 
-    /// Ready a [`CoupledState`] for rustdoc generation, extracting necessary internal data,
+    /// Prepare a [`CoupledState`] for rustdoc generation, extracting necessary internal data,
     /// and creating an appropriate data request
-    pub(crate) fn ready_generator(
+    pub(crate) fn prepare_generator(
         &self,
         config: &mut GlobalConfig,
     ) -> Result<StatefulRustdocGenerator<'_, ReadyState<'_>>, TerminalError> {
@@ -486,7 +486,7 @@ impl<'a> StatefulRustdocGenerator<'a, CoupledState<'a>> {
 }
 
 impl<'a> StatefulRustdocGenerator<'a, ReadyState<'a>> {
-    // TODO: Use the data request
+    // TODO: Use the data request in the witness system
     #[expect(dead_code)]
     /// Get the computed data request for this generator, if one exists
     pub(crate) fn get_data_request(&self) -> Option<&CrateDataRequest<'_>> {
@@ -532,12 +532,7 @@ impl RustdocFromFile {
 
     pub(crate) fn load_rustdoc(&self) -> Result<VersionedStorage, TerminalError> {
         trustfall_rustdoc::load_rustdoc(&self.path, None)
-            .with_context(|| {
-                format!(
-                    "Error loading rustdoc for `RustdocFromFile` from `{:?}`",
-                    self.path
-                )
-            })
+            .with_context(|| format!("failed to load rustdoc from file at `{:?}`", self.path))
             .into_terminal_result()
     }
 }
@@ -697,7 +692,7 @@ impl RustdocFromGitRevision {
         self.path.get_crate_source(crate_data).map_err(|err| {
             terminal_context(
                 err,
-                "Error retrieving manifest from `RustdocFromGitRevision`",
+                "failed to retrieve manifest file from git revision source",
             )
         })
     }

--- a/src/rustdoc_gen.rs
+++ b/src/rustdoc_gen.rs
@@ -449,7 +449,7 @@ impl<'a> StatefulRustdocGenerator<'a, CoupledState<'a>> {
                 return Ok(StatefulRustdocGenerator {
                     coupled_state: ReadyState::File { generator },
                     crate_data,
-                })
+                });
             }
             CoupledState::ProjectRoot { generator } => {
                 let source = generator

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -118,7 +118,7 @@ impl fmt::Display for CommandResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.result {
             Ok(success) => writeln!(f, "success: {success}")?,
-            Err(e) => writeln!(f, "--- error ---\n{e}")?,
+            Err(e) => writeln!(f, "--- error ---\n{e:?}")?,
         };
 
         write!(f, "{}", self.output)

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__multiple_ambiguous_package_name_definitions-output.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__multiple_ambiguous_package_name_definitions-output.snap
@@ -3,7 +3,7 @@ source: src/snapshot_tests.rs
 expression: result
 ---
 --- error ---
-Error while getting crate source from `RustdocFromProjectRoot`
+failed to retrieve local crate data
 
 Caused by:
     package `example` is ambiguous: it is defined by in multiple manifests within the root path test_crates/manifest_tests/multiple_ambiguous_package_name_definitions

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__multiple_ambiguous_package_name_definitions-output.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__multiple_ambiguous_package_name_definitions-output.snap
@@ -3,11 +3,14 @@ source: src/snapshot_tests.rs
 expression: result
 ---
 --- error ---
-package `example` is ambiguous: it is defined by in multiple manifests within the root path test_crates/manifest_tests/multiple_ambiguous_package_name_definitions
+Error while getting crate source from `RustdocFromProjectRoot`
 
-defined in:
-  test_crates/manifest_tests/multiple_ambiguous_package_name_definitions/Cargo.toml
-  test_crates/manifest_tests/multiple_ambiguous_package_name_definitions/nested/Cargo.toml
+Caused by:
+    package `example` is ambiguous: it is defined by in multiple manifests within the root path test_crates/manifest_tests/multiple_ambiguous_package_name_definitions
+    
+    defined in:
+      test_crates/manifest_tests/multiple_ambiguous_package_name_definitions/Cargo.toml
+      test_crates/manifest_tests/multiple_ambiguous_package_name_definitions/nested/Cargo.toml
 --- stdout ---
 
 --- stderr ---


### PR DESCRIPTION
# Commit Notes

+ Adds new `generate_data_request` method on `RustdocGenerator` trait
+ Changes `load_rustdoc` method to require optional `CrateDataRequest`
+ Splits rustdoc loading into two steps, which raises up the `CrateDataRequest`, making it accessible elsewhere

# Comments

This almost definitely needs more work, as this was just a crude hashing of what needs to happen. I'm going to put this as a draft for now, just to get feedback, but it's far from perfect in my opinion.

What this *does* do is breaks out the `CrateDataRequest` type from being a deeply internal type to being something accessible at the top level, allowing for easy access to information about the crate being queried. Now, the value returned is optional, since feeding rustdoc directly does not create a `CrateDataRequest`, that's why there's `Option<CrateDataRequest<'_>>` in quite a few places. 

This is mainly a necessary dependency for witness generation, as the generation of a witness crate requires knowing information about where the crate exists, or that it exists on crates.io.