### PR TITLE
Handle async methods in sealed trait return value lint

### DIFF
--- a/src/lints/pub_api_sealed_trait_method_return_value_added.ron
+++ b/src/lints/pub_api_sealed_trait_method_return_value_added.ron
@@ -1,0 +1,74 @@
+SemverQuery(
+    id: "pub_api_sealed_trait_method_return_value_added",
+    human_readable_name: "method in public API sealed trait return value added",
+    description: "A method in a public API sealed trait now returns a value instead of ().",
+    required_update: Major,
+    lint_level: Warn,
+    reference_link: None,
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        public_api_sealed @filter(op: "=", value: ["$true"])
+                        unconditionally_sealed @filter(op: "!=", value: ["$true"])
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        method {
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+                            method_name: name @output @tag
+                            async @tag(name: "is_async")
+
+                            return_value {
+                                is_unit @filter(op: "=", value: ["$true"])
+                            }
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on Trait {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        # It doesn't matter if the trait is currently sealed.
+                        # If the trait used to be only public-API sealed, downstream impls may exist.
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        method {
+                            name @filter(op: "=", value: ["%method_name"])
+                            public_api_eligible @filter(op: "=", value: ["$true"])
+                            async @filter(op: "=", value: ["%is_async"])
+
+                            return_value {
+                                is_unit @filter(op: "!=", value: ["$true"])
+                            }
+
+                            span_: span @optional {
+                                filename @output
+                                begin_line @output
+                                end_line @output
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+    },
+    error_message: "A method in a trait sealed for public API now returns a value. This isn't a SemVer-major breaking change, but downstream implementers may still be broken.",
+    per_result_error_template: Some("{{join \"::\" path}}::{{method_name}} in {{span_filename}}:{{span_begin_line}}"),
+    witness: None,
+)

--- a/src/lints/pub_api_sealed_trait_method_return_value_added.ron
+++ b/src/lints/pub_api_sealed_trait_method_return_value_added.ron
@@ -68,7 +68,7 @@ SemverQuery(
         "public": "public",
         "true": true,
     },
-    error_message: "A method in a trait sealed for public API now returns a value. This isn't a SemVer-major breaking change, but downstream implementers may still be broken.",
+    error_message: "A method in a public API sealed trait now returns a value. This isn't a SemVer-major breaking change, but if downstream implementers exist anyway, they will be broken.",
     per_result_error_template: Some("{{join \"::\" path}}::{{method_name}} in {{span_filename}}:{{span_begin_line}}"),
     witness: None,
 )

--- a/src/query.rs
+++ b/src/query.rs
@@ -1431,6 +1431,7 @@ add_lints!(
     proc_macro_now_doc_hidden,
     pub_api_sealed_trait_became_unconditionally_sealed,
     pub_api_sealed_trait_became_unsealed,
+    pub_api_sealed_trait_method_return_value_added,
     pub_api_sealed_trait_method_target_feature_removed,
     pub_const_added,
     pub_module_level_const_missing,

--- a/test_crates/pub_api_sealed_trait_method_return_value_added/new/Cargo.toml
+++ b/test_crates/pub_api_sealed_trait_method_return_value_added/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "pub_api_sealed_trait_method_return_value_added"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/pub_api_sealed_trait_method_return_value_added/new/src/lib.rs
+++ b/test_crates/pub_api_sealed_trait_method_return_value_added/new/src/lib.rs
@@ -1,0 +1,70 @@
+#![no_std]
+#![allow(async_fn_in_trait)]
+
+// Trait remains public API sealed but now returns a non-unit value.
+pub mod public_api_sealed_return_value_added {
+    #[doc(hidden)]
+    pub mod hidden {
+        pub trait Sealed {}
+    }
+
+    pub trait ReturnsUnit: hidden::Sealed {
+        fn method(&self) -> u8;
+    }
+
+    #[doc(hidden)]
+    pub trait DocHiddenReturnsUnit: hidden::Sealed {
+        fn method(&self) -> u8;
+    }
+}
+
+pub mod public_api_sealed_async_return_value_added {
+    #[doc(hidden)]
+    pub mod hidden {
+        pub trait Sealed {}
+    }
+
+    pub trait AsyncReturnsUnit: hidden::Sealed {
+        async fn method(&self) -> u8;
+    }
+
+    pub trait WasAsyncReturnsUnit: hidden::Sealed {
+        fn method(&self) -> u8;
+    }
+
+    pub trait BecomeAsyncReturnsUnit: hidden::Sealed {
+        async fn method(&self) -> u8;
+    }
+}
+
+pub mod becomes_unconditionally_sealed {
+    mod hidden {
+        pub trait Sealed {}
+    }
+
+    pub trait ReturnsUnit: hidden::Sealed {
+        fn method(&self) -> u8;
+    }
+}
+
+// Unconditionally sealed traits should still be ignored.
+pub mod unconditionally_sealed_return_value_added {
+    mod hidden {
+        pub trait Sealed {}
+    }
+
+    pub trait ReturnsUnit: hidden::Sealed {
+        fn method(&self) -> u8;
+    }
+}
+
+// Private traits should be ignored by the lint.
+mod private_return_value_added {
+    pub mod hidden {
+        pub trait Sealed {}
+    }
+
+    pub trait ReturnsUnit: hidden::Sealed {
+        fn method(&self) -> u8;
+    }
+}

--- a/test_crates/pub_api_sealed_trait_method_return_value_added/old/Cargo.toml
+++ b/test_crates/pub_api_sealed_trait_method_return_value_added/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "pub_api_sealed_trait_method_return_value_added"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/pub_api_sealed_trait_method_return_value_added/old/src/lib.rs
+++ b/test_crates/pub_api_sealed_trait_method_return_value_added/old/src/lib.rs
@@ -1,0 +1,71 @@
+#![no_std]
+#![allow(async_fn_in_trait)]
+
+// Traits in a public API sealed module that should trigger the lint.
+pub mod public_api_sealed_return_value_added {
+    #[doc(hidden)]
+    pub mod hidden {
+        pub trait Sealed {}
+    }
+
+    pub trait ReturnsUnit: hidden::Sealed {
+        fn method(&self);
+    }
+
+    #[doc(hidden)]
+    pub trait DocHiddenReturnsUnit: hidden::Sealed {
+        fn method(&self);
+    }
+}
+
+pub mod public_api_sealed_async_return_value_added {
+    #[doc(hidden)]
+    pub mod hidden {
+        pub trait Sealed {}
+    }
+
+    pub trait AsyncReturnsUnit: hidden::Sealed {
+        async fn method(&self);
+    }
+
+    pub trait WasAsyncReturnsUnit: hidden::Sealed {
+        async fn method(&self);
+    }
+
+    pub trait BecomeAsyncReturnsUnit: hidden::Sealed {
+        fn method(&self);
+    }
+}
+
+pub mod becomes_unconditionally_sealed {
+    #[doc(hidden)]
+    pub mod hidden {
+        pub trait Sealed {}
+    }
+
+    pub trait ReturnsUnit: hidden::Sealed {
+        fn method(&self);
+    }
+}
+
+// Traits that are unconditionally sealed should be ignored by the lint.
+pub mod unconditionally_sealed_return_value_added {
+    mod hidden {
+        pub trait Sealed {}
+    }
+
+    pub trait ReturnsUnit: hidden::Sealed {
+        fn method(&self);
+    }
+}
+
+// Private traits should be ignored by the lint.
+mod private_return_value_added {
+    pub mod hidden {
+        pub trait Sealed {}
+    }
+
+    pub trait ReturnsUnit: hidden::Sealed {
+        fn method(&self);
+    }
+}

--- a/test_outputs/query_execution/pub_api_sealed_trait_became_unconditionally_sealed.snap
+++ b/test_outputs/query_execution/pub_api_sealed_trait_became_unconditionally_sealed.snap
@@ -91,6 +91,20 @@ expression: "&query_execution_results"
       "visibility_limit": String("public"),
     },
   ],
+  "./test_crates/pub_api_sealed_trait_method_return_value_added/": [
+    {
+      "name": String("ReturnsUnit"),
+      "path": List([
+        String("pub_api_sealed_trait_method_return_value_added"),
+        String("becomes_unconditionally_sealed"),
+        String("ReturnsUnit"),
+      ]),
+      "span_begin_line": Uint64(45),
+      "span_end_line": Uint64(47),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
   "./test_crates/trait_method_target_feature_removed/": [
     {
       "name": String("FeatureRemovedFromPubApiSealedToUnconditional"),

--- a/test_outputs/query_execution/pub_api_sealed_trait_method_return_value_added.snap
+++ b/test_outputs/query_execution/pub_api_sealed_trait_method_return_value_added.snap
@@ -38,4 +38,16 @@ expression: "&query_execution_results"
       "span_filename": String("src/lib.rs"),
     },
   ],
+  "./test_crates/trait_method_return_value_added/": [
+    {
+      "method_name": String("method"),
+      "path": List([
+        String("trait_method_return_value_added"),
+        String("AlreadyPublicApiSealed"),
+      ]),
+      "span_begin_line": Uint64(33),
+      "span_end_line": Uint64(33),
+      "span_filename": String("src/lib.rs"),
+    },
+  ],
 }

--- a/test_outputs/query_execution/pub_api_sealed_trait_method_return_value_added.snap
+++ b/test_outputs/query_execution/pub_api_sealed_trait_method_return_value_added.snap
@@ -1,0 +1,41 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+---
+{
+  "./test_crates/pub_api_sealed_trait_method_return_value_added/": [
+    {
+      "method_name": String("method"),
+      "path": List([
+        String("pub_api_sealed_trait_method_return_value_added"),
+        String("public_api_sealed_return_value_added"),
+        String("ReturnsUnit"),
+      ]),
+      "span_begin_line": Uint64(12),
+      "span_end_line": Uint64(12),
+      "span_filename": String("src/lib.rs"),
+    },
+    {
+      "method_name": String("method"),
+      "path": List([
+        String("pub_api_sealed_trait_method_return_value_added"),
+        String("public_api_sealed_async_return_value_added"),
+        String("AsyncReturnsUnit"),
+      ]),
+      "span_begin_line": Uint64(28),
+      "span_end_line": Uint64(28),
+      "span_filename": String("src/lib.rs"),
+    },
+    {
+      "method_name": String("method"),
+      "path": List([
+        String("pub_api_sealed_trait_method_return_value_added"),
+        String("becomes_unconditionally_sealed"),
+        String("ReturnsUnit"),
+      ]),
+      "span_begin_line": Uint64(46),
+      "span_end_line": Uint64(46),
+      "span_filename": String("src/lib.rs"),
+    },
+  ],
+}

--- a/test_outputs/query_execution/trait_missing.snap
+++ b/test_outputs/query_execution/trait_missing.snap
@@ -1,7 +1,6 @@
 ---
 source: src/query.rs
 expression: "&query_execution_results"
-snapshot_kind: text
 ---
 {
   "./test_crates/switch_to_reexport_as_underscore/": [

--- a/test_outputs/query_execution/trait_no_longer_dyn_compatible.snap
+++ b/test_outputs/query_execution/trait_no_longer_dyn_compatible.snap
@@ -1,7 +1,6 @@
 ---
 source: src/query.rs
 expression: "&query_execution_results"
-snapshot_kind: text
 ---
 {
   "./test_crates/inherent_associated_pub_const_missing/": [
@@ -24,6 +23,20 @@ snapshot_kind: text
       ]),
       "span_begin_line": Uint64(70),
       "span_end_line": Uint64(72),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+  "./test_crates/pub_api_sealed_trait_method_return_value_added/": [
+    {
+      "name": String("BecomeAsyncReturnsUnit"),
+      "path": List([
+        String("pub_api_sealed_trait_method_return_value_added"),
+        String("public_api_sealed_async_return_value_added"),
+        String("BecomeAsyncReturnsUnit"),
+      ]),
+      "span_begin_line": Uint64(35),
+      "span_end_line": Uint64(37),
       "span_filename": String("src/lib.rs"),
       "visibility_limit": String("public"),
     },


### PR DESCRIPTION
## Summary
- ensure the sealed trait return-value lint tracks async methods and no longer requires the current trait to stay public-API sealed
- extend the pub_api_sealed_trait_method_return_value_added test crate with async examples, a newly unconditionally sealed trait, and edition 2024
- refresh query snapshots for the new coverage and related lint interactions

## Testing
- `cargo fmt`
- `cd test_crates/pub_api_sealed_trait_method_return_value_added/old && cargo test -- --quiet`
- `cd test_crates/pub_api_sealed_trait_method_return_value_added/new && cargo test -- --quiet`
- `INSTA_UPDATE=always cargo test -- --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68be5c235998832da2f6061bbee4c2aa