### PR TITLE
Add support for supressing unreleased items breakage

### DIFF
--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::Write as _;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -119,7 +119,7 @@ fn get_minimum_version_change(version: &semver::Version) -> VersionChange {
 }
 
 /// Intermediate state in [`run_check_release`]
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct LintResult {
     pub semver_query: SemverQuery,
     pub query_results: Vec<BTreeMap<Arc<str>, FieldValue>>,
@@ -260,6 +260,7 @@ fn print_triggered_lint(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn run_check_release(
     config: &mut GlobalConfig,
     data_storage: &DataStorage,
@@ -268,6 +269,7 @@ pub(super) fn run_check_release(
     overrides: &OverrideStack,
     witness_generation: &WitnessGeneration,
     witness_data: witness_gen::WitnessGenerationData,
+    baseline_report: Option<&CrateReport>,
 ) -> anyhow::Result<PendingCrateReport> {
     let current_version = data_storage.current_crate().crate_version();
     let baseline_version = data_storage.baseline_crate().crate_version();
@@ -387,6 +389,26 @@ pub(super) fn run_check_release(
         &mut lint_results,
     );
 
+    if let Some(baseline_report) = baseline_report {
+        let mut lint_map = lint_results
+            .iter_mut()
+            .map(|lint| (lint.semver_query.id.clone(), lint))
+            .collect::<HashMap<_, _>>();
+
+        for old_lint in &baseline_report.lint_results {
+            let Some(new_lint) = lint_map.get_mut(&old_lint.semver_query.id) else {
+                continue;
+            };
+
+            // note building a query results set requires adding Hash to FieldValue in trustfall
+            for old_result in &old_lint.query_results {
+                new_lint
+                    .query_results
+                    .retain(|new_result| !btreemap_eq_ignoring_span_keys(new_result, old_result));
+            }
+        }
+    }
+
     let checks_duration = checks_start_instant.elapsed();
 
     let mut required_bumps = Bumps { major: 0, minor: 0 };
@@ -424,6 +446,15 @@ pub(super) fn run_check_release(
         report,
         witness_run_report,
     })
+}
+
+type QueryResults = BTreeMap<Arc<str>, FieldValue>;
+
+fn btreemap_eq_ignoring_span_keys(a: &QueryResults, b: &QueryResults) -> bool {
+    let not_span = |(k, _): &(&Arc<str>, _)| {
+        !["span_filename", "span_begin_line", "span_end_line"].contains(&k.as_ref())
+    };
+    a.iter().filter(not_span).eq(b.iter().filter(not_span))
 }
 
 fn print_report(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use clap::ValueEnum;
 use data_generation::{DataStorage, IntoTerminalResult as _, TerminalError};
 use directories::ProjectDirs;
 use itertools::Itertools;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use std::collections::{BTreeMap, HashSet};
 use std::io::Write as _;
@@ -48,6 +48,8 @@ pub struct Check {
     build_target: Option<String>,
     /// Options for generating [witnesses](Witness).
     witness_generation: WitnessGeneration,
+    report_output: Option<PathBuf>,
+    baseline_report: Option<PathBuf>,
 }
 
 /// The kind of release we're making.
@@ -277,6 +279,8 @@ impl Check {
             baseline_feature_config: rustdoc_gen::FeatureConfig::default_for_baseline(),
             build_target: None,
             witness_generation: WitnessGeneration::default(),
+            report_output: None,
+            baseline_report: None,
         }
     }
 
@@ -338,6 +342,20 @@ impl Check {
     /// relying on the users cargo configuration.
     pub fn set_build_target(&mut self, build_target: String) -> &mut Self {
         self.build_target = Some(build_target);
+        self
+    }
+
+    /// File containing a report to use as baseline. A result is only included in the
+    /// report being generated if it's not already present in the baseline report
+    pub fn set_baseline_report(&mut self, baseline_report: PathBuf) -> &mut Self {
+        self.baseline_report = Some(baseline_report);
+        self
+    }
+
+    /// File where to save the report. Note: this is primarily intended to be paired with
+    /// a later invocation that passes `--baseline-report`. The file format is unstable.
+    pub fn set_report_output(&mut self, report_output: PathBuf) -> &mut Self {
+        self.report_output = Some(report_output);
         self
     }
 
@@ -552,6 +570,21 @@ note: skipped the following crates since they have no library target: {skipped}"
         let baseline_loader = self.get_rustdoc_generator(config, &self.baseline.source)?;
         let witness_target_dir = self.get_target_dir(&self.current.source)?;
 
+        let mut crate_reports = BaselineReport::default();
+
+        let version = env!("CARGO_PKG_VERSION").to_owned();
+
+        if let Some(baseline_report) = &self.baseline_report {
+            crate_reports = serde_json::from_reader(std::fs::File::open(baseline_report)?)?;
+
+            if crate_reports.version != version {
+                anyhow::bail!(
+                    "baseline report was generated with a different version: {} != {version} ",
+                    crate_reports.version
+                )
+            }
+        }
+
         // Create a report for each crate.
         // We want to run all the checks, even if one returns `Err`.
         let all_outcomes: Vec<anyhow::Result<(String, PendingCrateReport)>> = crates_to_check
@@ -602,6 +635,7 @@ note: skipped the following crates since they have no library target: {skipped}"
                     &selected.overrides,
                     &self.witness_generation,
                     witness_data,
+                    crate_reports.crate_reports.get(&name),
                 )?;
                 config.shell_status(
                     "Finished",
@@ -641,11 +675,33 @@ note: skipped the following crates since they have no library target: {skipped}"
                     ))?;
                 }
             }
+
+            if let Some(report_output) = &self.report_output {
+                let baseline_report = BaselineReport {
+                    version,
+                    crate_reports: reports,
+                };
+
+                std::fs::write(
+                    report_output,
+                    serde_json::to_string_pretty(&baseline_report)?,
+                )?;
+
+                reports = baseline_report.crate_reports;
+            }
+
             reports
         };
 
         Ok(Report { crate_reports })
     }
+}
+
+#[derive(Default, Serialize, Deserialize)]
+struct BaselineReport {
+    /// Version of cargo-semver-checks which generated the reports
+    version: String,
+    crate_reports: BTreeMap<String, CrateReport>,
 }
 
 fn overrides_for_workspace_package(
@@ -701,7 +757,7 @@ fn log_terminal_error(config: &mut GlobalConfig, err: TerminalError) -> anyhow::
 }
 
 /// Summary of version bumps from queries
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 struct Bumps {
     major: u32,
     minor: u32,
@@ -724,7 +780,7 @@ impl Bumps {
 
 /// Report of semver check of one crate.
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CrateReport {
     /// Bump between the current version and the baseline one.
     detected_bump: ActualSemverUpdate,
@@ -875,7 +931,7 @@ impl WitnessGeneration {
 
 /// Witness-related statistics produced while checking one crate.
 #[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WitnessStatistics {
     not_confirmed_by_witness: usize,
     consistency_check_mismatches: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,10 +182,12 @@ fn main() {
         None => args.check_release,
     };
 
+    let has_report_output = check_release.unstable_options.report_output.is_some();
+
     let check: cargo_semver_checks::Check = check_release.into();
 
     let report = exit_on_error(config.is_error(), || check.check_release(&mut config));
-    if report.is_cli_success() {
+    if report.is_cli_success() || (!report.has_required_witness_errors() && has_report_output) {
         std::process::exit(0);
     } else {
         std::process::exit(1);
@@ -356,6 +358,16 @@ struct UnstableOptions {
     /// Enable running witness-based consistency checks for lints whose witness purpose is `ConsistencyCheck`.
     #[arg(long, hide = true)]
     consistency_check: bool,
+
+    /// File where to save the report. Note: this is primarily intended to be paired with
+    /// a later invocation that passes `--baseline-report`. The file format is unstable.
+    #[arg(long, hide = true, conflicts_with = "baseline_report")]
+    report_output: Option<PathBuf>,
+
+    /// File containing a report to use as baseline. A result is only included in the
+    /// report being generated if not already present in the baseline report
+    #[arg(long, hide = true, conflicts_with = "report_output")]
+    baseline_report: Option<PathBuf>,
 }
 
 impl UnstableOptions {
@@ -380,6 +392,8 @@ impl UnstableOptions {
         let Self {
             witness_hints,
             consistency_check,
+            report_output,
+            baseline_report,
         } = self;
 
         if *witness_hints {
@@ -388,6 +402,14 @@ impl UnstableOptions {
 
         if *consistency_check {
             list.push("--consistency-check".into())
+        }
+
+        if report_output.is_some() {
+            list.push("--report-output".into())
+        }
+
+        if baseline_report.is_some() {
+            list.push("--baseline-report".into())
         }
 
         list
@@ -670,6 +692,14 @@ impl From<CheckRelease> for cargo_semver_checks::Check {
         witness_generation.show_hints = value.unstable_options.witness_hints;
         witness_generation.run_consistency_checks = value.unstable_options.consistency_check;
         check.set_witness_generation(witness_generation);
+
+        if let Some(baseline_report) = value.unstable_options.baseline_report {
+            check.set_baseline_report(baseline_report);
+        }
+
+        if let Some(report_output) = value.unstable_options.report_output {
+            check.set_report_output(report_output);
+        }
 
         check
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -58,7 +58,7 @@ impl LintLevel {
 }
 
 /// Kind of semver update.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ActualSemverUpdate {
     Major,
     Minor,

--- a/test_outputs/integration_snapshots__z_help.snap
+++ b/test_outputs/integration_snapshots__z_help.snap
@@ -26,4 +26,10 @@ Unstable options:
       --consistency-check
           Enable running witness-based consistency checks for lints whose witness purpose is `ConsistencyCheck`
 
+      --report-output <REPORT_OUTPUT>
+          File where to save the report. Note: this is primarily intended to be paired with a later invocation that passes `--baseline-report`. The file format is unstable
+
+      --baseline-report <BASELINE_REPORT>
+          File containing a report to use as baseline. A result is only included in the report being generated if not already present in the baseline report
+
 ----- stderr -----

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__multiple_ambiguous_package_name_definitions-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__multiple_ambiguous_package_name_definitions-input.snap
@@ -31,4 +31,6 @@ Check(
     show_hints: false,
     run_consistency_checks: false,
   ),
+  report_output: None,
+  baseline_report: None,
 )

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__semver_trick_self_referential-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__semver_trick_self_referential-input.snap
@@ -31,4 +31,6 @@ Check(
     show_hints: false,
     run_consistency_checks: false,
   ),
+  report_output: None,
+  baseline_report: None,
 )

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_all_publish_false-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_all_publish_false-input.snap
@@ -31,4 +31,6 @@ Check(
     show_hints: false,
     run_consistency_checks: false,
   ),
+  report_output: None,
+  baseline_report: None,
 )

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_baseline_compile_error-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_baseline_compile_error-input.snap
@@ -31,4 +31,6 @@ Check(
     show_hints: false,
     run_consistency_checks: false,
   ),
+  report_output: None,
+  baseline_report: None,
 )

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_baseline_conditional_compile_error-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_baseline_conditional_compile_error-input.snap
@@ -31,4 +31,6 @@ Check(
     show_hints: false,
     run_consistency_checks: false,
   ),
+  report_output: None,
+  baseline_report: None,
 )

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_no_lib_targets-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_no_lib_targets-input.snap
@@ -31,4 +31,6 @@ Check(
     show_hints: false,
     run_consistency_checks: false,
   ),
+  report_output: None,
+  baseline_report: None,
 )

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_publish_false_explicit-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_publish_false_explicit-input.snap
@@ -30,4 +30,6 @@ Check(
     show_hints: false,
     run_consistency_checks: false,
   ),
+  report_output: None,
+  baseline_report: None,
 )

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_publish_false_workspace_flag-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_publish_false_workspace_flag-input.snap
@@ -31,4 +31,6 @@ Check(
     show_hints: false,
     run_consistency_checks: false,
   ),
+  report_output: None,
+  baseline_report: None,
 )

--- a/tests/baseline_report.rs
+++ b/tests/baseline_report.rs
@@ -1,0 +1,51 @@
+//! End-to-end test for the `--report-output` / `--baseline-report` unstable flags.
+//!
+//! Asserts that:
+//! 1. A plain run against `trait_missing` exits non-zero (findings present).
+//! 2. Adding `--report-output` exits 0 and writes the JSON.
+//! 3. Re-running with `--baseline-report <that JSON>` exits 0 (findings subtracted).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+fn baseline_report_round_trip() {
+    let bin = assert_cmd::cargo::cargo_bin!("cargo-semver-checks");
+    let report_path: PathBuf = std::env::temp_dir().join("csc-baseline-report.json");
+
+    let _ = std::fs::remove_file(&report_path);
+
+    let base_args = [
+        "semver-checks",
+        "--manifest-path",
+        "test_crates/trait_missing/new",
+        "--baseline-root",
+        "test_crates/trait_missing/old",
+    ];
+
+    let status = Command::new(bin)
+        .args(base_args)
+        .status()
+        .expect("failed to run cargo-semver-checks");
+    assert!(!status.success(), "expected non-zero exit on plain run");
+
+    let status = Command::new(bin)
+        .args(base_args)
+        .args(["-Z", "unstable-options", "--report-output"])
+        .arg(&report_path)
+        .status()
+        .expect("failed to run cargo-semver-checks");
+    assert!(status.success(), "expected exit 0 with --report-output");
+    assert!(
+        report_path.exists(),
+        "expected --report-output to write the JSON"
+    );
+
+    let status = Command::new(bin)
+        .args(base_args)
+        .args(["-Z", "unstable-options", "--baseline-report"])
+        .arg(&report_path)
+        .status()
+        .expect("failed to run cargo-semver-checks");
+    assert!(status.success(), "expected exit 0 with --baseline-report");
+}


### PR DESCRIPTION
`cargo-semver-checks` compare changes across two branches, so, in per-PR workflows, we either check with main and risk flagging breakage on unreleased items, or check with the latest release, and PRs against a project whose main already has known breakage relative to its last release will keep flagging the same pre-existing findings on every PR

This PR adds two new `-Z unstable-options` flags that together enable a new workflow: save findings of main, subtract them from the PR run

- `--report-output <PATH>` — serialize the full `CrateReport`'s as JSON. When set, the binary exits 0 even with findings present (provided no required-witness errors), so CI can produce a baseline without failing.
- `--baseline-report <PATH>` — load a previously saved report and subtract any lint findings already present in it from the current run, ignoring source-location drift (`span_filename/span_begin_line/span_end_line`).

The pair of flags here lets you:

In main, run `cargo semver-checks --baseline-rev <last-release-tag> -Z unstable-options --report-output baseline.json`, and maybe save it in cache.
Then, in PR branch, run `cargo semver-checks --baseline-rev <last-release-tag> -Z unstable-options --baseline-report baseline.json`, which only fails if the PR introduces new breakage on top of what main already had.
The two flags are mutually exclusive (`conflicts_with`).

We can make this in a single invocation with one flag like `--subtract-rev <last_release_tag>`, but then we can't cache the first step

For now the PR contains a single, minimal test. I would like to know if maintainers have interest in the feature and have a preference for how this should be tested before adding new ones. Thanks!

# How the subtraction works

The subtraction/removal happens after running the semver queries and witness checks, where we have a finished `Vec<LintResult>`. If `--baseline-report <file>`  is set, we decode a `CrateReport` from the file, match lint results from the current run and from the file by lint id, and remove from the current run query results every result that is also present in the crate report from the file, by checking equality of both `BTreeMap<Arc<str>, FieldValue>`, but ignoring the keys `span_filename`, `span_begin_line` and `span_end_line`. This part, the core of the PR, is very small (~25 lines), and is included below:

<details>

```rust
    // semver queries and witness checks executed above
    let baseline_report: Option<CrateReport> = todo!();
    let mut lint_results: Vec<LintResult> = todo!();

    if let Some(baseline_report) = baseline_report {
        let mut lint_map: HashMap<String, &mut LintResult> = lint_results
            .iter_mut()
            .map(|lint| (lint.semver_query.id.clone(), lint))
            .collect();

        for old_lint in &baseline_report.lint_results {
            let Some(new_lint) = lint_map.get_mut(&old_lint.semver_query.id) else {
                continue;
            };

            // note building a query results set requires adding Hash to FieldValue in trustfall
            for old_result in &old_lint.query_results {
                new_lint
                    .query_results
                    .retain(|new_result| !btreemap_eq_ignoring_span_keys(new_result, old_result));
            }
        }
    }
    // compute bumps below

type QueryResults = BTreeMap<Arc<str>, FieldValue>;

fn btreemap_eq_ignoring_span_keys(a: &QueryResults, b: &QueryResults) -> bool {
    let not_span = |(k, _): &(&Arc<str>, _)| {
        !["span_filename", "span_begin_line", "span_end_line"].contains(&k.as_ref())
    };
    a.iter().filter(not_span).eq(b.iter().filter(not_span))
}
```

</details>

False positives are possible if more span fields are added, or the existing renamed, without updating `btreemap_eq_ignoring_span_keys`

False negatives are possible if a query returns the exact same values (ignoring spans) for two different items. Suppose a project has two functions named `foo`, one in path `foo::bar` and another in `bar::foo`. If the query returned only the name of the function, `foo`, but not the paths, the removal of one function in the baseline report would supress the removal of the other function. I haven't checked every query but I believe none would trigger this.
