### PR TITLE
Support rustdoc v55 which is currently in beta and nightly.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,9 +3022,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.54.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "814bc4dddadb32bef41ec20b836b35aa7aaf88356c721a0dd9cda41331394b8b"
+checksum = "61f25a84ea78419de928cd82c3b2f76709a696a64a880486c567b4c4da8f2dda"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -3815,16 +3815,16 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2875fe1f196b7776a19ae20853d71fa87f49b67dd5a419e9e7293a8ac7c7897a"
+checksum = "7059d956eadff3943e5963e7d5a254199562b4954733c64e03be22171ae1c8ea"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
  "indexmap",
  "rayon",
  "rustc-hash",
- "rustdoc-types 0.54.0",
+ "rustdoc-types 0.55.0",
  "trustfall",
 ]
 
@@ -3858,9 +3858,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall_rustdoc"
-version = "0.30.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa83994ef803cb9fc979f3f0aaabd54ca22de18110fabd62506bd050d5447f9"
+checksum = "e2851dc66286298097d48beec83cc9441bcfe973332f5a770dbb76ce1ded1f29"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3871,7 +3871,7 @@ dependencies = [
  "trustfall-rustdoc-adapter 43.3.0",
  "trustfall-rustdoc-adapter 45.3.0",
  "trustfall-rustdoc-adapter 53.2.0",
- "trustfall-rustdoc-adapter 54.1.0",
+ "trustfall-rustdoc-adapter 55.0.0",
  "trustfall_core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3815,9 +3815,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "55.0.0"
+version = "55.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059d956eadff3943e5963e7d5a254199562b4954733c64e03be22171ae1c8ea"
+checksum = "ca94ecd36a88d0a2414c65e894465c626bf14fdad44bba751d2290b0b15e339c"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
@@ -3871,7 +3871,7 @@ dependencies = [
  "trustfall-rustdoc-adapter 43.3.0",
  "trustfall-rustdoc-adapter 45.3.0",
  "trustfall-rustdoc-adapter 53.2.0",
- "trustfall-rustdoc-adapter 55.0.0",
+ "trustfall-rustdoc-adapter 55.0.1",
  "trustfall_core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [".github/", "brand/", "scripts/", "test_crates/", "test_outputs/", "t
 trustfall = "0.8.1"  # Ensure this matches the `trustfall_core` dev-dependency version below.
 # `cargo_metadata` is used at the API boundary of `trustfall_rustdoc`,
 # so ensure the version we use for `cargo_metadata` here matches what `trustfall_rustdoc` uses too.
-trustfall_rustdoc = { version = "0.30.0", default-features = false, features = ["v43", "v45", "v53", "v54", "rayon", "rustc-hash"] }
+trustfall_rustdoc = { version = "0.31.0", default-features = false, features = ["v43", "v45", "v53", "v55", "rayon", "rustc-hash"] }
 cargo_metadata = "0.21.0"
 # End of dependency block
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -367,7 +367,6 @@ mod tests {
     use anyhow::Context;
     use fs_err::PathExt;
     use rayon::prelude::*;
-    use semver::Version;
     use serde::{Deserialize, Serialize};
     use trustfall::{FieldValue, TransparentValue};
     use trustfall_core::ir::IndexedQuery;
@@ -832,31 +831,6 @@ mod tests {
         };
         for value in query_execution_results.values_mut() {
             value.sort_unstable_by_key(key_func);
-        }
-
-        // TODO: Remove this once Rust 1.86 is the oldest Rust supported by cargo-semver-checks.
-        // These snapshots don't match on Rust 1.85.x because of, ironically, a regression
-        // in newer Rust that inappropriately considers `#[target_feature]` safe functions
-        // to be unsafe.
-        if matches!(
-            query_name,
-            "function_no_longer_unsafe"
-                | "function_unsafe_added"
-                | "inherent_method_unsafe_added"
-                | "safe_function_target_feature_added"
-                | "safe_inherent_method_target_feature_added"
-                | "safe_function_requires_more_target_features"
-                | "safe_inherent_method_requires_more_target_features"
-                | "unsafe_function_requires_more_target_features"
-                | "unsafe_function_target_feature_added"
-                | "unsafe_inherent_method_requires_more_target_features"
-                | "unsafe_inherent_method_target_feature_added"
-        ) && rustc_version::version().is_ok_and(|version| version < Version::new(1, 86, 0))
-        {
-            eprintln!(
-                "skipping query execution test for lint `{query_name}` since data for it isn't available in Rust prior to 1.86"
-            );
-            return;
         }
 
         // TODO: Remove this when Rust 1.89 is no longer supported by cargo-semver-checks.

--- a/src/query.rs
+++ b/src/query.rs
@@ -367,6 +367,7 @@ mod tests {
     use anyhow::Context;
     use fs_err::PathExt;
     use rayon::prelude::*;
+    use semver::Version;
     use serde::{Deserialize, Serialize};
     use trustfall::{FieldValue, TransparentValue};
     use trustfall_core::ir::IndexedQuery;
@@ -831,6 +832,30 @@ mod tests {
         };
         for value in query_execution_results.values_mut() {
             value.sort_unstable_by_key(key_func);
+        }
+
+        // TODO: Remove this once Rust 1.90 is the oldest Rust supported by cargo-semver-checks.
+        // These snapshots don't match on older Rust because of a bug
+        // that inappropriately considers `#[target_feature]` safe functions to be unsafe.
+        if matches!(
+            query_name,
+            "function_no_longer_unsafe"
+                | "function_unsafe_added"
+                | "inherent_method_unsafe_added"
+                | "safe_function_requires_more_target_features"
+                | "safe_function_target_feature_added"
+                | "safe_inherent_method_requires_more_target_features"
+                | "safe_inherent_method_target_feature_added"
+                | "unsafe_function_requires_more_target_features"
+                | "unsafe_function_target_feature_added"
+                | "unsafe_inherent_method_requires_more_target_features"
+                | "unsafe_inherent_method_target_feature_added"
+        ) && rustc_version::version().is_ok_and(|version| version < Version::new(1, 90, 0))
+        {
+            eprintln!(
+                "skipping query execution test for lint `{query_name}` due to bug in its version of rustdoc"
+            );
+            return;
         }
 
         // TODO: Remove this when Rust 1.89 is no longer supported by cargo-semver-checks.

--- a/test_outputs/query_execution/function_no_longer_unsafe.snap
+++ b/test_outputs/query_execution/function_no_longer_unsafe.snap
@@ -29,4 +29,30 @@ expression: "&query_execution_results"
       "visibility_limit": String("public"),
     },
   ],
+  "./test_crates/unsafe_function_requires_more_target_features/": [
+    {
+      "name": String("becomes_safe"),
+      "path": List([
+        String("unsafe_function_requires_more_target_features"),
+        String("becomes_safe"),
+      ]),
+      "span_begin_line": Uint64(50),
+      "span_end_line": Uint64(50),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+  "./test_crates/unsafe_function_target_feature_added/": [
+    {
+      "name": String("becomes_safe"),
+      "path": List([
+        String("unsafe_function_target_feature_added"),
+        String("becomes_safe"),
+      ]),
+      "span_begin_line": Uint64(22),
+      "span_end_line": Uint64(22),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
 }

--- a/test_outputs/query_execution/function_unsafe_added.snap
+++ b/test_outputs/query_execution/function_unsafe_added.snap
@@ -16,18 +16,20 @@ expression: "&query_execution_results"
       "visibility_limit": String("public"),
     },
   ],
-  "./test_crates/safe_function_target_feature_added/": [
+  "./test_crates/safe_function_requires_more_target_features/": [
     {
-      "name": String("compute"),
+      "name": String("becomes_unsafe"),
       "path": List([
-        String("safe_function_target_feature_added"),
-        String("compute"),
+        String("safe_function_requires_more_target_features"),
+        String("becomes_unsafe"),
       ]),
-      "span_begin_line": Uint64(10),
-      "span_end_line": Uint64(12),
+      "span_begin_line": Uint64(27),
+      "span_end_line": Uint64(27),
       "span_filename": String("src/lib.rs"),
       "visibility_limit": String("public"),
     },
+  ],
+  "./test_crates/safe_function_target_feature_added/": [
     {
       "name": String("will_become_unsafe"),
       "path": List([

--- a/test_outputs/query_execution/inherent_method_unsafe_added.snap
+++ b/test_outputs/query_execution/inherent_method_unsafe_added.snap
@@ -47,6 +47,29 @@ expression: "&query_execution_results"
       "visibility_limit": String("public"),
     },
   ],
+  "./test_crates/safe_inherent_method_requires_more_target_features/": [
+    {
+      "method_name": String("becomes_unsafe"),
+      "method_visibility": String("public"),
+      "name": String("Foo"),
+      "non_matching_span_begin_line": List([
+        Uint64(19),
+      ]),
+      "non_matching_span_end_line": List([
+        Uint64(19),
+      ]),
+      "non_matching_span_filename": List([
+        String("src/lib.rs"),
+      ]),
+      "path": List([
+        String("safe_inherent_method_requires_more_target_features"),
+        String("Foo"),
+      ]),
+      "span_begin_line": Uint64(13),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
   "./test_crates/safe_inherent_method_target_feature_added/": [
     {
       "method_name": String("become_unsafe"),
@@ -66,50 +89,6 @@ expression: "&query_execution_results"
         String("Foo"),
       ]),
       "span_begin_line": Uint64(6),
-      "span_filename": String("src/lib.rs"),
-      "visibility_limit": String("public"),
-    },
-    {
-      "method_name": String("safe_add_feature"),
-      "method_visibility": String("public"),
-      "name": String("Foo"),
-      "non_matching_span_begin_line": List([
-        Uint64(15),
-      ]),
-      "non_matching_span_end_line": List([
-        Uint64(15),
-      ]),
-      "non_matching_span_filename": List([
-        String("src/lib.rs"),
-      ]),
-      "path": List([
-        String("safe_inherent_method_target_feature_added"),
-        String("Foo"),
-      ]),
-      "span_begin_line": Uint64(10),
-      "span_filename": String("src/lib.rs"),
-      "visibility_limit": String("public"),
-    },
-  ],
-  "./test_crates/unsafe_inherent_method_target_feature_added/": [
-    {
-      "method_name": String("safe"),
-      "method_visibility": String("public"),
-      "name": String("A"),
-      "non_matching_span_begin_line": List([
-        Uint64(20),
-      ]),
-      "non_matching_span_end_line": List([
-        Uint64(20),
-      ]),
-      "non_matching_span_filename": List([
-        String("src/lib.rs"),
-      ]),
-      "path": List([
-        String("unsafe_inherent_method_target_feature_added"),
-        String("A"),
-      ]),
-      "span_begin_line": Uint64(12),
       "span_filename": String("src/lib.rs"),
       "visibility_limit": String("public"),
     },

--- a/test_outputs/query_execution/safe_function_requires_more_target_features.snap
+++ b/test_outputs/query_execution/safe_function_requires_more_target_features.snap
@@ -2,4 +2,42 @@
 source: src/query.rs
 expression: "&query_execution_results"
 ---
-{}
+{
+  "./test_crates/safe_function_requires_more_target_features/": [
+    {
+      "fn_name": String("safe_function"),
+      "new_feature": String("avx2"),
+      "path": List([
+        String("safe_function_requires_more_target_features"),
+        String("safe_function"),
+      ]),
+      "span_begin_line": Uint64(5),
+      "span_end_line": Uint64(5),
+      "span_filename": String("src/lib.rs"),
+    },
+    {
+      "fn_name": String("replaced_with_broader_feature"),
+      "new_feature": String("avx2"),
+      "path": List([
+        String("safe_function_requires_more_target_features"),
+        String("replaced_with_broader_feature"),
+      ]),
+      "span_begin_line": Uint64(23),
+      "span_end_line": Uint64(23),
+      "span_filename": String("src/lib.rs"),
+    },
+  ],
+  "./test_crates/unsafe_function_requires_more_target_features/": [
+    {
+      "fn_name": String("safe_function"),
+      "new_feature": String("avx2"),
+      "path": List([
+        String("unsafe_function_requires_more_target_features"),
+        String("safe_function"),
+      ]),
+      "span_begin_line": Uint64(15),
+      "span_end_line": Uint64(15),
+      "span_filename": String("src/lib.rs"),
+    },
+  ],
+}

--- a/test_outputs/query_execution/safe_function_target_feature_added.snap
+++ b/test_outputs/query_execution/safe_function_target_feature_added.snap
@@ -2,4 +2,21 @@
 source: src/query.rs
 expression: "&query_execution_results"
 ---
-{}
+{
+  "./test_crates/safe_function_target_feature_added/": [
+    {
+      "feature": List([
+        String("sse2"),
+      ]),
+      "name": String("compute"),
+      "path": List([
+        String("safe_function_target_feature_added"),
+        String("compute"),
+      ]),
+      "span_begin_line": Uint64(10),
+      "span_end_line": Uint64(12),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+}

--- a/test_outputs/query_execution/safe_inherent_method_requires_more_target_features.snap
+++ b/test_outputs/query_execution/safe_inherent_method_requires_more_target_features.snap
@@ -2,4 +2,35 @@
 source: src/query.rs
 expression: "&query_execution_results"
 ---
-{}
+{
+  "./test_crates/safe_inherent_method_requires_more_target_features/": [
+    {
+      "method_name": String("safe_method"),
+      "method_visibility": String("public"),
+      "name": String("Foo"),
+      "new_feature": String("avx2"),
+      "path": List([
+        String("safe_inherent_method_requires_more_target_features"),
+        String("Foo"),
+      ]),
+      "span_begin_line": Uint64(9),
+      "span_end_line": Uint64(9),
+      "span_filename": String("src/lib.rs"),
+    },
+  ],
+  "./test_crates/unsafe_inherent_method_requires_more_target_features/": [
+    {
+      "method_name": String("safe_method"),
+      "method_visibility": String("public"),
+      "name": String("Foo"),
+      "new_feature": String("avx2"),
+      "path": List([
+        String("unsafe_inherent_method_requires_more_target_features"),
+        String("Foo"),
+      ]),
+      "span_begin_line": Uint64(9),
+      "span_end_line": Uint64(9),
+      "span_filename": String("src/lib.rs"),
+    },
+  ],
+}

--- a/test_outputs/query_execution/safe_inherent_method_target_feature_added.snap
+++ b/test_outputs/query_execution/safe_inherent_method_target_feature_added.snap
@@ -2,4 +2,45 @@
 source: src/query.rs
 expression: "&query_execution_results"
 ---
-{}
+{
+  "./test_crates/safe_inherent_method_target_feature_added/": [
+    {
+      "method_name": String("safe_add_feature"),
+      "method_visibility": String("public"),
+      "name": String("Foo"),
+      "new_required_feature_count": Uint64(1),
+      "new_target_feature": List([
+        String("sse2"),
+      ]),
+      "owner_type": String("Struct"),
+      "path": List([
+        String("safe_inherent_method_target_feature_added"),
+        String("Foo"),
+      ]),
+      "span_begin_line": Uint64(15),
+      "span_end_line": Uint64(15),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+  "./test_crates/unsafe_inherent_method_target_feature_added/": [
+    {
+      "method_name": String("safe"),
+      "method_visibility": String("public"),
+      "name": String("A"),
+      "new_required_feature_count": Uint64(1),
+      "new_target_feature": List([
+        String("avx"),
+      ]),
+      "owner_type": String("Struct"),
+      "path": List([
+        String("unsafe_inherent_method_target_feature_added"),
+        String("A"),
+      ]),
+      "span_begin_line": Uint64(20),
+      "span_end_line": Uint64(20),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+}

--- a/test_outputs/query_execution/unsafe_function_requires_more_target_features.snap
+++ b/test_outputs/query_execution/unsafe_function_requires_more_target_features.snap
@@ -3,57 +3,7 @@ source: src/query.rs
 expression: "&query_execution_results"
 ---
 {
-  "./test_crates/safe_function_requires_more_target_features/": [
-    {
-      "currently_unsafe": Boolean(true),
-      "fn_name": String("safe_function"),
-      "new_feature": String("avx2"),
-      "path": List([
-        String("safe_function_requires_more_target_features"),
-        String("safe_function"),
-      ]),
-      "span_begin_line": Uint64(5),
-      "span_end_line": Uint64(5),
-      "span_filename": String("src/lib.rs"),
-    },
-    {
-      "currently_unsafe": Boolean(true),
-      "fn_name": String("replaced_with_broader_feature"),
-      "new_feature": String("avx2"),
-      "path": List([
-        String("safe_function_requires_more_target_features"),
-        String("replaced_with_broader_feature"),
-      ]),
-      "span_begin_line": Uint64(23),
-      "span_end_line": Uint64(23),
-      "span_filename": String("src/lib.rs"),
-    },
-    {
-      "currently_unsafe": Boolean(true),
-      "fn_name": String("becomes_unsafe"),
-      "new_feature": String("bmi2"),
-      "path": List([
-        String("safe_function_requires_more_target_features"),
-        String("becomes_unsafe"),
-      ]),
-      "span_begin_line": Uint64(27),
-      "span_end_line": Uint64(27),
-      "span_filename": String("src/lib.rs"),
-    },
-  ],
   "./test_crates/unsafe_function_requires_more_target_features/": [
-    {
-      "currently_unsafe": Boolean(true),
-      "fn_name": String("safe_function"),
-      "new_feature": String("avx2"),
-      "path": List([
-        String("unsafe_function_requires_more_target_features"),
-        String("safe_function"),
-      ]),
-      "span_begin_line": Uint64(15),
-      "span_end_line": Uint64(15),
-      "span_filename": String("src/lib.rs"),
-    },
     {
       "currently_unsafe": Boolean(true),
       "fn_name": String("unsafe_function"),
@@ -79,7 +29,7 @@ expression: "&query_execution_results"
       "span_filename": String("src/lib.rs"),
     },
     {
-      "currently_unsafe": Boolean(true),
+      "currently_unsafe": Boolean(false),
       "fn_name": String("becomes_safe"),
       "new_feature": String("bmi2"),
       "path": List([

--- a/test_outputs/query_execution/unsafe_function_target_feature_added.snap
+++ b/test_outputs/query_execution/unsafe_function_target_feature_added.snap
@@ -20,7 +20,7 @@ expression: "&query_execution_results"
       "visibility_limit": String("public"),
     },
     {
-      "currently_unsafe": Boolean(true),
+      "currently_unsafe": Boolean(false),
       "feature": List([
         String("avx"),
       ]),

--- a/test_outputs/query_execution/unsafe_inherent_method_requires_more_target_features.snap
+++ b/test_outputs/query_execution/unsafe_inherent_method_requires_more_target_features.snap
@@ -6,20 +6,6 @@ expression: "&query_execution_results"
   "./test_crates/safe_inherent_method_requires_more_target_features/": [
     {
       "currently_unsafe": Boolean(true),
-      "method_name": String("safe_method"),
-      "method_visibility": String("public"),
-      "name": String("Foo"),
-      "new_feature": String("avx2"),
-      "path": List([
-        String("safe_inherent_method_requires_more_target_features"),
-        String("Foo"),
-      ]),
-      "span_begin_line": Uint64(9),
-      "span_end_line": Uint64(9),
-      "span_filename": String("src/lib.rs"),
-    },
-    {
-      "currently_unsafe": Boolean(true),
       "method_name": String("unsafe_method"),
       "method_visibility": String("public"),
       "name": String("Foo"),
@@ -30,40 +16,12 @@ expression: "&query_execution_results"
       ]),
       "span_begin_line": Uint64(14),
       "span_end_line": Uint64(14),
-      "span_filename": String("src/lib.rs"),
-    },
-    {
-      "currently_unsafe": Boolean(true),
-      "method_name": String("becomes_unsafe"),
-      "method_visibility": String("public"),
-      "name": String("Foo"),
-      "new_feature": String("avx2"),
-      "path": List([
-        String("safe_inherent_method_requires_more_target_features"),
-        String("Foo"),
-      ]),
-      "span_begin_line": Uint64(19),
-      "span_end_line": Uint64(19),
       "span_filename": String("src/lib.rs"),
     },
   ],
   "./test_crates/unsafe_inherent_method_requires_more_target_features/": [
     {
       "currently_unsafe": Boolean(true),
-      "method_name": String("safe_method"),
-      "method_visibility": String("public"),
-      "name": String("Foo"),
-      "new_feature": String("avx2"),
-      "path": List([
-        String("unsafe_inherent_method_requires_more_target_features"),
-        String("Foo"),
-      ]),
-      "span_begin_line": Uint64(9),
-      "span_end_line": Uint64(9),
-      "span_filename": String("src/lib.rs"),
-    },
-    {
-      "currently_unsafe": Boolean(true),
       "method_name": String("unsafe_method"),
       "method_visibility": String("public"),
       "name": String("Foo"),
@@ -77,7 +35,7 @@ expression: "&query_execution_results"
       "span_filename": String("src/lib.rs"),
     },
     {
-      "currently_unsafe": Boolean(true),
+      "currently_unsafe": Boolean(false),
       "method_name": String("becomes_safe"),
       "method_visibility": String("public"),
       "name": String("Foo"),

--- a/test_outputs/query_execution/unsafe_inherent_method_target_feature_added.snap
+++ b/test_outputs/query_execution/unsafe_inherent_method_target_feature_added.snap
@@ -22,7 +22,7 @@ expression: "&query_execution_results"
       "visibility_limit": String("public"),
     },
     {
-      "currently_unsafe": Boolean(true),
+      "currently_unsafe": Boolean(false),
       "feature_names": List([
         String("avx"),
       ]),

--- a/test_outputs/witnesses/function_unsafe_added.snap
+++ b/test_outputs/witnesses/function_unsafe_added.snap
@@ -8,10 +8,10 @@ filename = 'src/lib.rs'
 begin_line = 3
 hint = 'let witness = function_unsafe_added::add(...);'
 
-[["./test_crates/safe_function_target_feature_added/"]]
+[["./test_crates/safe_function_requires_more_target_features/"]]
 filename = 'src/lib.rs'
-begin_line = 10
-hint = 'let witness = safe_function_target_feature_added::compute(...);'
+begin_line = 27
+hint = 'let witness = safe_function_requires_more_target_features::becomes_unsafe(...);'
 
 [["./test_crates/safe_function_target_feature_added/"]]
 filename = 'src/lib.rs'


### PR DESCRIPTION
Rustdoc v55 is also the cutoff where false-positive `unsafe` markers on safe `#[target_feature]` functions are fixed. As a result, this PR flips the snapshot files to the fixed v55 behavior and disables running those tests on Rust < 1.90.