### PR TITLE
[Witness Generation] Add empty witness crate generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "predicates",
+ "rand",
  "rayon",
  "regex",
  "ron 0.8.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ anstyle = "1.0.10"
 anstream = "0.6.18"
 urlencoding = "2.1.3"
 cargo-config2 = "0.1.32"
+rand = "0.9.2"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -235,6 +235,7 @@ pub(super) fn run_check_release(
     release_type: Option<ReleaseType>,
     overrides: &OverrideStack,
     witness_generation: &WitnessGeneration,
+    witness_data: witness_gen::WitnessGenerationData,
 ) -> anyhow::Result<CrateReport> {
     let current_version = data_storage.current_crate().crate_version();
     let baseline_version = data_storage.baseline_crate().crate_version();
@@ -342,8 +343,8 @@ pub(super) fn run_check_release(
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
 
-    if let Some(ref witness_dir) = witness_generation.witness_directory {
-        witness_gen::run_witness_checks(config, witness_dir, &adapter, &all_results);
+    if witness_generation.generate_witnesses {
+        witness_gen::run_witness_checks(config, witness_data, crate_name, &adapter, &all_results);
     }
 
     let mut results_with_errors = vec![];

--- a/src/data_generation/request.rs
+++ b/src/data_generation/request.rs
@@ -13,17 +13,17 @@ use super::generate::GenerationSettings;
 use super::progress::{CallbackHandler, ProgressCallbacks};
 
 #[derive(Debug, Clone)]
-pub(super) struct RegistryRequest<'a> {
+pub(crate) struct RegistryRequest<'a> {
     index_entry: &'a tame_index::IndexVersion,
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct ProjectRequest<'a> {
+pub(crate) struct ProjectRequest<'a> {
     pub(super) manifest: &'a Manifest,
 }
 
 #[derive(Debug, Clone)]
-pub(super) enum RequestKind<'a> {
+pub(crate) enum RequestKind<'a> {
     Registry(RegistryRequest<'a>),
     LocalProject(ProjectRequest<'a>),
 }
@@ -194,7 +194,7 @@ impl<'a> CacheUse<'a> {
 
 #[derive(Debug, Clone)]
 pub(crate) struct CrateDataRequest<'a> {
-    pub(super) kind: RequestKind<'a>,
+    pub(crate) kind: RequestKind<'a>,
 
     // N.B.: `--no-default-features --feature default` is not the same as using default features,
     //       since it will fail if the crate has no "default" feature definition.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -578,6 +578,12 @@ note: skipped the following crates since they have no library target: {skipped}"
                     .prepare_generator(config)
                     .map_err(|err| log_terminal_error(config, err))?;
 
+                let witness_data = witness_gen::WitnessGenerationData::new(
+                    baseline_loader.get_data_request(),
+                    current_loader.get_data_request(),
+                    current_loader.get_target_root(),
+                );
+
                 let data_storage = generate_crate_data(
                     config,
                     generation_settings,
@@ -593,6 +599,7 @@ note: skipped the following crates since they have no library target: {skipped}"
                     self.release_type,
                     &selected.overrides,
                     &self.witness_generation,
+                    witness_data,
                 )?;
                 config.shell_status(
                     "Finished",
@@ -753,9 +760,9 @@ pub struct WitnessGeneration {
     /// Whether to print witness hints, short examples that show why a change is breaking,
     /// while not necessarily buildable standalone programs.  See [`Witness::hint_template`].
     pub show_hints: bool,
-    /// Optional directory to write full witness examples to.  If this is `None`, full witnesses
-    /// will not be generated.  See [`Witness::witness_template`].
-    pub witness_directory: Option<PathBuf>,
+    /// Whether to generate witness programs, longer, fully valid and compilable examples
+    /// of a breaking change. See [`Witness::witness_template`] and [`Witness::witness_query`].
+    pub generate_witnesses: bool,
 }
 
 impl WitnessGeneration {
@@ -765,7 +772,7 @@ impl WitnessGeneration {
     pub const fn new() -> Self {
         Self {
             show_hints: false,
-            witness_directory: None,
+            generate_witnesses: false,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,8 +340,8 @@ struct UnstableOptions {
     witness_hints: bool,
 
     /// Enable generating and testing witness programs, full examples of potentially-broken downstream code.
-    #[arg(long, id = "OUTPUT_DIR", hide = true)]
-    witnesses: Option<PathBuf>,
+    #[arg(long, hide = true)]
+    witnesses: bool,
 }
 
 impl UnstableOptions {
@@ -372,8 +372,8 @@ impl UnstableOptions {
             list.push("--witness-hints".into());
         }
 
-        if witnesses.is_some() {
-            list.push("--witnesses <OUTPUT_DIR>".into())
+        if *witnesses {
+            list.push("--witnesses".into())
         }
 
         list
@@ -642,6 +642,7 @@ impl From<CheckRelease> for cargo_semver_checks::Check {
 
         let mut witness_generation = WitnessGeneration::new();
         witness_generation.show_hints = value.unstable_options.witness_hints;
+        witness_generation.generate_witnesses = value.unstable_options.witnesses;
         check.set_witness_generation(witness_generation);
 
         check

--- a/src/rustdoc_gen.rs
+++ b/src/rustdoc_gen.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::collections::{BTreeSet, HashMap};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, bail};
 use itertools::Itertools;
@@ -486,13 +486,18 @@ impl<'a> StatefulRustdocGenerator<'a, CoupledState<'a>> {
 }
 
 impl<'a> StatefulRustdocGenerator<'a, ReadyState<'a>> {
-    // TODO: Use the data request in the witness system
-    #[expect(dead_code)]
     /// Get the computed data request for this generator, if one exists
     pub(crate) fn get_data_request(&self) -> Option<&CrateDataRequest<'_>> {
         match &self.coupled_state {
             ReadyState::File { .. } => None,
             ReadyState::Generator { data_request, .. } => Some(data_request),
+        }
+    }
+
+    pub(crate) fn get_target_root(&self) -> Option<&Path> {
+        match &self.coupled_state {
+            ReadyState::File { .. } => None,
+            ReadyState::Generator { target_root, .. } => Some(target_root),
         }
     }
 


### PR DESCRIPTION
# Commit Notes

+ Adds `rand` and lazy `run_id` generation to config
+ Adds simple empty witness crate generation
+ Adds `target` directory finding
+ Adds `baseline` and `current` data retrieval which is necessary for future witness testing
+ Modifies unstable flag to be boolean based, rather than requiring a path, since `target` is now used instead
+ Is accompanied by the writer's apology for such a bizarre delay in project development

# Comments

Well, `n`th time's the charm I guess? I'm back working on this, ideally much more consistently. I strangely feel more interested and encouraged only now that my life is filling with extra responsibilities.

I'm pretty happy with how this generates the *empty* witness crates, now to do the actual generation, which ideally should be fairly simple (hardest part should be the `Cargo.toml`, since that needs version info, and features and whatnot). There are one or two things in this PR that I feel may need touch-ups, but overall I'm happy with it.