### PR TITLE
Add `method_receiver_mut_ref_became_owned` lint.

### DIFF
--- a/src/lints/method_receiver_mut_ref_became_owned.ron
+++ b/src/lints/method_receiver_mut_ref_became_owned.ron
@@ -1,0 +1,79 @@
+SemverQuery(
+    id: "method_receiver_mut_ref_became_owned",
+    human_readable_name: "method receiver changed from mutable reference to owned value",
+    description: "A method's receiver changed from &mut self to self, transferring ownership as part of the call.",
+    required_update: Major,
+    lint_level: Deny,
+    reference_link: Some("https://doc.rust-lang.org/reference/items/associated-items.html#methods"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on ImplOwner {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        owner_type: __typename @tag @output
+                        name @output
+
+                        importable_path {
+                            path @tag @output
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        inherent_impl {
+                            method {
+                                visibility_limit @filter(op: "=", value: ["$public"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+                                method_name: name @output @tag
+
+                                receiver {
+                                    by_mut_reference @filter(op: "=", value: ["$true"])
+                                    receiver_kind: kind @tag @output
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on ImplOwner {
+                        __typename @filter(op: "=", value: ["%owner_type"])
+                        visibility_limit @filter(op: "=", value: ["$public"])
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        inherent_impl {
+                            method {
+                                visibility_limit @filter(op: "=", value: ["$public"])
+                                name @filter(op: "=", value: ["%method_name"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+
+                                receiver {
+                                    by_value @filter(op: "=", value: ["$true"])
+                                    kind @filter(op: "=", value: ["%receiver_kind"])
+                                }
+
+                                span_: span @optional {
+                                    filename @output
+                                    begin_line @output
+                                    end_line @output
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "true": true,
+    },
+    error_message: "A method's receiver changed from a mutable reference to an owned value. Ownership is transferred as part of the call, which is a breaking change.",
+    per_result_error_template: Some("{{join \"::\" path}}::{{method_name}} now takes {{receiver_kind}}, not &mut {{receiver_kind}}, in {{span_filename}}:{{span_begin_line}}"),
+    witness: None,
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1628,6 +1628,7 @@ add_lints!(
     macro_no_longer_exported,
     macro_now_doc_hidden,
     method_parameter_count_changed,
+    method_receiver_mut_ref_became_owned,
     method_receiver_ref_became_mut,
     method_receiver_ref_became_owned,
     method_requires_different_const_generic_params,

--- a/test_outputs/query_execution/method_receiver_mut_ref_became_owned.snap
+++ b/test_outputs/query_execution/method_receiver_mut_ref_became_owned.snap
@@ -1,0 +1,34 @@
+---
+source: src/query.rs
+expression: "&query_execution_results"
+---
+{
+  "./test_crates/method_receiver_changes/": [
+    {
+      "method_name": String("rcbox_refmut_to_owned"),
+      "name": String("PublicStruct"),
+      "owner_type": String("Struct"),
+      "path": List([
+        String("method_receiver_changes"),
+        String("PublicStruct"),
+      ]),
+      "receiver_kind": String("Rc<Box<Self>>"),
+      "span_begin_line": Uint64(20),
+      "span_end_line": Uint64(22),
+      "span_filename": String("src/lib.rs"),
+    },
+    {
+      "method_name": String("rcbox_refmut_to_owned"),
+      "name": String("PublicEnum"),
+      "owner_type": String("Enum"),
+      "path": List([
+        String("method_receiver_changes"),
+        String("PublicEnum"),
+      ]),
+      "receiver_kind": String("Rc<Box<Self>>"),
+      "span_begin_line": Uint64(74),
+      "span_end_line": Uint64(76),
+      "span_filename": String("src/lib.rs"),
+    },
+  ],
+}


### PR DESCRIPTION
Resolves #1225.
