### PR TITLE
Add repr_packed_changed lint

### DIFF
--- a/src/lints/repr_packed_changed.ron
+++ b/src/lints/repr_packed_changed.ron
@@ -1,0 +1,80 @@
+SemverQuery(
+    id: "repr_packed_changed",
+    human_readable_name: "repr(packed(N)) changed",
+    description: "A struct or union changed its repr(packed) alignment value.",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#repr-packed-n-change"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on ImplOwner {
+                        type: __typename @filter(op: "one_of", value: ["$types"]) @output @tag
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        attribute {
+                            content {
+                                base @filter(op: "=", value: ["$repr"])
+                                argument {
+                                    base @filter(op: "=", value: ["$packed"])
+                                    argument {
+                                        old_packed: raw_item @output @tag(name: "old_packed")
+                                    }
+                                }
+                            }
+                        }
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on ImplOwner {
+                        __typename @filter(op: "=", value: ["%type"])
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @output
+
+                        attribute {
+                            content {
+                                base @filter(op: "=", value: ["$repr"])
+                                argument {
+                                    base @filter(op: "=", value: ["$packed"])
+                                    argument {
+                                        raw_item @filter(op: "!=", value: ["%old_packed"]) @output(name: "new_packed")
+                                    }
+                                }
+                            }
+                        }
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                            end_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "repr": "repr",
+        "packed": "packed",
+        "true": true,
+        "types": ["Struct", "Union"],
+    },
+    error_message: "repr(packed) value changed. This can break code that depends on the type's alignment or layout.",
+    per_result_error_template: Some("{{lowercase type}} {{name}} changed repr(packed) from {{old_packed}} to {{new_packed}} in {{span_filename}}:{{span_begin_line}}"),
+    witness: None,
+)

--- a/src/lints/repr_packed_changed.ron
+++ b/src/lints/repr_packed_changed.ron
@@ -74,7 +74,7 @@ SemverQuery(
         "true": true,
         "types": ["Struct", "Union"],
     },
-    error_message: "repr(packed) value changed. This can break code that depends on the type's alignment or layout.",
-    per_result_error_template: Some("{{lowercase type}} {{name}} changed repr(packed) from {{old_packed}} to {{new_packed}} in {{span_filename}}:{{span_begin_line}}"),
+    error_message: "The minimum alignment allowed for a type has changed. This can break code that depends on the type's alignment or layout.",
+    per_result_error_template: Some("{{lowercase type}} {{name}} changed from #[repr(packed({{old_packed}}))] to #[repr(packed({{new_packed}}))] in {{span_filename}}:{{span_begin_line}}"),
     witness: None,
 )

--- a/src/lints/repr_packed_changed.ron
+++ b/src/lints/repr_packed_changed.ron
@@ -74,7 +74,7 @@ SemverQuery(
         "true": true,
         "types": ["Struct", "Union"],
     },
-    error_message: "The minimum alignment allowed for a type has changed. This can break code that depends on the type's alignment or layout.",
+    error_message: "The maximum alignment for a type has changed. This can break code that depends on the type's alignment or layout.",
     per_result_error_template: Some("{{lowercase type}} {{name}} changed from #[repr(packed({{old_packed}}))] to #[repr(packed({{new_packed}}))] in {{span_filename}}:{{span_begin_line}}"),
     witness: None,
 )

--- a/src/query.rs
+++ b/src/query.rs
@@ -1444,6 +1444,7 @@ add_lints!(
     repr_c_plain_struct_fields_reordered,
     repr_c_removed,
     repr_packed_added,
+    repr_packed_changed,
     repr_packed_removed,
     safe_function_requires_more_target_features,
     safe_function_target_feature_added,

--- a/test_crates/repr_packed_changed/new/Cargo.toml
+++ b/test_crates/repr_packed_changed/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "repr_packed_changed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/repr_packed_changed/new/src/lib.rs
+++ b/test_crates/repr_packed_changed/new/src/lib.rs
@@ -2,7 +2,7 @@
 
 // true positive: struct with packed value changed
 #[repr(packed(2))]
-pub struct StructPacked1;
+pub struct StructPacked1(i64);
 
 // true positive: union with packed value changed
 #[repr(packed(4))]
@@ -12,14 +12,14 @@ pub union UnionPacked2 {
 
 // packed value unchanged
 #[repr(packed(1))]
-pub struct StructPackedUnchanged;
+pub struct StructPackedUnchanged(i64);
 
 // no repr(packed)
-pub struct StructNoPacked;
+pub struct StructNoPacked(i64);
 
 // becomes private
 #[repr(packed(2))]
-struct StructPackedBecomesPrivate;
+struct StructPackedBecomesPrivate(i64);
 
 // union becomes private
 #[repr(packed(4))]

--- a/test_crates/repr_packed_changed/new/src/lib.rs
+++ b/test_crates/repr_packed_changed/new/src/lib.rs
@@ -1,0 +1,39 @@
+#![no_std]
+
+// true positive: struct with packed value changed
+#[repr(packed(2))]
+pub struct StructPacked1;
+
+// true positive: union with packed value changed
+#[repr(packed(4))]
+pub union UnionPacked2 {
+    field1: i32,
+}
+
+// packed value unchanged
+#[repr(packed(1))]
+pub struct StructPackedUnchanged;
+
+// no repr(packed)
+pub struct StructNoPacked;
+
+// becomes private
+#[repr(packed(2))]
+struct StructPackedBecomesPrivate;
+
+// union becomes private
+#[repr(packed(4))]
+union UnionPackedBecomesPrivate {
+    field1: i32,
+}
+
+// union packed unchanged
+#[repr(packed(2))]
+pub union UnionPackedUnchanged {
+    field1: i32,
+}
+
+// union without repr(packed)
+pub union UnionNoPacked {
+    field1: i32,
+}

--- a/test_crates/repr_packed_changed/old/Cargo.toml
+++ b/test_crates/repr_packed_changed/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "repr_packed_changed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/repr_packed_changed/old/src/lib.rs
+++ b/test_crates/repr_packed_changed/old/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
 // true positive: struct with packed value changed
-#[repr(packed(1))]
-pub struct StructPacked1;
+#[repr(packed(4))]
+pub struct StructPacked1(i64);
 
 // true positive: union with packed value changed
 #[repr(packed(2))]
@@ -12,14 +12,14 @@ pub union UnionPacked2 {
 
 // packed value unchanged
 #[repr(packed(1))]
-pub struct StructPackedUnchanged;
+pub struct StructPackedUnchanged(i64);
 
 // no repr(packed)
-pub struct StructNoPacked;
+pub struct StructNoPacked(i64);
 
 // becomes private
 #[repr(packed(1))]
-pub struct StructPackedBecomesPrivate;
+pub struct StructPackedBecomesPrivate(i64);
 
 // union becomes private
 #[repr(packed(2))]

--- a/test_crates/repr_packed_changed/old/src/lib.rs
+++ b/test_crates/repr_packed_changed/old/src/lib.rs
@@ -1,0 +1,39 @@
+#![no_std]
+
+// true positive: struct with packed value changed
+#[repr(packed(1))]
+pub struct StructPacked1;
+
+// true positive: union with packed value changed
+#[repr(packed(2))]
+pub union UnionPacked2 {
+    field1: i32,
+}
+
+// packed value unchanged
+#[repr(packed(1))]
+pub struct StructPackedUnchanged;
+
+// no repr(packed)
+pub struct StructNoPacked;
+
+// becomes private
+#[repr(packed(1))]
+pub struct StructPackedBecomesPrivate;
+
+// union becomes private
+#[repr(packed(2))]
+pub union UnionPackedBecomesPrivate {
+    field1: i32,
+}
+
+// union packed unchanged
+#[repr(packed(2))]
+pub union UnionPackedUnchanged {
+    field1: i32,
+}
+
+// union without repr(packed)
+pub union UnionNoPacked {
+    field1: i32,
+}

--- a/test_outputs/query_execution/repr_packed_changed.snap
+++ b/test_outputs/query_execution/repr_packed_changed.snap
@@ -1,0 +1,34 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+---
+{
+  "./test_crates/repr_packed_changed/": [
+    {
+      "name": String("StructPacked1"),
+      "new_packed": String("2"),
+      "old_packed": String("1"),
+      "path": List([
+        String("repr_packed_changed"),
+        String("StructPacked1"),
+      ]),
+      "span_begin_line": Uint64(5),
+      "span_end_line": Uint64(5),
+      "span_filename": String("src/lib.rs"),
+      "type": String("Struct"),
+    },
+    {
+      "name": String("UnionPacked2"),
+      "new_packed": String("4"),
+      "old_packed": String("2"),
+      "path": List([
+        String("repr_packed_changed"),
+        String("UnionPacked2"),
+      ]),
+      "span_begin_line": Uint64(9),
+      "span_end_line": Uint64(11),
+      "span_filename": String("src/lib.rs"),
+      "type": String("Union"),
+    },
+  ],
+}

--- a/test_outputs/query_execution/repr_packed_changed.snap
+++ b/test_outputs/query_execution/repr_packed_changed.snap
@@ -7,7 +7,7 @@ expression: "&query_execution_results"
     {
       "name": String("StructPacked1"),
       "new_packed": String("2"),
-      "old_packed": String("1"),
+      "old_packed": String("4"),
       "path": List([
         String("repr_packed_changed"),
         String("StructPacked1"),

--- a/test_outputs/query_execution/struct_missing.snap
+++ b/test_outputs/query_execution/struct_missing.snap
@@ -1,7 +1,6 @@
 ---
 source: src/query.rs
 expression: "&query_execution_results"
-snapshot_kind: text
 ---
 {
   "./test_crates/move_item_and_reexport/": [
@@ -75,6 +74,20 @@ snapshot_kind: text
       ]),
       "span_begin_line": Uint64(15),
       "span_end_line": Uint64(15),
+      "span_filename": String("src/lib.rs"),
+      "struct_type": String("unit"),
+      "visibility_limit": String("public"),
+    },
+  ],
+  "./test_crates/repr_packed_changed/": [
+    {
+      "name": String("StructPackedBecomesPrivate"),
+      "path": List([
+        String("repr_packed_changed"),
+        String("StructPackedBecomesPrivate"),
+      ]),
+      "span_begin_line": Uint64(22),
+      "span_end_line": Uint64(22),
       "span_filename": String("src/lib.rs"),
       "struct_type": String("unit"),
       "visibility_limit": String("public"),

--- a/test_outputs/query_execution/struct_missing.snap
+++ b/test_outputs/query_execution/struct_missing.snap
@@ -89,7 +89,7 @@ expression: "&query_execution_results"
       "span_begin_line": Uint64(22),
       "span_end_line": Uint64(22),
       "span_filename": String("src/lib.rs"),
-      "struct_type": String("unit"),
+      "struct_type": String("tuple"),
       "visibility_limit": String("public"),
     },
   ],

--- a/test_outputs/query_execution/union_missing.snap
+++ b/test_outputs/query_execution/union_missing.snap
@@ -1,7 +1,6 @@
 ---
 source: src/query.rs
 expression: "&query_execution_results"
-snapshot_kind: text
 ---
 {
   "./test_crates/repr_packed_added_removed/": [
@@ -24,6 +23,19 @@ snapshot_kind: text
       ]),
       "span_begin_line": Uint64(49),
       "span_end_line": Uint64(51),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+  "./test_crates/repr_packed_changed/": [
+    {
+      "name": String("UnionPackedBecomesPrivate"),
+      "path": List([
+        String("repr_packed_changed"),
+        String("UnionPackedBecomesPrivate"),
+      ]),
+      "span_begin_line": Uint64(26),
+      "span_end_line": Uint64(28),
       "span_filename": String("src/lib.rs"),
       "visibility_limit": String("public"),
     },


### PR DESCRIPTION
## Summary
- add `repr_packed_changed` lint for structs and unions whose `repr(packed)` value changes
- cover packed value changes and false positives in new test crate
- update snapshots for affected lints

## Testing
- `cargo insta test --accept`
- `cargo test -- --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68b8e05a2624832d90dda86b14318ebe