### PR TITLE
Weekly `cargo update` of dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,9 +418,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -463,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1877,9 +1877,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "human-panic"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b84a66a325082740043a6c28bbea400c129eac0d3a27673a1de971e44bf1f7"
+checksum = "ac63a746b187e95d51fe16850eb04d1cfef203f6af98e6c405a6f262ad3df00a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1887,7 +1887,7 @@ dependencies = [
  "os_info",
  "serde",
  "serde_derive",
- "toml 0.8.23",
+ "toml 0.9.1",
  "uuid",
 ]
 
@@ -1930,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2562,9 +2562,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.7.3"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546b279bf0638ee811d9e47de2ca5b66575a543035d79fdf83959dd2f5c3b4c3"
+checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
 dependencies = [
  "base64 0.22.1",
  "indexmap",
@@ -2663,9 +2663,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "8927b0664f5c5a98265138b7e3f90aa19a6b21353182469ace36d4ac527b7b1b"
 dependencies = [
  "memchr",
 ]
@@ -3019,9 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "once_cell",
  "ring",
@@ -3043,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3134,6 +3134,15 @@ name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -3543,9 +3552,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0207d6ed1852c2a124c1fbec61621acb8330d2bf969a5d0643131e9affd985a5"
+dependencies = [
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_writer",
 ]
 
 [[package]]
@@ -3567,6 +3588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3574,8 +3604,8 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
  "winnow",
 ]
@@ -3585,6 +3615,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b679217f2848de74cabd3e8fc5e6d66f40b7da40f8e1954d92054d9010690fd5"
 
 [[package]]
 name = "tower"
@@ -3693,12 +3729,13 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "43.2.0"
+version = "43.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1931350ab17c5f3492b521fb8b9fdfd802b5f0178f526a9528eadfd3ab4036"
+checksum = "e45f0d9f0ccb63fae11296982e6b11b0787549d3938152383965bce69522787b"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
+ "indexmap",
  "rayon",
  "rust-target-feature-data",
  "rustc-hash",
@@ -3708,12 +3745,13 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "45.2.0"
+version = "45.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "787b86d0f455ecf0df318d65cc82e238850fc4649b415a8a86dfdfc00046d3fa"
+checksum = "3366268b3ef1865dad19d01d3e24b55262fd5255209d802202c7afb3cea27e4c"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
+ "indexmap",
  "rayon",
  "rustc-hash",
  "rustdoc-types 0.41.0",
@@ -3722,12 +3760,13 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "53.1.0"
+version = "53.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c40bd18b4a970afdd078a06b2c8b80ac39aeb19a372a81e0d9656923f1b9e30"
+checksum = "92f4f342f754e47a3cf08d7441a930654d33b7d219f2e4e0458ded73c9eba286"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
+ "indexmap",
  "rayon",
  "rustc-hash",
  "rustdoc-types 0.53.0",
@@ -3776,9 +3815,9 @@ dependencies = [
  "trustfall",
  "trustfall-rustdoc-adapter 37.5.0",
  "trustfall-rustdoc-adapter 39.3.0",
- "trustfall-rustdoc-adapter 43.2.0",
- "trustfall-rustdoc-adapter 45.2.0",
- "trustfall-rustdoc-adapter 53.1.0",
+ "trustfall-rustdoc-adapter 43.2.1",
+ "trustfall-rustdoc-adapter 45.2.1",
+ "trustfall-rustdoc-adapter 53.1.1",
 ]
 
 [[package]]


### PR DESCRIPTION
Automation to keep dependencies in `Cargo.lock` current.

The following is the output from `cargo update`:

```txt
     Locking 16 packages to latest Rust 1.87 compatible versions
    Updating clap v4.5.40 -> v4.5.41
    Updating clap_builder v4.5.40 -> v4.5.41
    Updating clap_derive v4.5.40 -> v4.5.41
    Updating human-panic v2.0.2 -> v2.0.3
    Updating hyper-util v0.1.14 -> v0.1.15
    Updating plist v1.7.3 -> v1.7.4
    Updating quick-xml v0.37.5 -> v0.38.0
    Updating rustls v0.23.28 -> v0.23.29
    Updating rustls-webpki v0.103.3 -> v0.103.4
      Adding serde_spanned v1.0.0
      Adding toml v0.9.1
      Adding toml_datetime v0.7.0
      Adding toml_writer v1.0.0
    Removing trustfall-rustdoc-adapter v43.2.0
    Removing trustfall-rustdoc-adapter v45.2.0
    Removing trustfall-rustdoc-adapter v53.1.0
      Adding trustfall-rustdoc-adapter v43.2.1
      Adding trustfall-rustdoc-adapter v45.2.1
      Adding trustfall-rustdoc-adapter v53.1.1
note: pass `--verbose` to see 5 unchanged dependencies behind latest
```
