### PR TITLE
Remove unused atty dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,17 +160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,7 +306,6 @@ dependencies = [
  "anstyle",
  "anyhow",
  "assert_cmd",
- "atty",
  "bugreport",
  "cargo-config2",
  "cargo_metadata",
@@ -1859,15 +1847,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "home"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ ron = "0.11.0"
 serde = { version = "1.0.217", features = ["derive"] }
 semver = "1.0.25"
 handlebars = "6.3.0"
-atty = "0.2.14"
 clap-cargo = { version = "0.17.0", features = ["cargo_metadata"] }
 ignore = "0.4.23"
 clap-verbosity-flag = "3.0.2"


### PR DESCRIPTION
`atty` doesn't seem to be used.