### PR TITLE
Add minor lint for losing all non-`pub` fields

### DIFF
--- a/src/lints/struct_no_longer_has_non_pub_fields.ron
+++ b/src/lints/struct_no_longer_has_non_pub_fields.ron
@@ -1,0 +1,68 @@
+SemverQuery(
+    id: "struct_no_longer_has_non_pub_fields",
+    human_readable_name: "struct no longer has non-pub fields",
+    description: "A (exhaustive) pub struct has lost all its non-pub fields and can now be constructed using a struct literal",
+    required_update: Minor,
+    lint_level: Allow,
+    reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-add"),
+    query: r#"
+    {
+        CrateDiff {
+            current {
+                item {
+                    ... on Struct {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        # must ignore non_exhaustive structs
+                        attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
+
+                        # Current has no non-pub fields (all fields are public)
+                        field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            visibility_limit @filter(op: "!=", value: ["$public"])
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                            end_line @output
+                        }
+                    }
+                }
+            }
+            baseline {
+                item {
+                    ... on Struct {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @output
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        # must ignore non_exhaustive structs
+                        attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
+
+                        # Baseline had at least one non-pub field
+                        field @fold @transform(op: "count") @filter(op: ">", value: ["$zero"]) {
+                            visibility_limit @filter(op: "!=", value: ["$public"])
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "non_exhaustive": "#[non_exhaustive]",
+        "true": true,
+        "zero": 0,
+    },
+    error_message: "A pub struct has lost all its non-pub fields and can now be constructed using a struct literal.",
+    per_result_error_template: Some("struct {{name}} in {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1727,6 +1727,7 @@ add_lints!(
     struct_must_use_added,
     struct_must_use_removed,
     struct_no_longer_non_exhaustive,
+    struct_no_longer_has_non_pub_fields,
     struct_now_doc_hidden,
     struct_pub_field_missing,
     struct_pub_field_now_doc_hidden,

--- a/test_crates/struct_no_longer_has_non_pub_fields/new/Cargo.toml
+++ b/test_crates/struct_no_longer_has_non_pub_fields/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "struct_no_longer_has_non_pub_fields"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/struct_no_longer_has_non_pub_fields/new/src/lib.rs
+++ b/test_crates/struct_no_longer_has_non_pub_fields/new/src/lib.rs
@@ -1,0 +1,24 @@
+#![no_std]
+
+pub struct MyStruct {
+    pub pub_field: i32,
+    // private_field removed - now constructible!
+}
+
+pub struct AlwaysNonPubFieldStruct {
+    pub pub_field: i32,
+    private_field: i32,
+}
+
+pub struct AlwaysPubFieldStruct {
+    pub pub_field: i32,
+}
+
+struct NonPubStruct {
+    pub pub_field: i32,
+}
+
+#[non_exhaustive]
+pub struct NonExhaustiveStruct {
+    pub pub_field: i32,
+}

--- a/test_crates/struct_no_longer_has_non_pub_fields/old/Cargo.toml
+++ b/test_crates/struct_no_longer_has_non_pub_fields/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "struct_no_longer_has_non_pub_fields"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/struct_no_longer_has_non_pub_fields/old/src/lib.rs
+++ b/test_crates/struct_no_longer_has_non_pub_fields/old/src/lib.rs
@@ -1,0 +1,26 @@
+#![no_std]
+
+pub struct MyStruct {
+    pub pub_field: i32,
+    private_field: i32,
+}
+
+pub struct AlwaysNonPubFieldStruct {
+    pub pub_field: i32,
+    private_field: i32,
+}
+
+pub struct AlwaysPubFieldStruct {
+    pub pub_field: i32,
+}
+
+struct NonPubStruct {
+    pub pub_field: i32,
+    private_field: i32,
+}
+
+#[non_exhaustive]
+pub struct NonExhaustiveStruct {
+    pub pub_field: i32,
+    private_field: i32,
+}

--- a/test_outputs/query_execution/struct_no_longer_has_non_pub_fields.snap
+++ b/test_outputs/query_execution/struct_no_longer_has_non_pub_fields.snap
@@ -1,0 +1,18 @@
+---
+source: src/query.rs
+---
+{
+  "./test_crates/struct_no_longer_has_non_pub_fields/": [
+    {
+      "name": String("MyStruct"),
+      "path": List([
+        String("struct_no_longer_has_non_pub_fields"),
+        String("MyStruct"),
+      ]),
+      "span_begin_line": Uint64(3),
+      "span_end_line": Uint64(6),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+}


### PR DESCRIPTION
An example would simply be:

```diff
pub struct MyStruct {
- field: i32,
}
```

A follow up from: https://github.com/obi1kenobi/cargo-semver-checks/pull/1550/files#r2719626142