### PR TITLE
Add lint for repr(align) additions

### DIFF
--- a/src/lints/repr_align_added.ron
+++ b/src/lints/repr_align_added.ron
@@ -1,0 +1,75 @@
+SemverQuery(
+    id: "repr_align_added",
+    human_readable_name: "repr(align) added",
+    description: "A struct, enum, or union gained a #[repr(align(N))] attribute.",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#repr-align-add"),
+    query: r#"
+    {
+        CrateDiff {
+            current {
+                item {
+                    ... on ImplOwner {
+                        type: __typename @filter(op: "one_of", value: ["$types"]) @output @tag
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @output
+
+                        attribute {
+                            content {
+                                base @filter(op: "=", value: ["$repr"])
+                                argument {
+                                    base @filter(op: "=", value: ["$align"])
+                                }
+                            }
+                        }
+
+                        importable_path {
+                            path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                            end_line @output
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on ImplOwner {
+                        __typename @filter(op: "=", value: ["%type"])
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        attribute @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            content {
+                                base @filter(op: "=", value: ["$repr"])
+                                argument {
+                                    base @filter(op: "=", value: ["$align"])
+                                }
+                            }
+                        }
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "align": "align",
+        "public": "public",
+        "repr": "repr",
+        "true": true,
+        "types": ["Struct", "Enum", "Union"],
+        "zero": 0,
+    },
+    error_message: "repr(align(N)) was added to a type. This changes its alignment and prevents it from being used inside repr(packed) types.",
+    per_result_error_template: Some("{{lowercase type}} {{name}} in {{span_filename}}:{{span_begin_line}}"),
+    witness: None,
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1440,6 +1440,7 @@ add_lints!(
     pub_static_mut_now_immutable,
     pub_static_now_doc_hidden,
     pub_static_now_mutable,
+    repr_align_added,
     repr_c_enum_struct_variant_fields_reordered,
     repr_c_plain_struct_fields_reordered,
     repr_c_removed,

--- a/test_crates/repr_align_added_removed/new/Cargo.toml
+++ b/test_crates/repr_align_added_removed/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "repr_align_added_removed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/repr_align_added_removed/new/src/lib.rs
+++ b/test_crates/repr_align_added_removed/new/src/lib.rs
@@ -1,0 +1,78 @@
+#![no_std]
+
+// should trigger lint for gaining alignment
+#[repr(align(16))]
+pub struct StructBecomesAligned;
+
+// should trigger lint for gaining alignment
+#[repr(align(32))]
+pub enum EnumBecomesAligned {
+    A,
+}
+
+// should trigger lint for gaining alignment
+#[repr(align(64))]
+pub union UnionBecomesAligned {
+    field1: i32,
+}
+
+// should only trigger lint for becoming private
+#[repr(align(8))]
+struct StructBecomesAlignedAndPrivate;
+
+// should only trigger lint for becoming private
+#[repr(align(8))]
+enum EnumBecomesAlignedAndPrivate {
+    A,
+}
+
+// should only trigger lint for becoming private
+#[repr(align(8))]
+union UnionBecomesAlignedAndPrivate {
+    field1: i32,
+}
+
+// no lints expected
+#[repr(align(8))]
+pub struct StructStaysAligned;
+
+// no lints expected
+#[repr(align(8))]
+pub enum EnumStaysAligned {
+    A,
+}
+
+// no lints expected
+#[repr(align(8))]
+pub union UnionStaysAligned {
+    field1: i32,
+}
+
+// no lints expected
+pub struct StructStaysUnaligned;
+
+// no lints expected
+pub enum EnumStaysUnaligned {
+    A,
+}
+
+// no lints expected
+pub union UnionStaysUnaligned {
+    field1: i32,
+}
+
+// no lints expected
+#[repr(align(8))]
+struct PrivateStructBecomesAligned;
+
+// no lints expected
+#[repr(align(8))]
+enum PrivateEnumBecomesAligned {
+    A,
+}
+
+// no lints expected
+#[repr(align(8))]
+union PrivateUnionBecomesAligned {
+    field1: i32,
+}

--- a/test_crates/repr_align_added_removed/old/Cargo.toml
+++ b/test_crates/repr_align_added_removed/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "repr_align_added_removed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/repr_align_added_removed/old/src/lib.rs
+++ b/test_crates/repr_align_added_removed/old/src/lib.rs
@@ -1,0 +1,69 @@
+#![no_std]
+
+// should trigger lint for gaining alignment
+pub struct StructBecomesAligned;
+
+// should trigger lint for gaining alignment
+pub enum EnumBecomesAligned {
+    A,
+}
+
+// should trigger lint for gaining alignment
+pub union UnionBecomesAligned {
+    field1: i32,
+}
+
+// should only trigger lint for becoming private
+pub struct StructBecomesAlignedAndPrivate;
+
+// should only trigger lint for becoming private
+pub enum EnumBecomesAlignedAndPrivate {
+    A,
+}
+
+// should only trigger lint for becoming private
+pub union UnionBecomesAlignedAndPrivate {
+    field1: i32,
+}
+
+// no lints expected
+#[repr(align(8))]
+pub struct StructStaysAligned;
+
+// no lints expected
+#[repr(align(8))]
+pub enum EnumStaysAligned {
+    A,
+}
+
+// no lints expected
+#[repr(align(8))]
+pub union UnionStaysAligned {
+    field1: i32,
+}
+
+// no lints expected
+pub struct StructStaysUnaligned;
+
+// no lints expected
+pub enum EnumStaysUnaligned {
+    A,
+}
+
+// no lints expected
+pub union UnionStaysUnaligned {
+    field1: i32,
+}
+
+// no lints expected
+struct PrivateStructBecomesAligned;
+
+// no lints expected
+enum PrivateEnumBecomesAligned {
+    A,
+}
+
+// no lints expected
+union PrivateUnionBecomesAligned {
+    field1: i32,
+}

--- a/test_outputs/query_execution/enum_missing.snap
+++ b/test_outputs/query_execution/enum_missing.snap
@@ -105,6 +105,19 @@ expression: "&query_execution_results"
       "visibility_limit": String("public"),
     },
   ],
+  "./test_crates/repr_align_added_removed/": [
+    {
+      "name": String("EnumBecomesAlignedAndPrivate"),
+      "path": List([
+        String("repr_align_added_removed"),
+        String("EnumBecomesAlignedAndPrivate"),
+      ]),
+      "span_begin_line": Uint64(20),
+      "span_end_line": Uint64(22),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
   "./test_crates/switch_to_reexport_as_underscore/": [
     {
       "name": String("Enum"),

--- a/test_outputs/query_execution/repr_align_added.snap
+++ b/test_outputs/query_execution/repr_align_added.snap
@@ -1,0 +1,41 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+---
+{
+  "./test_crates/repr_align_added_removed/": [
+    {
+      "name": String("StructBecomesAligned"),
+      "path": List([
+        String("repr_align_added_removed"),
+        String("StructBecomesAligned"),
+      ]),
+      "span_begin_line": Uint64(5),
+      "span_end_line": Uint64(5),
+      "span_filename": String("src/lib.rs"),
+      "type": String("Struct"),
+    },
+    {
+      "name": String("EnumBecomesAligned"),
+      "path": List([
+        String("repr_align_added_removed"),
+        String("EnumBecomesAligned"),
+      ]),
+      "span_begin_line": Uint64(9),
+      "span_end_line": Uint64(11),
+      "span_filename": String("src/lib.rs"),
+      "type": String("Enum"),
+    },
+    {
+      "name": String("UnionBecomesAligned"),
+      "path": List([
+        String("repr_align_added_removed"),
+        String("UnionBecomesAligned"),
+      ]),
+      "span_begin_line": Uint64(15),
+      "span_end_line": Uint64(17),
+      "span_filename": String("src/lib.rs"),
+      "type": String("Union"),
+    },
+  ],
+}

--- a/test_outputs/query_execution/struct_missing.snap
+++ b/test_outputs/query_execution/struct_missing.snap
@@ -1,7 +1,6 @@
 ---
 source: src/query.rs
 expression: "&query_execution_results"
-snapshot_kind: text
 ---
 {
   "./test_crates/move_item_and_reexport/": [
@@ -51,6 +50,20 @@ snapshot_kind: text
       "span_end_line": Uint64(54),
       "span_filename": String("src/lib.rs"),
       "struct_type": String("plain"),
+      "visibility_limit": String("public"),
+    },
+  ],
+  "./test_crates/repr_align_added_removed/": [
+    {
+      "name": String("StructBecomesAlignedAndPrivate"),
+      "path": List([
+        String("repr_align_added_removed"),
+        String("StructBecomesAlignedAndPrivate"),
+      ]),
+      "span_begin_line": Uint64(17),
+      "span_end_line": Uint64(17),
+      "span_filename": String("src/lib.rs"),
+      "struct_type": String("unit"),
       "visibility_limit": String("public"),
     },
   ],

--- a/test_outputs/query_execution/union_missing.snap
+++ b/test_outputs/query_execution/union_missing.snap
@@ -1,9 +1,21 @@
 ---
 source: src/query.rs
 expression: "&query_execution_results"
-snapshot_kind: text
 ---
 {
+  "./test_crates/repr_align_added_removed/": [
+    {
+      "name": String("UnionBecomesAlignedAndPrivate"),
+      "path": List([
+        String("repr_align_added_removed"),
+        String("UnionBecomesAlignedAndPrivate"),
+      ]),
+      "span_begin_line": Uint64(25),
+      "span_end_line": Uint64(27),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
   "./test_crates/repr_packed_added_removed/": [
     {
       "name": String("UnionBecomesPackedAndPrivate"),


### PR DESCRIPTION
## Summary
- add `repr_align_added` lint to report new `repr(align(N))` on public structs, enums, and unions
- test newly aligned and unchanged types
- update snapshots and register lint

## Testing
- `./scripts/regenerate_test_rustdocs.sh repr_align_added_removed`
- `cargo insta test --accept`
- `cargo test -- --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68b8e04f2f04832d842e6be0a3247537