### PR TITLE
specify cargo-binstall metadata for faster download

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,10 @@ codegen-units = 1
 
 [features]
 default = []
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"


### PR DESCRIPTION
If these metadata aren't specified, `cargo-binstall` checks on github various attempts of the download format.

Specifying these saves API calls.

## How to test

Do the following with and without these metadata and check that the log lines are fewer, which demonstrates that cargo-binstall is doing less operations.

```
cd cargo-semver-checks
cargo-binstall cargo-semver-checks@0.46.0 --manifest-path ./Cargo.toml  --log-level debug --force
```

On my laptop, with this PR I get 80 lines of logs. Without this PR, I get 1243 lines.
