### PR TITLE
Add next Rust minor to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
         #
         #            Also make sure to update the MSRV in the cargo-semver-checks-action CI:
         #            https://github.com/obi1kenobi/cargo-semver-checks-action/blob/main/.github/workflows/test-action.yml#L18
-        toolchain: ["1.91", "1.92", "1.93", "1.94", "stable", "beta"]
+        toolchain: ["1.91", "1.92", "1.93", "1.94", "1.95", "stable", "beta"]
         experimental: [false]
         include:
           - toolchain: "nightly"
@@ -2366,7 +2366,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: ["1.91", "1.92", "1.93", "1.94", "stable"]
+        toolchain: ["1.91", "1.92", "1.93", "1.94", "1.95", "stable"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Automation to ensure we test on all supported Rust versions as new stable Rust versions are released.

The following is the output from `git diff`:

```diff
diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
index bf0485a..0c6211f 100644
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
         #
         #            Also make sure to update the MSRV in the cargo-semver-checks-action CI:
         #            https://github.com/obi1kenobi/cargo-semver-checks-action/blob/main/.github/workflows/test-action.yml#L18
-        toolchain: ["1.91", "1.92", "1.93", "1.94", "stable", "beta"]
+        toolchain: ["1.91", "1.92", "1.93", "1.94", "1.95", "stable", "beta"]
         experimental: [false]
         include:
           - toolchain: "nightly"
@@ -2366,7 +2366,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: ["1.91", "1.92", "1.93", "1.94", "stable"]
+        toolchain: ["1.91", "1.92", "1.93", "1.94", "1.95", "stable"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
```
