### PR TITLE
Add minor lint: inherent_method_no_longer_unsafe

### DIFF
--- a/src/lints/inherent_method_no_longer_unsafe.ron
+++ b/src/lints/inherent_method_no_longer_unsafe.ron
@@ -1,0 +1,105 @@
+SemverQuery(
+    id: "inherent_method_no_longer_unsafe",
+    human_readable_name: "pub method is no longer unsafe",
+    description: "A method or associated fn is no longer unsafe to call. Callers that use an `unsafe` block may get `unused_unsafe` warnings.",
+    required_update: Minor,
+    lint_level: Allow,
+    reference_link: Some("https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#calling-an-unsafe-function-or-method"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on ImplOwner {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+
+                        importable_path {
+                            path @output @tag
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        inherent_impl {
+                            method {
+                                method_visibility: visibility_limit @filter(op: "=", value: ["$public"]) @output
+                                method_name: name @output @tag
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+                                unsafe @filter(op: "=", value: ["$true"])
+
+                                span_: span @optional {
+                                    filename @output
+                                    begin_line @output
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            current {
+                item {
+                    ... on ImplOwner {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @output
+
+                        importable_path {
+                            path @filter(op: "=", value: ["%path"])
+                            public_api @filter(op: "=", value: ["$true"])
+                        }
+
+                        # We use "impl" instead of "inherent_impl" here because moving
+                        # an inherently-implemented method to a trait is not necessarily
+                        # a breaking change, so we don't want to report it.
+                        #
+                        # We look for "zero matching unsafe methods" rather than
+                        # "methods that are not unsafe" (incorrect!) since multiple methods with
+                        # the same name are allowed to exist on the same type (e.g. via traits).
+                        #
+                        # The above by itself is still not enough: say if the method was removed,
+                        # that still makes the "there is no method ..." statement true.
+                        # So we add an additional clause demanding that a method by that name
+                        # with appropriate visibility actually exists.
+                        impl @fold @transform(op: "count") @filter(op: ">", value: ["$zero"]) {
+                            method {
+                                visibility_limit @filter(op: "one_of", value: ["$public_or_default"])
+                                name @filter(op: "=", value: ["%method_name"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+                            }
+                        }
+                        impl @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            method {
+                                visibility_limit @filter(op: "one_of", value: ["$public_or_default"])
+                                name @filter(op: "=", value: ["%method_name"])
+                                unsafe @filter(op: "=", value: ["$true"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+                            }
+                        }
+
+                        # Get the non-matching methods by that name so we can report them
+                        # in the lint error message.
+                        impl @fold {
+                            method {
+                                visibility_limit @filter(op: "one_of", value: ["$public_or_default"])
+                                name @filter(op: "=", value: ["%method_name"])
+                                unsafe @filter(op: "!=", value: ["$true"])
+                                public_api_eligible @filter(op: "=", value: ["$true"])
+
+                                non_matching_span_: span @optional {
+                                    filename @output
+                                    begin_line @output
+                                    end_line @output
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "public_or_default": ["public", "default"],
+        "zero": 0,
+        "true": true,
+    },
+    error_message: "A publicly-visible method or associated fn is no longer `unsafe`. Callers that use an `unsafe` block may encounter `unused_unsafe` lint warnings. Reverting this change would also be a major breaking change.",
+    per_result_error_template: Some("{{name}}::{{method_name}} in {{multiple_spans non_matching_span_filename non_matching_span_begin_line}}"),
+)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1705,6 +1705,7 @@ add_lints!(
     inherent_method_missing,
     inherent_method_must_use_added,
     inherent_method_must_use_removed,
+    inherent_method_no_longer_unsafe,
     inherent_method_no_longer_unwind,
     inherent_method_now_doc_hidden,
     inherent_method_now_returns_unit,

--- a/test_crates/inherent_method_no_longer_unsafe/new/Cargo.toml
+++ b/test_crates/inherent_method_no_longer_unsafe/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "inherent_method_no_longer_unsafe"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/inherent_method_no_longer_unsafe/new/src/lib.rs
+++ b/test_crates/inherent_method_no_longer_unsafe/new/src/lib.rs
@@ -1,0 +1,39 @@
+#![no_std]
+
+pub struct Foo;
+
+impl Foo {
+    // Was unsafe, now safe.
+    pub fn associated_fn(x: i64, y: i64) -> i64 {
+        x + y
+    }
+
+    // Was unsafe, now safe.
+    pub fn method(&self, x: i64) -> i64 {
+        x
+    }
+
+    // Still unsafe.
+    pub unsafe fn stays_unsafe(&self) {}
+
+    // Was already safe.
+    pub fn already_safe(&self) {}
+
+    // will_be_removed is gone.
+}
+
+pub enum Bar {
+    Var1,
+    Var2,
+}
+
+impl Bar {
+    // Was unsafe, now safe.
+    pub fn unsafe_enum_associated_fn() {}
+}
+
+struct PrivateStruct;
+
+impl PrivateStruct {
+    pub fn becomes_safe(&self) {}
+}

--- a/test_crates/inherent_method_no_longer_unsafe/old/Cargo.toml
+++ b/test_crates/inherent_method_no_longer_unsafe/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "inherent_method_no_longer_unsafe"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/inherent_method_no_longer_unsafe/old/src/lib.rs
+++ b/test_crates/inherent_method_no_longer_unsafe/old/src/lib.rs
@@ -1,0 +1,40 @@
+#![no_std]
+
+pub struct Foo;
+
+impl Foo {
+    // These two become safe in new -- should be caught.
+    pub unsafe fn associated_fn(x: i64, y: i64) -> i64 {
+        x + y
+    }
+
+    pub unsafe fn method(&self, x: i64) -> i64 {
+        x
+    }
+
+    // Stays unsafe in new -- no match.
+    pub unsafe fn stays_unsafe(&self) {}
+
+    // Already safe -- no match.
+    pub fn already_safe(&self) {}
+
+    // Removed entirely in new -- different lint.
+    pub unsafe fn will_be_removed(&self) {}
+}
+
+pub enum Bar {
+    Var1,
+    Var2,
+}
+
+impl Bar {
+    // Becomes safe in new -- should be caught (works on enums too).
+    pub unsafe fn unsafe_enum_associated_fn() {}
+}
+
+// Not pub, so changes here shouldn't be caught.
+struct PrivateStruct;
+
+impl PrivateStruct {
+    pub unsafe fn becomes_safe(&self) {}
+}

--- a/test_outputs/query_execution/inherent_method_missing.snap
+++ b/test_outputs/query_execution/inherent_method_missing.snap
@@ -1,5 +1,6 @@
 ---
 source: src/query.rs
+assertion_line: 1073
 ---
 {
   "./test_crates/inherent_method_const_removed/": [
@@ -67,6 +68,21 @@ source: src/query.rs
       ]),
       "span_begin_line": Uint64(43),
       "span_end_line": Uint64(45),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+  "./test_crates/inherent_method_no_longer_unsafe/": [
+    {
+      "method_name": String("will_be_removed"),
+      "method_visibility": String("public"),
+      "name": String("Foo"),
+      "path": List([
+        String("inherent_method_no_longer_unsafe"),
+        String("Foo"),
+      ]),
+      "span_begin_line": Uint64(22),
+      "span_end_line": Uint64(22),
       "span_filename": String("src/lib.rs"),
       "visibility_limit": String("public"),
     },

--- a/test_outputs/query_execution/inherent_method_no_longer_unsafe.snap
+++ b/test_outputs/query_execution/inherent_method_no_longer_unsafe.snap
@@ -1,0 +1,138 @@
+---
+source: src/query.rs
+assertion_line: 1073
+---
+{
+  "./test_crates/inherent_method_no_longer_unsafe/": [
+    {
+      "method_name": String("associated_fn"),
+      "method_visibility": String("public"),
+      "name": String("Foo"),
+      "non_matching_span_begin_line": List([
+        Uint64(7),
+      ]),
+      "non_matching_span_end_line": List([
+        Uint64(9),
+      ]),
+      "non_matching_span_filename": List([
+        String("src/lib.rs"),
+      ]),
+      "path": List([
+        String("inherent_method_no_longer_unsafe"),
+        String("Foo"),
+      ]),
+      "span_begin_line": Uint64(7),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "method_name": String("method"),
+      "method_visibility": String("public"),
+      "name": String("Foo"),
+      "non_matching_span_begin_line": List([
+        Uint64(12),
+      ]),
+      "non_matching_span_end_line": List([
+        Uint64(14),
+      ]),
+      "non_matching_span_filename": List([
+        String("src/lib.rs"),
+      ]),
+      "path": List([
+        String("inherent_method_no_longer_unsafe"),
+        String("Foo"),
+      ]),
+      "span_begin_line": Uint64(11),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "method_name": String("unsafe_enum_associated_fn"),
+      "method_visibility": String("public"),
+      "name": String("Bar"),
+      "non_matching_span_begin_line": List([
+        Uint64(32),
+      ]),
+      "non_matching_span_end_line": List([
+        Uint64(32),
+      ]),
+      "non_matching_span_filename": List([
+        String("src/lib.rs"),
+      ]),
+      "path": List([
+        String("inherent_method_no_longer_unsafe"),
+        String("Bar"),
+      ]),
+      "span_begin_line": Uint64(32),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+  "./test_crates/unsafe_inherent_method_requires_more_target_features/": [
+    {
+      "method_name": String("globally_enabled_method"),
+      "method_visibility": String("public"),
+      "name": String("Foo"),
+      "non_matching_span_begin_line": List([
+        Uint64(29),
+      ]),
+      "non_matching_span_end_line": List([
+        Uint64(29),
+      ]),
+      "non_matching_span_filename": List([
+        String("src/lib.rs"),
+      ]),
+      "path": List([
+        String("unsafe_inherent_method_requires_more_target_features"),
+        String("Foo"),
+      ]),
+      "span_begin_line": Uint64(19),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "method_name": String("becomes_safe"),
+      "method_visibility": String("public"),
+      "name": String("Foo"),
+      "non_matching_span_begin_line": List([
+        Uint64(34),
+      ]),
+      "non_matching_span_end_line": List([
+        Uint64(34),
+      ]),
+      "non_matching_span_filename": List([
+        String("src/lib.rs"),
+      ]),
+      "path": List([
+        String("unsafe_inherent_method_requires_more_target_features"),
+        String("Foo"),
+      ]),
+      "span_begin_line": Uint64(22),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+  "./test_crates/unsafe_inherent_method_target_feature_added/": [
+    {
+      "method_name": String("becomes_safe"),
+      "method_visibility": String("public"),
+      "name": String("A"),
+      "non_matching_span_begin_line": List([
+        Uint64(16),
+      ]),
+      "non_matching_span_end_line": List([
+        Uint64(16),
+      ]),
+      "non_matching_span_filename": List([
+        String("src/lib.rs"),
+      ]),
+      "path": List([
+        String("unsafe_inherent_method_target_feature_added"),
+        String("A"),
+      ]),
+      "span_begin_line": Uint64(10),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
+}


### PR DESCRIPTION
Adds a new Minor/Allow lint that detects when a public inherent method or associated fn is no longer unsafe. From the tracking list in #949.

The query mirrors inherent_method_unsafe_added with the unsafe filters inverted, using the same 3-fold impl pattern to handle trait migration and method removal edge cases.

Test crate covers associated fn, self method, and enum associated fn becoming safe, plus negative cases for stays-unsafe, already-safe, removed-entirely, and private-struct.