### PR TITLE
New lint: struct_no_private_fields_no_longer_non_exhaustive

### DIFF
--- a/src/lints/struct_no_private_fields_no_longer_non_exhaustive.ron
+++ b/src/lints/struct_no_private_fields_no_longer_non_exhaustive.ron
@@ -1,0 +1,61 @@
+SemverQuery(
+    id: "struct_no_private_fields_no_longer_non_exhaustive",
+    human_readable_name: "struct with no private fields no longer #[non_exhaustive]",
+    description: "A pub struct with no private fields is no longer #[non_exhaustive]. It is now possible to exhaustively list all of its fields outside of its crate, potentially causing breaking changes if new fields are added.",
+    required_update: Minor,
+    lint_level: Allow,
+    reference_link: Some("https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute"),
+    query: r#"
+    {
+        CrateDiff {
+            current {
+                item {
+                    ... on Struct {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        name @output
+                        struct_type @output
+
+                        attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                            end_line @output
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on Struct {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        attrs @filter(op: "contains", value: ["$non_exhaustive"])
+
+                        field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            visibility_limit @filter(op: "!=", value: ["$public"])
+                        }
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "non_exhaustive": "#[non_exhaustive]",
+        "true": true,
+        "zero": 0,
+    },
+    error_message: "A pub struct with no private fields is no longer #[non_exhaustive]. It is now possible to exhaustively list all of its fields outside of its crate, potentially causing breaking changes if new fields are added.",
+    per_result_error_template: Some("struct {{name}} in {{span_filename}}:{{span_begin_line}}"),
+    witness: None,
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1725,6 +1725,7 @@ add_lints!(
     struct_missing,
     struct_must_use_added,
     struct_must_use_removed,
+    struct_no_private_fields_no_longer_non_exhaustive,
     struct_now_doc_hidden,
     struct_pub_field_missing,
     struct_pub_field_now_doc_hidden,

--- a/test_crates/struct_no_private_fields_no_longer_non_exhaustive/new/Cargo.toml
+++ b/test_crates/struct_no_private_fields_no_longer_non_exhaustive/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "struct_no_private_fields_no_longer_non_exhaustive"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/struct_no_private_fields_no_longer_non_exhaustive/new/src/lib.rs
+++ b/test_crates/struct_no_private_fields_no_longer_non_exhaustive/new/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+
+pub struct NoFields;
+pub struct NoFieldsTuple();
+pub struct NoFieldsStruct {}
+
+pub struct Tuple(pub u8);
+pub struct Struct {
+    pub inner: u8,
+    pub another: Tuple,
+}
+
+pub struct WithPrivate {
+    pub(self) inner: u8,
+}

--- a/test_crates/struct_no_private_fields_no_longer_non_exhaustive/old/Cargo.toml
+++ b/test_crates/struct_no_private_fields_no_longer_non_exhaustive/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "struct_no_private_fields_no_longer_non_exhaustive"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/struct_no_private_fields_no_longer_non_exhaustive/old/src/lib.rs
+++ b/test_crates/struct_no_private_fields_no_longer_non_exhaustive/old/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+
+#[non_exhaustive]
+pub struct NoFields;
+#[non_exhaustive]
+pub struct NoFieldsTuple();
+#[non_exhaustive]
+pub struct NoFieldsStruct {}
+
+#[non_exhaustive]
+pub struct Tuple(pub u8);
+#[non_exhaustive]
+pub struct Struct {
+    pub inner: u8,
+    pub another: Tuple,
+}
+
+#[non_exhaustive]
+pub struct WithPrivate {
+    pub(self) inner: u8,
+}

--- a/test_outputs/query_execution/struct_no_private_fields_no_longer_non_exhaustive.snap
+++ b/test_outputs/query_execution/struct_no_private_fields_no_longer_non_exhaustive.snap
@@ -1,0 +1,67 @@
+---
+source: src/query.rs
+---
+{
+  "./test_crates/struct_no_private_fields_no_longer_non_exhaustive/": [
+    {
+      "name": String("NoFields"),
+      "path": List([
+        String("struct_no_private_fields_no_longer_non_exhaustive"),
+        String("NoFields"),
+      ]),
+      "span_begin_line": Uint64(3),
+      "span_end_line": Uint64(3),
+      "span_filename": String("src/lib.rs"),
+      "struct_type": String("unit"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("NoFieldsTuple"),
+      "path": List([
+        String("struct_no_private_fields_no_longer_non_exhaustive"),
+        String("NoFieldsTuple"),
+      ]),
+      "span_begin_line": Uint64(4),
+      "span_end_line": Uint64(4),
+      "span_filename": String("src/lib.rs"),
+      "struct_type": String("tuple"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("NoFieldsStruct"),
+      "path": List([
+        String("struct_no_private_fields_no_longer_non_exhaustive"),
+        String("NoFieldsStruct"),
+      ]),
+      "span_begin_line": Uint64(5),
+      "span_end_line": Uint64(5),
+      "span_filename": String("src/lib.rs"),
+      "struct_type": String("plain"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("Tuple"),
+      "path": List([
+        String("struct_no_private_fields_no_longer_non_exhaustive"),
+        String("Tuple"),
+      ]),
+      "span_begin_line": Uint64(7),
+      "span_end_line": Uint64(7),
+      "span_filename": String("src/lib.rs"),
+      "struct_type": String("tuple"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("Struct"),
+      "path": List([
+        String("struct_no_private_fields_no_longer_non_exhaustive"),
+        String("Struct"),
+      ]),
+      "span_begin_line": Uint64(8),
+      "span_end_line": Uint64(11),
+      "span_filename": String("src/lib.rs"),
+      "struct_type": String("plain"),
+      "visibility_limit": String("public"),
+    },
+  ],
+}


### PR DESCRIPTION
- As suggested in #949
- Allow-by-default
- Name is bikesheddable