### PR TITLE
Add minor lint for removing #[non_exhaustive] from public struct

### DIFF
--- a/src/lints/struct_no_longer_non_exhaustive.ron
+++ b/src/lints/struct_no_longer_non_exhaustive.ron
@@ -1,0 +1,66 @@
+SemverQuery(
+    id: "struct_no_longer_non_exhaustive",
+    human_readable_name: "struct no longer #[non_exhaustive]",
+    description: "A pub struct is no longer #[non_exhaustive]. It can now be constructed using a struct literal outside its crate.",
+    required_update: Minor,
+    lint_level: Allow,
+    reference_link: Some("https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute"),
+    query: r#"
+    {
+        CrateDiff {
+            current {
+                item {
+                    ... on Struct {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        name @output
+                        struct_type @output
+
+                        attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
+
+                        # ensure all fields are public (no private fields).
+                        field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            visibility_limit @filter(op: "!=", value: ["$public"])
+                        }
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                            end_line @output
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on Struct {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        attrs @filter(op: "contains", value: ["$non_exhaustive"])
+
+                        # ensure all fields are public (no private fields).
+                        field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            visibility_limit @filter(op: "!=", value: ["$public"])
+                        }
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "non_exhaustive": "#[non_exhaustive]",
+        "true": true,
+        "zero": 0,
+    },
+    error_message: "A public struct is no longer #[non_exhaustive]. It can newly be constructed using a struct literal outside its crate.",
+    per_result_error_template: Some("struct {{name}} in {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1725,6 +1725,7 @@ add_lints!(
     struct_missing,
     struct_must_use_added,
     struct_must_use_removed,
+    struct_no_longer_non_exhaustive,
     struct_now_doc_hidden,
     struct_pub_field_missing,
     struct_pub_field_now_doc_hidden,

--- a/test_crates/struct_no_longer_non_exhaustive/new/Cargo.toml
+++ b/test_crates/struct_no_longer_non_exhaustive/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "struct_no_longer_non_exhaustive"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/struct_no_longer_non_exhaustive/new/src/lib.rs
+++ b/test_crates/struct_no_longer_non_exhaustive/new/src/lib.rs
@@ -1,0 +1,34 @@
+#![no_std]
+
+// This struct was marked #[non_exhaustive] and has no private fields. It should trigger this lint.
+pub struct MyStruct {
+    pub field: i32,
+}
+
+// Changes in a private struct should not be reported.
+struct PrivateStruct {
+    pub field: i32,
+}
+
+// This struct was not marked #[non_exhaustive] previously.
+pub struct AlwaysExhaustiveStruct {
+    pub field: i32,
+}
+
+// This struct is still non_exhaustive.
+#[non_exhaustive]
+pub struct NeverExhaustiveStruct {
+    pub field: i32,
+}
+
+// Changes in a struct with private fields should not be reported.
+pub struct StructWithPrivateField {
+    pub pub_field: i32,
+    priv_field: i32,
+}
+
+// The struct gained a private field while losing #[non_exhaustive] (should not be reported).
+pub struct GainedPrivateField {
+    pub pub_field: i32,
+    new_private_field: i32,
+}

--- a/test_crates/struct_no_longer_non_exhaustive/old/Cargo.toml
+++ b/test_crates/struct_no_longer_non_exhaustive/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "struct_no_longer_non_exhaustive"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/struct_no_longer_non_exhaustive/old/src/lib.rs
+++ b/test_crates/struct_no_longer_non_exhaustive/old/src/lib.rs
@@ -1,0 +1,31 @@
+#![no_std]
+
+#[non_exhaustive]
+pub struct MyStruct {
+    pub field: i32,
+}
+
+#[non_exhaustive]
+struct PrivateStruct {
+    pub field: i32,
+}
+
+pub struct AlwaysExhaustiveStruct {
+    pub field: i32,
+}
+
+#[non_exhaustive]
+pub struct NeverExhaustiveStruct {
+    pub field: i32,
+}
+
+#[non_exhaustive]
+pub struct StructWithPrivateField {
+    pub pub_field: i32,
+    priv_field: i32,
+}
+
+#[non_exhaustive]
+pub struct GainedPrivateField {
+    pub pub_field: i32,
+}

--- a/test_outputs/query_execution/struct_no_longer_non_exhaustive.snap
+++ b/test_outputs/query_execution/struct_no_longer_non_exhaustive.snap
@@ -1,0 +1,19 @@
+---
+source: src/query.rs
+---
+{
+  "./test_crates/struct_no_longer_non_exhaustive/": [
+    {
+      "name": String("MyStruct"),
+      "path": List([
+        String("struct_no_longer_non_exhaustive"),
+        String("MyStruct"),
+      ]),
+      "span_begin_line": Uint64(4),
+      "span_end_line": Uint64(6),
+      "span_filename": String("src/lib.rs"),
+      "struct_type": String("plain"),
+      "visibility_limit": String("public"),
+    },
+  ],
+}


### PR DESCRIPTION
(with the struct having all public fields)

This makes the struct constructible via struct literal, which may or may not have been intended.

An example of something that should trigger this lint:

```diff
-#[non_exhaustive]
pub struct MyStruct {
    pub field: i32,
}
```

Context:
[Unchecked bullet in list of opt-in minor lints](https://github.com/obi1kenobi/cargo-semver-checks/issues/949)

I did my best also to follow the patterns in a similar lint addition (for enums): https://github.com/obi1kenobi/cargo-semver-checks/pull/1186

---

edit: my apologies, I'm just seeing that https://github.com/obi1kenobi/cargo-semver-checks/pull/1549 was recently opened too. I'm happy to close my PR in favor of that once since it was first -- I can take a look through some other open issues!