### PR TITLE
Include cfg and toolchain in build fingerprint, to avoid collisions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,8 +422,8 @@ jobs:
           path: bins\
 
   cross-version-caching:
-    # Ensure that cached rustdoc JSON files from an mismatched rustdoc version
-    # are transparently cleared and overwritten with the rustdoc version from the current toolchain.
+    # Ensure that cached rustdoc JSON files from a mismatched rustdoc version
+    # are not reused when running with the current toolchain.
     # Fixes: https://github.com/obi1kenobi/cargo-semver-checks/issues/415
     name: 'Caching across rustdoc versions'
     runs-on: ubuntu-latest
@@ -473,7 +473,7 @@ jobs:
         id: cache
         uses: actions/cache/restore@v5
         with:
-          key: cross-version-caching-adler2-2_0_1-${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('semver/**/Cargo.lock') }}-${{ github.job }}-rustdoc
+          key: cross-version-caching-adler2-2_0_1-${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('semver/**/Cargo.lock') }}-${{ github.job }}
           path: subject/target/semver-checks/cache
 
       - name: Restore cargo index and rustdoc target dir
@@ -493,7 +493,7 @@ jobs:
         uses: actions/cache/save@v5
         if: steps.cache.outputs.cache-hit != 'true'
         with:
-          key: cross-version-caching-adler2-2_0_1-${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('semver/**/Cargo.lock') }}-${{ github.job }}-rustdoc
+          key: cross-version-caching-adler2-2_0_1-${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('semver/**/Cargo.lock') }}-${{ github.job }}
           path: subject/target/semver-checks/cache
 
       - name: Install newer rust
@@ -513,22 +513,31 @@ jobs:
 
           # Show what's in the cache.
           ls subject-new/target/semver-checks/cache/
-          EXPECTED_PREFIX='subject-new/target/semver-checks/cache/adler2-2_0_1-default-01666ec060466c14'
-          EXPECTED_CACHED_METADATA="${EXPECTED_PREFIX}.metadata.json"
-          EXPECTED_CACHED_RUSTDOC="${EXPECTED_PREFIX}.json"
+          mapfile -t OLD_CACHED_RUSTDOCS < <(find subject-new/target/semver-checks/cache \
+            -maxdepth 1 \
+            -name 'adler2-2_0_1-*.json' \
+            ! -name '*.metadata.json' \
+            | sort)
+
+          [ "${#OLD_CACHED_RUSTDOCS[@]}" -eq 1 ] || { \
+            echo "expected exactly one cached adler2 rustdoc file, found ${#OLD_CACHED_RUSTDOCS[@]}"; \
+            exit 1;
+          }
+          OLD_CACHED_RUSTDOC="${OLD_CACHED_RUSTDOCS[0]}"
+          OLD_CACHED_METADATA="${OLD_CACHED_RUSTDOC%.json}.metadata.json"
 
           # Ensure the previous cached rustdoc and metadata files still exist.
-          [ -f "$EXPECTED_CACHED_METADATA" ] || { \
+          [ -f "$OLD_CACHED_METADATA" ] || { \
             echo "could not find adler2 metadata cache file"; \
             exit 1;
           }
-          [ -f "$EXPECTED_CACHED_RUSTDOC" ] || { \
+          [ -f "$OLD_CACHED_RUSTDOC" ] || { \
             echo "could not find adler2 rustdoc cache file"; \
             exit 1;
           }
 
           OLD_RUSTDOC_VERSION=
-          OLD_RUSTDOC_VERSION=$(jq .format_version "$EXPECTED_CACHED_RUSTDOC")
+          OLD_RUSTDOC_VERSION=$(jq .format_version "$OLD_CACHED_RUSTDOC")
           export OLD_RUSTDOC_VERSION
 
           # Run cargo-semver-checks with the older cached file.
@@ -539,12 +548,38 @@ jobs:
 
           # Show what's in the cache now.
           ls subject-new/target/semver-checks/cache/
+          mapfile -t CACHED_RUSTDOCS < <(find subject-new/target/semver-checks/cache \
+            -maxdepth 1 \
+            -name 'adler2-2_0_1-*.json' \
+            ! -name '*.metadata.json' \
+            | sort)
+
+          [ "${#CACHED_RUSTDOCS[@]}" -eq 2 ] || { \
+            echo "expected two cached adler2 rustdoc files, found ${#CACHED_RUSTDOCS[@]}"; \
+            exit 1;
+          }
+          NEW_CACHED_RUSTDOC=
+          for cached_rustdoc in "${CACHED_RUSTDOCS[@]}"; do
+            if [ "$cached_rustdoc" != "$OLD_CACHED_RUSTDOC" ]; then
+              NEW_CACHED_RUSTDOC="$cached_rustdoc"
+              break
+            fi
+          done
+          [ -n "$NEW_CACHED_RUSTDOC" ] || { \
+            echo "could not find new adler2 rustdoc cache file"; \
+            exit 1;
+          }
+          NEW_CACHED_METADATA="${NEW_CACHED_RUSTDOC%.json}.metadata.json"
+          [ -f "$NEW_CACHED_METADATA" ] || { \
+            echo "could not find new adler2 metadata cache file"; \
+            exit 1;
+          }
 
           NEW_RUSTDOC_VERSION=
-          NEW_RUSTDOC_VERSION=$(jq .format_version "$EXPECTED_CACHED_RUSTDOC")
+          NEW_RUSTDOC_VERSION=$(jq .format_version "$NEW_CACHED_RUSTDOC")
           export NEW_RUSTDOC_VERSION
 
-          # Ensure the cached rustdoc versions were indeed different before and after.
+          # Ensure the cached rustdoc versions differ across the separate cache entries.
           [ "$OLD_RUSTDOC_VERSION" != "$NEW_RUSTDOC_VERSION" ] || exit 1
 
   cross-feature-caching:
@@ -588,7 +623,7 @@ jobs:
         id: cache
         uses: actions/cache/restore@v5
         with:
-          key: cross-feature-caching-${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('semver/**/Cargo.lock') }}-${{ github.job }}-rustdoc
+          key: cross-feature-caching-${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('semver/**/Cargo.lock') }}-${{ github.job }}
           path: subject/target/semver-checks/cache
 
       - name: Restore cargo index and rustdoc target dir
@@ -611,7 +646,7 @@ jobs:
         uses: actions/cache/save@v5
         if: steps.cache.outputs.cache-hit != 'true'
         with:
-          key: cross-feature-caching-${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('semver/**/Cargo.lock') }}-${{ github.job }}-rustdoc
+          key: cross-feature-caching-${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('semver/**/Cargo.lock') }}-${{ github.job }}
           path: subject/target/semver-checks/cache
 
       # Run cargo-semver-checks, enabling feature `unstable` this time.
@@ -643,31 +678,24 @@ jobs:
           # Show what's in the cache.
           ls subject/target/semver-checks/cache/
 
-          # The previous cached rustdoc should continue to exist.
-          PREVIOUS_PREFIX='subject/target/semver-checks/cache/serde-1_0_162-default-5900ebf8bb9b9f8b'
-          PREVIOUS_RUSTDOC="${PREVIOUS_PREFIX}.json"
-          PREVIOUS_METADATA="${PREVIOUS_PREFIX}.metadata.json"
-          if [ ! -f "$PREVIOUS_RUSTDOC" ]; then
-            echo "Older rustdoc JSON not found in cache!"
-            exit 1
-          fi
-          if [ ! -f "$PREVIOUS_METADATA" ]; then
-            echo "Older metadata file not found in cache!"
-            exit 1
-          fi
+          # The previous cached rustdoc and the new feature-specific rustdoc should both exist.
+          mapfile -t CACHED_RUSTDOCS < <(find subject/target/semver-checks/cache \
+            -maxdepth 1 \
+            -name 'serde-1_0_162-*.json' \
+            ! -name '*.metadata.json' \
+            | sort)
 
-          # There should also be a new cached rustdoc file for the new feature settings.
-          NEW_PREFIX='subject/target/semver-checks/cache/serde-1_0_162-default-6999ae87ca463ab3'
-          NEW_RUSTDOC="${NEW_PREFIX}.json"
-          NEW_METADATA="${NEW_PREFIX}.metadata.json"
-          if [ ! -f "$NEW_RUSTDOC" ]; then
-            echo "New rustdoc JSON for new feature combo not found in cache!"
+          if [ "${#CACHED_RUSTDOCS[@]}" -ne 2 ]; then
+            echo "Expected exactly two serde rustdoc JSON cache files, found ${#CACHED_RUSTDOCS[@]}."
             exit 1
           fi
-          if [ ! -f "$NEW_METADATA" ]; then
-            echo "New metadata file for new feature combo not found in cache!"
-            exit 1
-          fi
+          for cached_rustdoc in "${CACHED_RUSTDOCS[@]}"; do
+            metadata="${cached_rustdoc%.json}.metadata.json"
+            if [ ! -f "$metadata" ]; then
+              echo "Metadata file not found in cache for $cached_rustdoc!"
+              exit 1
+            fi
+          done
 
       - name: Cleanup
         run: |

--- a/src/data_generation/generate.rs
+++ b/src/data_generation/generate.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
@@ -9,6 +10,73 @@ use crate::data_generation::request::RequestKind;
 use super::error::{IntoTerminalResult as _, TerminalError};
 use super::progress::CallbackHandler;
 use super::request::CrateDataRequest;
+
+const EXTRA_RUSTDOCFLAGS: &str = "-Z unstable-options --document-private-items --document-hidden-items --output-format=json --cap-lints=allow";
+
+#[derive(Debug, Clone)]
+pub(crate) struct RustdocBuildEnvironment {
+    pub(crate) target_triple: String,
+    pub(crate) cargo_rustflags: Cow<'static, str>,
+    pub(crate) cargo_rustdocflags: Cow<'static, str>,
+    pub(crate) toolchain_version: String,
+}
+
+impl RustdocBuildEnvironment {
+    pub(crate) fn from_env_and_config_for_target(
+        build_target: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        let flags = Flags::from_env_and_config_for_target(build_target)?;
+
+        // Generating rustdoc JSON for a crate also involves checking that crate's dependencies.
+        // The check is done by rustc, not rustdoc, so it's subject to `RUSTFLAGS` not
+        // `RUSTDOCFLAGS`. We don't want rustc to fail that check if the user has set
+        // `RUSTFLAGS="-Dwarnings"` here.
+        // This fixes: https://github.com/obi1kenobi/cargo-semver-checks/issues/589
+        let cargo_rustflags = if flags.rustflags.is_empty() {
+            Cow::Borrowed("--cap-lints=allow")
+        } else {
+            Cow::Owned(format!("{} --cap-lints=allow", flags.rustflags))
+        };
+
+        // Preserve user rustdoc flags, including `--cfg <custom-value>` settings that toggle
+        // what functionality is compiled into the scanned crate.
+        // Suggested in: https://github.com/obi1kenobi/cargo-semver-checks/discussions/1012
+        let cargo_rustdocflags = if flags.rustdocflags.is_empty() {
+            Cow::Borrowed(EXTRA_RUSTDOCFLAGS)
+        } else {
+            Cow::Owned(format!("{} {}", flags.rustdocflags, EXTRA_RUSTDOCFLAGS))
+        };
+
+        // Include the rustdoc toolchain version in artifact identity, since rustdoc JSON may
+        // change across toolchains.
+        let cmd_output = std::process::Command::new("rustdoc")
+            .arg("--version")
+            .output()
+            .context("'rustdoc --version' failed, is Rust installed correctly?")?;
+        if !cmd_output.status.success() {
+            anyhow::bail!(
+                "'rustdoc --version' exited with status {}",
+                cmd_output.status
+            );
+        }
+        let mut toolchain_version = String::from_utf8(cmd_output.stdout)
+            .context("'rustdoc --version' output is not legal UTF-8")?;
+        toolchain_version.truncate(toolchain_version.trim_end().len());
+        let prefix = "rustdoc ";
+        anyhow::ensure!(
+            toolchain_version.starts_with(prefix),
+            "'rustdoc --version' output did not start with 'rustdoc '",
+        );
+        toolchain_version.drain(..prefix.len());
+
+        Ok(Self {
+            target_triple: flags.target_triple,
+            cargo_rustflags,
+            cargo_rustdocflags,
+            toolchain_version,
+        })
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct GenerationSettings {
@@ -46,6 +114,7 @@ pub(super) fn generate_rustdoc(
     request: &CrateDataRequest<'_>,
     build_dir: &Path,
     settings: GenerationSettings,
+    build_environment: &RustdocBuildEnvironment,
     callbacks: &mut CallbackHandler<'_>,
 ) -> Result<(PathBuf, cargo_metadata::Metadata), TerminalError> {
     let crate_name = request.kind.name().into_terminal_result()?;
@@ -116,6 +185,7 @@ pub(super) fn generate_rustdoc(
         crate_name,
         version,
         &settings,
+        build_environment,
         callbacks,
     )?;
 
@@ -209,6 +279,7 @@ fn get_default_build_target_triple(config: &cargo_config2::Config) -> anyhow::Re
 }
 
 struct Flags {
+    target_triple: String,
     rustflags: String,
     rustdocflags: String,
 }
@@ -317,6 +388,7 @@ impl Flags {
         Ok(Self {
             rustflags: Self::determine_rustflags(&config, &triple)?,
             rustdocflags: Self::determine_rustdocflags(&config, &triple)?,
+            target_triple: triple,
         })
     }
 }
@@ -452,41 +524,10 @@ fn run_cargo_doc(
     crate_name: &str,
     version: &str,
     settings: &GenerationSettings,
+    build_environment: &RustdocBuildEnvironment,
     callbacks: &mut CallbackHandler<'_>,
 ) -> Result<PathBuf, TerminalError> {
     let pkg_spec = format!("{crate_name}@{version}");
-
-    // Load the current rustflags and rustdocflags settings.
-    // We'll want to modify them.
-    let Flags {
-        rustflags: prior_rustflags,
-        rustdocflags: mut prior_rustdocflags,
-    } = Flags::from_env_and_config_for_target(request.build_target()).into_terminal_result()?;
-
-    // Generating rustdoc JSON for a crate also involves checking that crate's dependencies.
-    // The check is done by rustc, not rustdoc, so it's subject to `RUSTFLAGS` not `RUSTDOCFLAGS`.
-    // We don't want rustc to fail that check if the user has set `RUSTFLAGS="-Dwarnings"` here.
-    // This fixes: https://github.com/obi1kenobi/cargo-semver-checks/issues/589
-    let rustflags = if !prior_rustflags.is_empty() {
-        let mut prior_rustflags = prior_rustflags;
-        prior_rustflags.push_str(" --cap-lints=allow");
-        std::borrow::Cow::Owned(prior_rustflags)
-    } else {
-        std::borrow::Cow::Borrowed("--cap-lints=allow")
-    };
-
-    // Ensure we preserve `RUSTDOCFLAGS` if they are set.
-    // This allows users to supply `--cfg <custom-value>` settings in `RUSTDOCFLAGS`
-    // in order to toggle what functionality is compiled into the scanned crate.
-    // Suggested in: https://github.com/obi1kenobi/cargo-semver-checks/discussions/1012
-    let extra_rustdocflags = "-Z unstable-options --document-private-items --document-hidden-items --output-format=json --cap-lints=allow";
-    let rustdocflags = if !prior_rustdocflags.is_empty() {
-        prior_rustdocflags.push(' ');
-        prior_rustdocflags.push_str(extra_rustdocflags);
-        std::borrow::Cow::Owned(prior_rustdocflags)
-    } else {
-        std::borrow::Cow::Borrowed(extra_rustdocflags)
-    };
 
     // Run the rustdoc generation command on the placeholder crate,
     // specifically requesting the rustdoc of *only* the crate specified in `pkg_spec`.
@@ -499,8 +540,11 @@ fn run_cargo_doc(
     callbacks.generate_rustdoc_start();
     let mut cmd = std::process::Command::new("cargo");
     cmd.env("RUSTC_BOOTSTRAP", "1")
-        .env("RUSTDOCFLAGS", rustdocflags.as_ref())
-        .env("RUSTFLAGS", rustflags.as_ref())
+        .env(
+            "RUSTDOCFLAGS",
+            build_environment.cargo_rustdocflags.as_ref(),
+        )
+        .env("RUSTFLAGS", build_environment.cargo_rustflags.as_ref())
         .stdout(std::process::Stdio::null()) // Don't pollute output
         .stderr(settings.stderr())
         .arg("doc")
@@ -557,7 +601,7 @@ fn run_cargo_doc(
         )
         .expect("formatting failed");
 
-        if rustflags.contains("--cfg") {
+        if build_environment.cargo_rustflags.contains("--cfg") {
             writeln!(
                 message,
                 "note: RUSTFLAGS appears to contain '--cfg' arguments."

--- a/src/data_generation/request.rs
+++ b/src/data_generation/request.rs
@@ -9,7 +9,7 @@ use crate::manifest::Manifest;
 use crate::util::slugify;
 
 use super::error::{IntoTerminalResult, TerminalError};
-use super::generate::GenerationSettings;
+use super::generate::{GenerationSettings, RustdocBuildEnvironment};
 use super::progress::{CallbackHandler, ProgressCallbacks};
 
 #[derive(Debug, Clone)]
@@ -98,6 +98,7 @@ struct CacheEntry<'a> {
 impl<'a> CacheUse<'a> {
     fn new(
         request: &CrateDataRequest<'a>,
+        build_environment: &RustdocBuildEnvironment,
         settings: CacheSettings<&'a Path>,
     ) -> anyhow::Result<Self> {
         // We can only cache registry crates. For local crates, we have no idea of the state
@@ -110,13 +111,7 @@ impl<'a> CacheUse<'a> {
             settings
         };
 
-        let key = {
-            if let Some(build_target) = request.build_target {
-                format!("{}-{}", request.cache_slug()?, build_target)
-            } else {
-                request.cache_slug()?
-            }
-        };
+        let key = request.artifact_slug(build_environment)?;
 
         let (json_cache_location, metadata_cache_location) = {
             match settings {
@@ -205,9 +200,6 @@ pub(crate) struct CrateDataRequest<'a> {
 
     /// Purely for progress reporting purposes. Does not change behavior.
     pub(super) is_baseline: bool,
-
-    /// Fingerprint of the feature selections, for use in disambiguating between artifacts.
-    features_fingerprint: String,
 }
 
 impl<'a> CrateDataRequest<'a> {
@@ -218,14 +210,12 @@ impl<'a> CrateDataRequest<'a> {
         build_target: Option<&'a str>,
         is_baseline: bool,
     ) -> Self {
-        let features_fingerprint = make_features_hash(default_features, &extra_features);
         Self {
             kind: RequestKind::Registry(RegistryRequest { index_entry }),
             default_features,
             extra_features,
             build_target,
             is_baseline,
-            features_fingerprint,
         }
     }
 
@@ -236,14 +226,12 @@ impl<'a> CrateDataRequest<'a> {
         build_target: Option<&'a str>,
         is_baseline: bool,
     ) -> Self {
-        let features_fingerprint = make_features_hash(default_features, &extra_features);
         Self {
             kind: RequestKind::LocalProject(ProjectRequest { manifest }),
             default_features,
             extra_features,
             build_target,
             is_baseline,
-            features_fingerprint,
         }
     }
 
@@ -320,7 +308,11 @@ impl<'a> CrateDataRequest<'a> {
         // since they almost always indicate a serious bug in our mental model.
         // An example of a failure here would be "crates don't always have a name, actually"
         // which is something we want to know about ASAP.
-        let cache = CacheUse::new(self, cache_settings).into_terminal_result()?;
+        let build_environment =
+            RustdocBuildEnvironment::from_env_and_config_for_target(self.build_target())
+                .into_terminal_result()?;
+        let cache =
+            CacheUse::new(self, &build_environment, cache_settings).into_terminal_result()?;
 
         // Can we satisfy the request from cache?
         match cache.read() {
@@ -372,11 +364,15 @@ impl<'a> CrateDataRequest<'a> {
         }
 
         // Generate the data we need.
-        let build_dir = target_root.join(self.build_path_slug().into_terminal_result()?);
+        let build_dir = target_root.join(
+            self.build_path_slug(&build_environment)
+                .into_terminal_result()?,
+        );
         let (data_path, metadata) = super::generate::generate_rustdoc(
             self,
             &build_dir,
             generation_settings,
+            &build_environment,
             &mut callbacks,
         )?;
 
@@ -421,27 +417,90 @@ impl<'a> CrateDataRequest<'a> {
         Ok(data)
     }
 
-    /// A path-safe unique identifier that includes the crate's source, name, version, and features.
-    fn build_path_slug(&self) -> anyhow::Result<String> {
+    /// A path-safe unique identifier for the placeholder build directory.
+    fn build_path_slug(
+        &self,
+        build_environment: &RustdocBuildEnvironment,
+    ) -> anyhow::Result<String> {
         Ok(format!(
             "{}-{}",
             match &self.kind {
                 RequestKind::Registry { .. } => "registry",
                 RequestKind::LocalProject { .. } => "local",
             },
-            self.cache_slug()?,
+            self.artifact_slug(build_environment)?,
         ))
     }
 
-    /// A path-safe unique identified that includes the crate's name, version, and features.
-    fn cache_slug(&self) -> anyhow::Result<String> {
+    /// A path-safe unique identifier for the generated rustdoc artifact.
+    fn artifact_slug(&self, build_environment: &RustdocBuildEnvironment) -> anyhow::Result<String> {
         Ok(format!(
             "{}-{}-{}-{}",
             slugify(self.kind.name()?),
             slugify(self.kind.version()?),
-            slugify(self.build_target.unwrap_or("default")),
-            &self.features_fingerprint,
+            slugify(&build_environment.target_triple),
+            self.artifact_fingerprint(build_environment)?,
         ))
+    }
+
+    fn artifact_fingerprint(
+        &self,
+        build_environment: &RustdocBuildEnvironment,
+    ) -> anyhow::Result<String> {
+        // Bump this when the fields or semantics hashed into rustdoc artifact identity change, so
+        // old cache entries and placeholder build directories cannot collide with the new
+        // interpretation.
+        const RUSTDOC_ARTIFACT_FINGERPRINT_SCHEMA: &str = "rustdoc-artifact-v1";
+
+        let mut hasher = sha2::Sha256::new();
+        update_artifact_hash(&mut hasher, "schema", RUSTDOC_ARTIFACT_FINGERPRINT_SCHEMA);
+        update_artifact_hash(
+            &mut hasher,
+            "source",
+            match &self.kind {
+                RequestKind::Registry { .. } => "registry",
+                RequestKind::LocalProject { .. } => "local",
+            },
+        );
+        update_artifact_hash(&mut hasher, "name", self.kind.name()?);
+        update_artifact_hash(&mut hasher, "version", self.kind.version()?);
+        update_artifact_hash(
+            &mut hasher,
+            "default_features",
+            if self.default_features {
+                "true"
+            } else {
+                "false"
+            },
+        );
+        for feature in &self.extra_features {
+            update_artifact_hash(&mut hasher, "feature", feature);
+        }
+        update_artifact_hash(&mut hasher, "target", &build_environment.target_triple);
+        update_artifact_hash(
+            &mut hasher,
+            "rustflags",
+            build_environment.cargo_rustflags.as_ref(),
+        );
+        update_artifact_hash(
+            &mut hasher,
+            "rustdocflags",
+            build_environment.cargo_rustdocflags.as_ref(),
+        );
+        update_artifact_hash(
+            &mut hasher,
+            "toolchain_version",
+            &build_environment.toolchain_version,
+        );
+
+        // Store the hash as string with hex number (leading zeros added).
+        let mut hash = format!("{:0>64x}", hasher.finalize());
+
+        // First 16 hex characters are good enough for our use case.
+        // For birthday paradox to occur, a single crate version must be run
+        // with approximately 2**32 artifact configurations.
+        hash.truncate(16);
+        Ok(hash)
     }
 }
 
@@ -464,26 +523,101 @@ fn load_rustdoc_with_optional_metadata(
     }
 }
 
-fn make_features_hash(default_features: bool, extra_features: &BTreeSet<Cow<'_, str>>) -> String {
-    // Use newlines as the record separator, since newlines are not valid in feature names.
-    let mut hasher = sha2::Sha256::new();
+fn update_artifact_hash(hasher: &mut sha2::Sha256, label: &str, value: &str) {
+    // Length-prefix each field so adjacent records cannot collide by concatenating ambiguously.
+    for entry in [label, value] {
+        let bytes = entry.as_bytes();
+        hasher.update(bytes.len().to_le_bytes());
+        hasher.update(bytes);
+    }
+}
 
-    // The default feature is always first. The name `default` is reserved for default features.
-    if default_features {
-        hasher.update("default\n".as_bytes());
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn test_manifest() -> Manifest {
+        Manifest::parse(PathBuf::from(
+            "test_crates/cfg_conditional_compilation/old/Cargo.toml",
+        ))
+        .expect("failed to load test manifest")
     }
 
-    for feature in extra_features {
-        hasher.update(feature.as_bytes());
-        hasher.update("\n".as_bytes());
+    fn build_environment(
+        target_triple: &str,
+        rustdocflags: &'static str,
+    ) -> RustdocBuildEnvironment {
+        RustdocBuildEnvironment {
+            target_triple: target_triple.to_owned(),
+            cargo_rustflags: Cow::Borrowed("--cap-lints=allow"),
+            cargo_rustdocflags: Cow::Borrowed(rustdocflags),
+            toolchain_version: String::from("1.95.0"),
+        }
     }
 
-    // Store the hash as string with hex number (leading zeros added)
-    let mut hash = format!("{:0>64x}", hasher.finalize());
+    #[test]
+    fn artifact_slug_uses_canonical_target_triple() {
+        let implicit_build_environment =
+            RustdocBuildEnvironment::from_env_and_config_for_target(None)
+                .expect("implicit build environment failed");
+        let target_triple = implicit_build_environment.target_triple.clone();
+        let explicit_build_environment =
+            RustdocBuildEnvironment::from_env_and_config_for_target(Some(&target_triple))
+                .expect("explicit build environment failed");
 
-    // First 16 characters is good enough for our use case.
-    // For birthday paradox to occur, a single crate version must be run
-    // with approximately 2**32 feature configurations.
-    hash.truncate(16);
-    hash
+        let implicit_manifest = test_manifest();
+        let explicit_manifest = test_manifest();
+        let implicit = CrateDataRequest::from_local_project(
+            &implicit_manifest,
+            true,
+            BTreeSet::new(),
+            None,
+            false,
+        );
+        let explicit = CrateDataRequest::from_local_project(
+            &explicit_manifest,
+            true,
+            BTreeSet::new(),
+            Some(&target_triple),
+            false,
+        );
+
+        assert_eq!(
+            implicit
+                .artifact_slug(&implicit_build_environment)
+                .expect("implicit artifact slug failed"),
+            explicit
+                .artifact_slug(&explicit_build_environment)
+                .expect("explicit artifact slug failed"),
+        );
+    }
+
+    #[test]
+    fn artifact_slug_includes_effective_rustdocflags() {
+        let manifest = test_manifest();
+        let request =
+            CrateDataRequest::from_local_project(&manifest, true, BTreeSet::new(), None, false);
+        let host_environment = RustdocBuildEnvironment::from_env_and_config_for_target(None)
+            .expect("build environment failed");
+        let without_cfg = build_environment(
+            &host_environment.target_triple,
+            "-Z unstable-options --document-private-items --document-hidden-items --output-format=json --cap-lints=allow",
+        );
+        let with_cfg = build_environment(
+            &host_environment.target_triple,
+            "--cfg custom -Z unstable-options --document-private-items --document-hidden-items --output-format=json --cap-lints=allow",
+        );
+
+        assert_ne!(
+            request
+                .artifact_slug(&without_cfg)
+                .expect("artifact slug without cfg failed"),
+            request
+                .artifact_slug(&with_cfg)
+                .expect("artifact slug with cfg failed"),
+        );
+    }
 }


### PR DESCRIPTION
Collisions caused by two concurrent `cargo-semver-checks` invocations on the same project with different `--cfg` flags were causing flaky CI tests, and in principle could also cause false-positive/false-negative outcomes from incorrect cache key reuse. This PR resolves that issue.
