### PR TITLE
Separate report printing from generation

### DIFF
--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -298,15 +298,15 @@ pub(super) fn run_check_release(
     let index_storage = data_storage.create_indexes();
     let adapter = index_storage.create_adapter();
 
-    let mut queries = SemverQuery::all_queries();
-    let all_queries_len = queries.len();
-    queries.retain(|_, query| {
+    let mut queries_to_run = SemverQuery::all_queries();
+    let all_queries_len = queries_to_run.len();
+    queries_to_run.retain(|_, query| {
         !version_change
             .level
             .supports_requirement(overrides.effective_required_update(query))
             && overrides.effective_lint_level(query) > LintLevel::Allow
     });
-    let selected_checks = queries.len();
+    let selected_checks = queries_to_run.len();
     let skipped_checks = all_queries_len - selected_checks;
 
     config.shell_status(
@@ -339,7 +339,7 @@ pub(super) fn run_check_release(
         .expect("print failed");
 
     let checks_start_instant = Instant::now();
-    let lint_results = queries
+    let lint_results = queries_to_run
         .into_par_iter()
         .map(|(_, semver_query)| {
             let start_instant = std::time::Instant::now();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,9 @@ use serde::Serialize;
 use std::collections::{BTreeMap, HashSet};
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
-use check_release::run_check_release;
+use check_release::{LintResult, run_check_release};
 use rustdoc_gen::CrateDataForRustdoc;
 
 pub use config::{FeatureFlag, GlobalConfig};
@@ -696,6 +697,16 @@ pub struct CrateReport {
     detected_bump: ActualSemverUpdate,
     /// Minimum additional bump (on top of `detected_bump`) required to respect semver.
     required_bumps: Bumps,
+    /// Numbers of warning-level lints requiring minor and major bumps
+    suggested_bumps: Bumps,
+    /// Detailed information about individual lints
+    lint_results: Vec<LintResult>,
+    /// How long it took to run the selected queries
+    checks_duration: Duration,
+    /// Number of queries run
+    selected_checks: usize,
+    /// Number of ignored queries
+    skipped_checks: usize,
 }
 
 impl CrateReport {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -666,6 +666,28 @@ fn log_terminal_error(config: &mut GlobalConfig, err: TerminalError) -> anyhow::
     }
 }
 
+/// Summary of version bumps from queries
+#[derive(Debug)]
+struct Bumps {
+    major: u32,
+    minor: u32,
+}
+
+impl Bumps {
+    /// Minimum bump required to respect semver.
+    /// For example, if the crate contains breaking changes, this is [`Some(RequiredSemverUpdate::Major)`].
+    /// If no additional bump is required, this is [`Option::None`].
+    pub fn update_type(&self) -> Option<RequiredSemverUpdate> {
+        if self.major > 0 {
+            Some(RequiredSemverUpdate::Major)
+        } else if self.minor > 0 {
+            Some(RequiredSemverUpdate::Minor)
+        } else {
+            None
+        }
+    }
+}
+
 /// Report of semver check of one crate.
 #[non_exhaustive]
 #[derive(Debug)]
@@ -673,16 +695,14 @@ pub struct CrateReport {
     /// Bump between the current version and the baseline one.
     detected_bump: ActualSemverUpdate,
     /// Minimum additional bump (on top of `detected_bump`) required to respect semver.
-    /// For example, if the crate contains breaking changes, this is [`Some(ReleaseType::Major)`].
-    /// If no additional bump beyond the already-detected one is required, this is [`Option::None`].
-    required_bump: Option<ReleaseType>,
+    required_bumps: Bumps,
 }
 
 impl CrateReport {
     /// Check if the semver check was successful.
     /// `true` if required bump <= detected bump.
     pub fn success(&self) -> bool {
-        match self.required_bump {
+        match self.required_bumps.update_type().map(ReleaseType::from) {
             // If `None`, no additional bump is required.
             None => true,
             // If `Some`, additional bump is required, so the report is not successful.
@@ -713,7 +733,7 @@ impl CrateReport {
     /// Minimum bump required to respect semver.
     /// It's [`Option::None`] if no bump is required beyond the already-detected bump.
     pub fn required_bump(&self) -> Option<ReleaseType> {
-        self.required_bump
+        self.required_bumps.update_type().map(ReleaseType::from)
     }
 
     /// Bump between the current version and the baseline one.


### PR DESCRIPTION
For #1421

This doesn't add any public APIs yet, only avoids printing as a side effect. 
