### PR TITLE
tests: force ASCII cargo diagnostics in snapshot tests (CARGO_TERM_UNICODE=false)

### DIFF
--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -146,6 +146,8 @@ fn assert_integration_test(test_name: &str, invocation: &[&str]) {
         // remove the cargo verbosity variable, which gets passed to `cargo doc`
         // and may create a nonreproducible environment.
         std::env::remove_var("CARGO_TERM_VERBOSE");
+        // force ASCII diagnostics for reproducible snapshots across cargo/rust versions.
+        std::env::set_var("CARGO_TERM_UNICODE", "false");
     }
 
     let stdout = StaticWriter::new();

--- a/tests/integration_snapshots.rs
+++ b/tests/integration_snapshots.rs
@@ -31,6 +31,8 @@ fn assert_integration_test(
 
     // never use color for more readable snapshots
     cmd.env("CARGO_TERM_COLOR", "never");
+    // use ASCII-only diagnostics for reproducible snapshots across cargo/rust versions
+    cmd.env("CARGO_TERM_UNICODE", "false");
     // disable backtrace printing for reproducibility
     cmd.env("RUST_BACKTRACE", "0");
 


### PR DESCRIPTION
### Motivation
- Snapshot tests were unstable when Rust/Cargo emitted Unicode-rich diagnostics (e.g. with `-Z rustc-unicode`), causing snapshot mismatches across toolchain runs.
- Ensure reproducible, ASCII-only diagnostics so snapshots remain stable regardless of Cargo/rust diagnostic rendering mode.

### Description
- Set `CARGO_TERM_UNICODE=false` for the command-driven integration snapshots by adding `cmd.env("CARGO_TERM_UNICODE", "false")` in `tests/integration_snapshots.rs`.
- Force ASCII diagnostics for in-process snapshot helpers by calling `std::env::set_var("CARGO_TERM_UNICODE", "false")` in `src/snapshot_tests.rs` so spawned `cargo` subprocesses emit stable ASCII output.

### Testing
- Ran `cargo fmt` and formatting completed successfully.
- Ran `cargo clippy --all-targets --no-deps --fix --allow-dirty --allow-staged -- -D warnings --allow deprecated` and the repo lints completed without warnings/errors after fixes.
- Ran `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items` and documentation built cleanly.
- Ran `cargo test` and the full test suite passed (unit tests, integration snapshot tests, and doctests completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699921a6923c832d9f6624896653336a)