### PR TITLE
Weekly `cargo update` of dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "3.2.1"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824f08d01d0f496b3eca4f001a13cf17690a6ee930043d20817f547455fd98f8"
+checksum = "baf68cef89750956493a66a10f512b9e58d9db21f2a573c079c0bdf1207a54a7"
 dependencies = [
  "autocfg",
 ]
@@ -2141,9 +2141,9 @@ checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
 
 [[package]]
 name = "jiff"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
+checksum = "a87d9b8105c23642f50cbbae03d1f75d8422c5cb98ce7ee9271f7ff7505be6b8"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -2156,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
+checksum = "b787bebb543f8969132630c51fd0afab173a86c6abae56ff3b9e5e3e3f9f6e58"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3731,9 +3731,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "55.3.3"
+version = "55.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8321b467209acfc50033d1a1e3dcef57bc1ffc06edd35d35864762afcc267b"
+checksum = "2b177d7e975679d4df300f0634a52bc05c9dfed700c3eebf0c8d8079b2ac3849"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
@@ -3746,9 +3746,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "56.2.3"
+version = "56.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b15dd1709925f26a71445419b065c039f1ed60f0ba8006fb2d0915efdcb459d"
+checksum = "2601442a0665d6064f536b32773e2b8844a978d97374775a2747d77ce8aa865a"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
@@ -3761,9 +3761,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "57.0.3"
+version = "57.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7950740304be32cbc465ff05b4c8e22a9e6575684cca74e32a5d673168194398"
+checksum = "4fd815729744c29ab8b89459c7da261f38b74831d44658a0809ef5d6e3ad2027"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
@@ -3814,9 +3814,9 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "trustfall",
- "trustfall-rustdoc-adapter 55.3.3",
- "trustfall-rustdoc-adapter 56.2.3",
- "trustfall-rustdoc-adapter 57.0.3",
+ "trustfall-rustdoc-adapter 55.3.4",
+ "trustfall-rustdoc-adapter 56.2.4",
+ "trustfall-rustdoc-adapter 57.0.4",
  "trustfall_core",
 ]
 
@@ -4489,6 +4489,6 @@ checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e404bcd8afdaf006e529269d3e85a743f9480c3cef60034d77860d02964f3ba"
+checksum = "d0095ecd462946aa3927d9297b63ef82fb9a5316d7a37d134eeb36e58228615a"


### PR DESCRIPTION
Automation to keep dependencies in `Cargo.lock` current.

The following is the output from `cargo update`:

```txt
     Locking 7 packages to latest Rust 1.90 compatible versions
    Updating fs-err v3.2.1 -> v3.2.2
    Updating jiff v0.2.16 -> v0.2.17
    Updating jiff-static v0.2.16 -> v0.2.17
    Removing trustfall-rustdoc-adapter v55.3.3
    Removing trustfall-rustdoc-adapter v56.2.3
    Removing trustfall-rustdoc-adapter v57.0.3
      Adding trustfall-rustdoc-adapter v55.3.4
      Adding trustfall-rustdoc-adapter v56.2.4
      Adding trustfall-rustdoc-adapter v57.0.4
    Updating zmij v0.1.7 -> v0.1.9
note: pass `--verbose` to see 2 unchanged dependencies behind latest
```
