### PR TITLE
Add workflow to auto-apply lint fixes

### DIFF
--- a/.github/workflows/lint_fix.yml
+++ b/.github/workflows/lint_fix.yml
@@ -1,0 +1,120 @@
+name: Apply lint fixes
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  apply-lint-fixes:
+    if: github.repository_owner == 'obi1kenobi'
+    runs-on: ubuntu-latest
+    env:
+      OLD_BRANCH: "${{ github.ref_name }}"
+      NEW_BRANCH: "${{ github.ref_name }}-lint-fix"
+      PR_TITLE: "chore: apply lint fixes for ${{ github.ref_name }}"
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.RUST_UPDATER_GITHUB_TOKEN }}
+          ref: ${{ env.OLD_BRANCH }}
+          persist-credentials: true
+
+      - name: Install rust
+        id: toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          rustflags: ""
+          cache: false
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo clippy fix
+        run: |
+          set -euxo pipefail
+          cargo clippy --all-targets --fix --allow-dirty --allow-staged
+
+      - name: Run cargo fmt
+        run: |
+          set -euxo pipefail
+          cargo fmt
+
+      - name: Check for changes
+        id: changes
+        run: |
+          set -euo pipefail
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "dirty=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dirty=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Prepare commit
+        if: steps.changes.outputs.dirty == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          CHANGES="$(git status --short)"
+          git switch --force-create "$NEW_BRANCH"
+          git add -A
+          git commit --no-verify -m "chore: apply lint fixes"
+          {
+            echo "$PR_TITLE"
+            echo
+            echo "The workflow applied lint fixes on branch $OLD_BRANCH."
+            if [[ -n "$CHANGES" ]]; then
+              echo
+              echo "Changes:"
+              echo '```'
+              echo "$CHANGES"
+              echo '```'
+            fi
+          } > body.md
+
+      - name: Push branch
+        if: steps.changes.outputs.dirty == 'true'
+        run: |
+          set -euo pipefail
+          git push --force --set-upstream origin "$NEW_BRANCH"
+
+      - name: Edit existing open pull request
+        if: steps.changes.outputs.dirty == 'true'
+        id: edit
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.RUST_UPDATER_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if STATE="$(gh pr view "$NEW_BRANCH" --repo "$GITHUB_REPOSITORY" --json state --jq '.state')"; then
+            if [[ "$STATE" != "OPEN" ]]; then
+              exit 1
+            fi
+            gh pr edit "$NEW_BRANCH" \
+              --title "$PR_TITLE" \
+              --body-file body.md \
+              --repo "$GITHUB_REPOSITORY" \
+              --base "$OLD_BRANCH"
+          else
+            exit 1
+          fi
+
+      - name: Open new pull request
+        if: steps.changes.outputs.dirty == 'true' && steps.edit.outcome != 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.RUST_UPDATER_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh pr create \
+            --title "$PR_TITLE" \
+            --body-file body.md \
+            --repo "$GITHUB_REPOSITORY" \
+            --base "$OLD_BRANCH"
+
+      - name: No lint fixes needed
+        if: steps.changes.outputs.dirty != 'true'
+        run: echo "No lint fixes were necessary."

--- a/.github/workflows/lint_fix.yml
+++ b/.github/workflows/lint_fix.yml
@@ -2,6 +2,11 @@ name: Apply lint fixes
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to update snapshots on
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -12,9 +17,9 @@ jobs:
     if: github.repository_owner == 'obi1kenobi'
     runs-on: ubuntu-latest
     env:
-      OLD_BRANCH: "${{ github.ref_name }}"
-      NEW_BRANCH: "${{ github.ref_name }}-lint-fix"
-      PR_TITLE: "chore: apply lint fixes for ${{ github.ref_name }}"
+      OLD_BRANCH: "${{ github.event.inputs.branch }}"
+      NEW_BRANCH: "${{ github.event.inputs.branch }}-lint-fix"
+      PR_TITLE: "chore: apply lint fixes for ${{ github.event.inputs.branch }}"
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- add a manually triggered workflow that runs clippy --fix and fmt on the chosen branch
- have the workflow commit any resulting changes onto a new branch named after the original branch with a -lint-fix suffix
- automatically push the fixes branch and open or update a pull request back to the original branch

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e172c91c64832d845a27d8797275d5