### PR TITLE
Allow invocation from full binary name instead of cargo subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,15 @@ fn main() {
     }
     .write_global();
 
-    let Cargo::SemverChecks(args) = Cargo::parse();
+    // Catch possible invocations from development tooling that use `cargo run` or with the full
+    // binary name `cargo-semver-checks`, and normalize the expected subcommand so that it works the
+    // same way as the cargo wrapper `cargo semver-checks` style invocation.
+    let mut raw_args: Vec<_> = env::args_os().collect();
+    if raw_args.get(1).is_none_or(|arg| arg != "semver-checks") {
+        raw_args.insert(1, "semver-checks".into());
+    }
+
+    let Cargo::SemverChecks(args) = Cargo::parse_from(raw_args);
 
     let feature_flags = HashSet::from_iter(args.unstable_features.clone());
 


### PR DESCRIPTION
This project has continually annoyed me by making it hard to invoke the right tooling from specialized environments with hard coded tool paths. Using the indented Cargo wrapper to invoke the subcommand as `cargo semver-checks` works fine, but if you hard code a path to a binary like `/usr/bin/cargo-semver-checks` it refuses to run because it doesn't have the same argument structure and the top level `cargo` subcommand isn't found. This makes it difficult to do conditional execution such as finding the binary and then executing the binary you found or hard coding a full path to it somewhere out of the shell `$PATH`.

This fixes that by allowing invocation with either the full binary name *or* the cargo wrapper. This is similar to how many other Cargo tools work. For example `cargo deny` works this way (except they check for and *remove* the extra subcommand instead of checking for it's absence and adding it, but this was less disruptive to the rest of the CLI argument handling.

https://github.com/EmbarkStudios/cargo-deny/blob/main/src/cargo-deny/main.rs#L265-L269