### PR TITLE
Upgrade dev dependency major versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,18 +537,6 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
@@ -2062,12 +2050,12 @@ version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
- "console 0.16.3",
+ "console",
  "once_cell",
  "regex",
  "ron",
  "serde",
- "similar",
+ "similar 2.7.0",
  "strip-ansi-escapes",
  "tempfile",
  "toml_edit",
@@ -2076,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "insta-cmd"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffeeefa927925cced49ccb01bf3e57c9d4cd132df21e576eb9415baeab2d3de6"
+checksum = "bffdf4af1db390cf0401535d7c1303cd079a074d28d8473b026fdb6559c41403"
 dependencies = [
  "insta",
  "serde",
@@ -3140,6 +3128,12 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "similar"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
 dependencies = [
  "bstr",
  "unicode-segmentation",
@@ -3147,13 +3141,13 @@ dependencies = [
 
 [[package]]
 name = "similar-asserts"
-version = "1.7.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
+checksum = "997e6ca38e97437973fc9f7f50a50d1274cacd874341a4960fea90067291038c"
 dependencies = [
- "console 0.15.11",
+ "console",
  "serde",
- "similar",
+ "similar 3.1.1",
 ]
 
 [[package]]
@@ -4151,15 +4145,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,11 +56,11 @@ rand = "0.9.2"
 
 [dev-dependencies]
 assert_cmd = "2.0"
-similar-asserts = { version = "1.6.1", features = ["serde"] }
+similar-asserts = { version = "2.0.0", features = ["serde"] }
 predicates = "3.1.3"
 insta = { version = "1.42.0", features = ["ron", "filters", "toml"] }
 regex = "1.11.1"
-insta-cmd = "0.6.0"
+insta-cmd = "0.7.0"
 rayon = "1.10.0"
 trustfall_core = "0.8.1"  # Ensure this matches the `trustfall` version above.
 


### PR DESCRIPTION
## Summary

- Upgrade `insta-cmd` from `0.6.0` to `0.7.0`.
- Upgrade `similar-asserts` from `1.x` to `2.0.0`.
- Refresh the lockfile for the resulting dev-dependency graph changes.

## Notes

`similar-asserts` 2.0 moves to Rust 2024 with MSRV 1.85 and uses `similar` 3. The repository MSRV is 1.91, and no source changes were needed.

## Validation

- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets --no-deps --fix --allow-dirty --allow-staged -- -D warnings --allow deprecated`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items`
- `cargo test`

The sandboxed `cargo test` run hit the known crates.io DNS failure in the `target_specific_dependencies` fixture; the network-enabled retry passed.