### PR TITLE
fix: clarify method_parameter_count_changed error template

### DIFF
--- a/src/lints/method_parameter_count_changed.ron
+++ b/src/lints/method_parameter_count_changed.ron
@@ -128,5 +128,5 @@ SemverQuery(
         "zero": 0,
     },
     error_message: "A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.",
-    per_result_error_template: Some("{{join \"::\" path}}::{{method_name}} now takes {{unpack_if_singleton current_parameter_count}} parameters instead of {{old_parameter_count}}, in {{multiple_spans non_matching_span_filename non_matching_span_begin_line}}"),
+    per_result_error_template: Some("{{join \"::\" path}}::{{method_name}} takes {{old_parameter_count}} parameters in {{span_filename}}:{{span_begin_line}}, but now takes {{unpack_if_singleton current_parameter_count}} parameters in {{multiple_spans non_matching_span_filename non_matching_span_begin_line}}"),
 )


### PR DESCRIPTION
## Summary

Fixes #430 — the `per_result_error_template` in `method_parameter_count_changed` was confusing because the span pointed to the **current** code but the wording made it sound like it referred to the **baseline**.

## Problem

The old template produced messages like:

```
Foo::bar now takes 2 parameters instead of 3, in src/lib.rs:16
```

The span `src/lib.rs:16` refers to the **current** version's code location, but reading "instead of 3, in src/lib.rs:16" makes it seem like line 16 is where it *used to* take 3 parameters.

## Fix

The new template clearly labels both locations:

```
Foo::bar takes 3 parameters in src/lib.rs:10, but now takes 2 parameters in src/lib.rs:16
```

- `src/lib.rs:10` → baseline span (where the method used to be defined)
- `src/lib.rs:16` → current span (where the method is now defined)

All needed template variables (`span_filename`, `span_begin_line` for baseline; `non_matching_span_filename`, `non_matching_span_begin_line` for current) were already available in the query's `@output` directives — no query changes needed.

## Verification

- `cargo test method_parameter_count_changed` — ✅ passes (2/2 tests)
- `cargo clippy --all-targets --no-deps -- -D warnings --allow deprecated` — ✅ clean
- `cargo fmt --check` — ✅ clean
- Snapshot file unchanged (it stores raw query results, not rendered templates)

## Note

The sibling lints `function_parameter_count_changed` and `trait_method_parameter_count_changed` have a similar ambiguous pattern — happy to fix those in a follow-up PR if desired.