### PR TITLE
Remove the unused toggle for disabling `--no-deps` rustdoc mode.

### DIFF
--- a/src/data_generation/generate.rs
+++ b/src/data_generation/generate.rs
@@ -18,9 +18,6 @@ pub(crate) struct GenerationSettings {
 
     /// On `true`, pass `--color=always` to `cargo` invocations. On `false`, pass `--color=never`.
     pub(crate) use_color: bool,
-
-    /// On `false`, pass `--no-deps` to `cargo`.
-    pub(crate) deps: bool,
 }
 
 impl GenerationSettings {
@@ -514,9 +511,7 @@ fn run_cargo_doc(
     if let Some(build_target) = request.build_target {
         cmd.arg("--target").arg(build_target);
     }
-    if !settings.deps {
-        cmd.arg("--no-deps");
-    }
+    cmd.arg("--no-deps");
 
     // Respect our configured color choice
     cmd.arg(settings.color_flag());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,7 +401,6 @@ impl Check {
     pub fn check_release(&self, config: &mut GlobalConfig) -> anyhow::Result<Report> {
         let generation_settings = data_generation::GenerationSettings {
             use_color: config.err_color_choice(),
-            deps: false,
             pass_through_stderr: config.is_verbose(),
         };
 

--- a/src/witness_gen/test_support.rs
+++ b/src/witness_gen/test_support.rs
@@ -233,7 +233,6 @@ pub(super) fn make_test_data_storage(
     let generation_settings = GenerationSettings {
         pass_through_stderr: false,
         use_color: false,
-        deps: false,
     };
     let mut callbacks = NoopProgressCallbacks;
     let baseline_storage = baseline_request


### PR DESCRIPTION
We always pass `--no-deps`, so the setting is just noise.
