### PR TITLE
Add lint for functions now returning unit

### DIFF
--- a/src/lints/function_now_returns_unit.ron
+++ b/src/lints/function_now_returns_unit.ron
@@ -1,0 +1,53 @@
+SemverQuery(
+    id: "function_now_returns_unit",
+    human_readable_name: "pub fn now returns unit",
+    description: "A public function that previously returned a value now returns the unit type `()`.",
+    required_update: Major,
+    lint_level: Deny,
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Function {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        return_value {
+                            is_unit @filter(op: "=", value: ["$false"])
+                        }
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Function {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @output
+                        return_value {
+                            is_unit @filter(op: "=", value: ["$true"])
+                        }
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                            end_line @output
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+        "false": false,
+    },
+    error_message: "A public function now returns the unit type `()`, indicating loss of previously returned value.",
+    per_result_error_template: Some("function {{join \"::\" path}} now returns `()`, in {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1401,6 +1401,7 @@ add_lints!(
     function_no_longer_unsafe,
     function_now_const,
     function_now_doc_hidden,
+    function_now_returns_unit,
     function_parameter_count_changed,
     function_requires_different_const_generic_params,
     function_requires_different_generic_type_params,

--- a/test_crates/function_now_returns_unit/new/Cargo.toml
+++ b/test_crates/function_now_returns_unit/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "function_now_returns_unit"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/function_now_returns_unit/new/src/lib.rs
+++ b/test_crates/function_now_returns_unit/new/src/lib.rs
@@ -1,0 +1,8 @@
+#![no_std]
+
+pub fn public_fn() {}
+
+fn private_fn() {}
+
+#[doc(hidden)]
+pub fn doc_hidden_fn() {}

--- a/test_crates/function_now_returns_unit/old/Cargo.toml
+++ b/test_crates/function_now_returns_unit/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "function_now_returns_unit"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/function_now_returns_unit/old/src/lib.rs
+++ b/test_crates/function_now_returns_unit/old/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+
+pub fn public_fn() -> i32 {
+    42
+}
+
+fn private_fn() -> i32 {
+    42
+}
+
+#[doc(hidden)]
+pub fn doc_hidden_fn() -> i32 {
+    42
+}

--- a/test_outputs/query_execution/function_now_returns_unit.snap
+++ b/test_outputs/query_execution/function_now_returns_unit.snap
@@ -1,0 +1,32 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+---
+{
+  "./test_crates/async_impl_future_equivalence/": [
+    {
+      "name": String("switches_to_async"),
+      "path": List([
+        String("async_impl_future_equivalence"),
+        String("switches_to_async"),
+      ]),
+      "span_begin_line": Uint64(12),
+      "span_end_line": Uint64(12),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+  "./test_crates/function_now_returns_unit/": [
+    {
+      "name": String("public_fn"),
+      "path": List([
+        String("function_now_returns_unit"),
+        String("public_fn"),
+      ]),
+      "span_begin_line": Uint64(3),
+      "span_end_line": Uint64(3),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+}


### PR DESCRIPTION
## Summary
- detect when a public function starts returning the unit type `()`
- add test crate covering public, private, and doc-hidden cases

## Testing
- `cargo fmt`
- `cargo test` (old test crate)
- `cargo test` (new test crate)
- `cargo test query::tests_lints::function_now_returns_unit -- --exact --nocapture`
- `cargo test -- --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68be5b0686b4832d8fee3d16de07325c