### PR TITLE
Add repr_align_changed lint

### DIFF
--- a/src/lints/repr_align_changed.ron
+++ b/src/lints/repr_align_changed.ron
@@ -74,7 +74,7 @@ SemverQuery(
         "types": ["Struct", "Enum", "Union"],
         "true": true,
     },
-    error_message: "A type's repr(align) changed to a different value.",
+    error_message: "A type's repr(align) changed to a different value. This can break code that depends on the type's alignment or layout.",
     per_result_error_template: Some("{{lowercase type}} {{name}} repr(align({{old_align}})) -> repr(align({{new_align}})) in {{span_filename}}:{{span_begin_line}}"),
     witness: None,
 )

--- a/src/lints/repr_align_changed.ron
+++ b/src/lints/repr_align_changed.ron
@@ -1,0 +1,80 @@
+SemverQuery(
+    id: "repr_align_changed",
+    human_readable_name: "repr(align(N)) changed",
+    description: "A struct, enum, or union changed its repr(align) value.",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#repr-align-n-change"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on ImplOwner {
+                        type: __typename @filter(op: "one_of", value: ["$types"]) @output @tag
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        attribute {
+                            content {
+                                base @filter(op: "=", value: ["$repr"])
+                                argument {
+                                    base @filter(op: "=", value: ["$align"])
+                                    argument {
+                                        old_align: base @output @tag
+                                    }
+                                }
+                            }
+                        }
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on ImplOwner {
+                        __typename @filter(op: "=", value: ["%type"])
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @output
+
+                        attribute {
+                            content {
+                                base @filter(op: "=", value: ["$repr"])
+                                argument {
+                                    base @filter(op: "=", value: ["$align"])
+                                    argument {
+                                        new_align: base @filter(op: "!=", value: ["%old_align"]) @output
+                                    }
+                                }
+                            }
+                        }
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                            end_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "repr": "repr",
+        "align": "align",
+        "types": ["Struct", "Enum", "Union"],
+        "true": true,
+    },
+    error_message: "A type's repr(align) changed to a different value.",
+    per_result_error_template: Some("{{lowercase type}} {{name}} repr(align({{old_align}})) -> repr(align({{new_align}})) in {{span_filename}}:{{span_begin_line}}"),
+    witness: None,
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1440,6 +1440,7 @@ add_lints!(
     pub_static_mut_now_immutable,
     pub_static_now_doc_hidden,
     pub_static_now_mutable,
+    repr_align_changed,
     repr_c_enum_struct_variant_fields_reordered,
     repr_c_plain_struct_fields_reordered,
     repr_c_removed,

--- a/test_crates/repr_align_changed/new/Cargo.toml
+++ b/test_crates/repr_align_changed/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "repr_align_changed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/repr_align_changed/new/src/lib.rs
+++ b/test_crates/repr_align_changed/new/src/lib.rs
@@ -1,0 +1,26 @@
+#![no_std]
+
+#[repr(align(16))]
+pub struct StructAlignChanged;
+
+#[repr(align(32))]
+pub enum EnumAlignChanged {
+    A,
+}
+
+#[repr(align(64))]
+pub union UnionAlignChanged {
+    a: u8,
+}
+
+#[repr(align(16))]
+pub struct StructAlignUnchanged;
+
+#[repr(align(16))]
+struct WasPub;
+
+mod reexported_mod {
+    #[repr(align(16))]
+    pub struct Reexported;
+}
+// `Reexported` is no longer re-exported

--- a/test_crates/repr_align_changed/old/Cargo.toml
+++ b/test_crates/repr_align_changed/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "repr_align_changed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/repr_align_changed/old/src/lib.rs
+++ b/test_crates/repr_align_changed/old/src/lib.rs
@@ -1,0 +1,27 @@
+#![no_std]
+
+#[repr(align(8))]
+pub struct StructAlignChanged;
+
+#[repr(align(8))]
+pub enum EnumAlignChanged {
+    A,
+}
+
+#[repr(align(8))]
+pub union UnionAlignChanged {
+    a: u8,
+}
+
+#[repr(align(16))]
+pub struct StructAlignUnchanged;
+
+#[repr(align(8))]
+pub struct WasPub;
+
+mod reexported_mod {
+    #[repr(align(8))]
+    pub struct Reexported;
+}
+
+pub use reexported_mod::Reexported;

--- a/test_outputs/query_execution/repr_align_changed.snap
+++ b/test_outputs/query_execution/repr_align_changed.snap
@@ -1,0 +1,47 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+---
+{
+  "./test_crates/repr_align_changed/": [
+    {
+      "name": String("StructAlignChanged"),
+      "new_align": String("16"),
+      "old_align": String("8"),
+      "path": List([
+        String("repr_align_changed"),
+        String("StructAlignChanged"),
+      ]),
+      "span_begin_line": Uint64(4),
+      "span_end_line": Uint64(4),
+      "span_filename": String("src/lib.rs"),
+      "type": String("Struct"),
+    },
+    {
+      "name": String("EnumAlignChanged"),
+      "new_align": String("32"),
+      "old_align": String("8"),
+      "path": List([
+        String("repr_align_changed"),
+        String("EnumAlignChanged"),
+      ]),
+      "span_begin_line": Uint64(7),
+      "span_end_line": Uint64(9),
+      "span_filename": String("src/lib.rs"),
+      "type": String("Enum"),
+    },
+    {
+      "name": String("UnionAlignChanged"),
+      "new_align": String("64"),
+      "old_align": String("8"),
+      "path": List([
+        String("repr_align_changed"),
+        String("UnionAlignChanged"),
+      ]),
+      "span_begin_line": Uint64(12),
+      "span_end_line": Uint64(14),
+      "span_filename": String("src/lib.rs"),
+      "type": String("Union"),
+    },
+  ],
+}

--- a/test_outputs/query_execution/struct_missing.snap
+++ b/test_outputs/query_execution/struct_missing.snap
@@ -1,7 +1,6 @@
 ---
 source: src/query.rs
 expression: "&query_execution_results"
-snapshot_kind: text
 ---
 {
   "./test_crates/move_item_and_reexport/": [
@@ -51,6 +50,32 @@ snapshot_kind: text
       "span_end_line": Uint64(54),
       "span_filename": String("src/lib.rs"),
       "struct_type": String("plain"),
+      "visibility_limit": String("public"),
+    },
+  ],
+  "./test_crates/repr_align_changed/": [
+    {
+      "name": String("WasPub"),
+      "path": List([
+        String("repr_align_changed"),
+        String("WasPub"),
+      ]),
+      "span_begin_line": Uint64(20),
+      "span_end_line": Uint64(20),
+      "span_filename": String("src/lib.rs"),
+      "struct_type": String("unit"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("Reexported"),
+      "path": List([
+        String("repr_align_changed"),
+        String("Reexported"),
+      ]),
+      "span_begin_line": Uint64(24),
+      "span_end_line": Uint64(24),
+      "span_filename": String("src/lib.rs"),
+      "struct_type": String("unit"),
       "visibility_limit": String("public"),
     },
   ],


### PR DESCRIPTION
## Summary
- add `repr_align_changed` lint for alignment value changes on public structs, enums, and unions
- cover alignment changes and guard cases in test crate

## Testing
- `cargo insta test`
- `cargo test -- --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68b8e011ada4832d8318f42d1a26f91e