### PR TITLE
Upgrade cargo_toml to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ checksum = "25ada53f7339c78084fb37d7e17f34e76537541c4fbb02fa3a2baa14b8faad37"
 dependencies = [
  "serde",
  "serde_derive",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -314,7 +314,7 @@ dependencies = [
  "bugreport",
  "cargo-config2",
  "cargo_metadata",
- "cargo_toml 0.22.3",
+ "cargo_toml",
  "clap",
  "clap-cargo",
  "clap-verbosity-flag",
@@ -342,7 +342,7 @@ dependencies = [
  "sha2 0.10.9",
  "similar-asserts",
  "tame-index",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "trustfall",
  "trustfall_core",
  "trustfall_rustdoc",
@@ -365,23 +365,13 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
-dependencies = [
- "serde",
- "toml 0.9.12+spec-1.1.0",
-]
-
-[[package]]
-name = "cargo_toml"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa61aec073ec94791433ddf3df2323ff9d1711557c2a0eefb0f99cb4f8dca520"
 dependencies = [
  "semver",
  "serde",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -1809,7 +1799,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sysinfo 0.38.4",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "uuid",
 ]
 
@@ -3421,21 +3411,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
@@ -3443,10 +3418,10 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -3456,15 +3431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f22ba417d437b5fa5dcba6c27dbd6c14f38845315b724d89fed73b7a426451b7"
 dependencies = [
  "smallvec",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -3485,10 +3451,10 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -3497,7 +3463,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -3593,7 +3559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b6527fffe29ec0456f4ca5135b2eb33c3463bf336fafd54ecde198c4593a73"
 dependencies = [
  "cargo_metadata",
- "cargo_toml 1.0.0",
+ "cargo_toml",
  "indexmap",
  "rayon",
  "rustc-hash",
@@ -3608,7 +3574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61a48f46a8ee5b56fe9edf4f539d6eaa4fbbb0aa13da78e80366b5fac7a16009"
 dependencies = [
  "cargo_metadata",
- "cargo_toml 1.0.0",
+ "cargo_toml",
  "indexmap",
  "rayon",
  "rustc-hash",
@@ -3623,7 +3589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "557031fcc0a5f7ac758f3d728a8f475460bc62c660f369b2f3d4cf3ab8f47b7f"
 dependencies = [
  "cargo_metadata",
- "cargo_toml 1.0.0",
+ "cargo_toml",
  "indexmap",
  "rayon",
  "rustc-hash",
@@ -4206,12 +4172,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ rustls = { version = "0.23.36", default-features = false, features = ["ring", "s
 human-panic = "2.0.2"
 bugreport = "0.6.0"
 itertools = "0.15.0"
-cargo_toml = "0.22.1"
+cargo_toml = "1.0.0"
 toml = "1.1.2"
 directories = "6.0.0"
 sha2 = "0.10.8"

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -6,8 +6,8 @@ pub(crate) struct Callbacks<'a> {
     config: &'a mut GlobalConfig,
 
     // (crate_name, version, is_baseline) keys
-    generate_starts: BTreeMap<(&'a str, &'a str, bool), std::time::Instant>,
-    parse_starts: BTreeMap<(&'a str, &'a str, bool), std::time::Instant>,
+    generate_starts: BTreeMap<(String, String, bool), std::time::Instant>,
+    parse_starts: BTreeMap<(String, String, bool), std::time::Instant>,
 }
 
 impl<'a> Callbacks<'a> {
@@ -21,7 +21,7 @@ impl<'a> Callbacks<'a> {
 }
 
 impl<'a> crate::data_generation::ProgressCallbacks<'a> for Callbacks<'a> {
-    fn generate_rustdoc_start(&mut self, crate_name: &'a str, version: &'a str, is_baseline: bool) {
+    fn generate_rustdoc_start(&mut self, crate_name: &str, version: &str, is_baseline: bool) {
         let kind = if is_baseline { "baseline" } else { "current" };
 
         // Ignore terminal printing failures.
@@ -31,21 +31,16 @@ impl<'a> crate::data_generation::ProgressCallbacks<'a> for Callbacks<'a> {
         );
 
         self.generate_starts.insert(
-            (crate_name, version, is_baseline),
+            (crate_name.to_owned(), version.to_owned(), is_baseline),
             std::time::Instant::now(),
         );
     }
 
-    fn generate_rustdoc_success(
-        &mut self,
-        crate_name: &'a str,
-        version: &'a str,
-        is_baseline: bool,
-    ) {
+    fn generate_rustdoc_success(&mut self, crate_name: &str, version: &str, is_baseline: bool) {
         let kind = if is_baseline { "baseline" } else { "current" };
         let start = self
             .generate_starts
-            .remove(&(crate_name, version, is_baseline))
+            .remove(&(crate_name.to_owned(), version.to_owned(), is_baseline))
             .expect("success on generation task that never started");
 
         // Ignore terminal printing failures.
@@ -58,8 +53,8 @@ impl<'a> crate::data_generation::ProgressCallbacks<'a> for Callbacks<'a> {
     fn parse_rustdoc_start(
         &mut self,
         cached: bool,
-        crate_name: &'a str,
-        version: &'a str,
+        crate_name: &str,
+        version: &str,
         is_baseline: bool,
     ) {
         let kind = if is_baseline { "baseline" } else { "current" };
@@ -72,7 +67,7 @@ impl<'a> crate::data_generation::ProgressCallbacks<'a> for Callbacks<'a> {
         );
 
         self.parse_starts.insert(
-            (crate_name, version, is_baseline),
+            (crate_name.to_owned(), version.to_owned(), is_baseline),
             std::time::Instant::now(),
         );
     }
@@ -80,14 +75,14 @@ impl<'a> crate::data_generation::ProgressCallbacks<'a> for Callbacks<'a> {
     fn parse_rustdoc_success(
         &mut self,
         _cached: bool,
-        crate_name: &'a str,
-        version: &'a str,
+        crate_name: &str,
+        version: &str,
         is_baseline: bool,
     ) {
         let kind = if is_baseline { "baseline" } else { "current" };
         let start = self
             .parse_starts
-            .remove(&(crate_name, version, is_baseline))
+            .remove(&(crate_name.to_owned(), version.to_owned(), is_baseline))
             .expect("success on parse task that never started");
 
         // Ignore terminal printing failures.
@@ -99,8 +94,8 @@ impl<'a> crate::data_generation::ProgressCallbacks<'a> for Callbacks<'a> {
 
     fn non_fatal_error(
         &mut self,
-        crate_name: &'a str,
-        version: &'a str,
+        crate_name: &str,
+        version: &str,
         is_baseline: bool,
         error: anyhow::Error,
     ) {

--- a/src/data_generation/generate.rs
+++ b/src/data_generation/generate.rs
@@ -149,7 +149,7 @@ pub(super) fn generate_rustdoc(
         // That issue is tracked here: https://github.com/obi1kenobi/cargo-semver-checks/issues/902
         match run_cargo_update(
             crate_name,
-            version,
+            version.as_ref(),
             request,
             placeholder_manifest_path.as_path(),
             &settings,
@@ -181,7 +181,7 @@ pub(super) fn generate_rustdoc(
         &placeholder_manifest_path,
         target_dir,
         crate_name,
-        version,
+        version.as_ref(),
         &settings,
         build_environment,
         callbacks,
@@ -195,7 +195,11 @@ fn produce_repro_workspace_shell_commands(request: &CrateDataRequest<'_>) -> Str
         RequestKind::Registry { .. } => format!(
             "{}@={}",
             request.kind.name().expect("failed to get crate name"),
-            request.kind.version().expect("failed to get crate version")
+            request
+                .kind
+                .version()
+                .expect("failed to get crate version")
+                .as_ref()
         ),
         RequestKind::LocalProject(project) => format!(
             "--path {}",
@@ -812,7 +816,12 @@ fn create_placeholder_rustdoc_manifest(
 
     Ok(Manifest::<()> {
         package: {
-            let mut package = Package::new("placeholder", "0.0.0");
+            let mut package = Package::new(
+                "placeholder",
+                "0.0.0"
+                    .parse()
+                    .expect("hardcoded semver version should parse"),
+            );
             package.publish = Inheritable::Set(Publish::Flag(false));
             Some(package)
         },
@@ -830,7 +839,11 @@ fn create_placeholder_rustdoc_manifest(
                     // We need the *exact* version as a dependency, or else cargo will
                     // give us the latest semver-compatible version which is not we want.
                     // Fixes: https://github.com/obi1kenobi/cargo-semver-checks/issues/261
-                    version: Some(format!("={}", request.kind.version()?)),
+                    version: Some(
+                        format!("={}", request.kind.version()?.as_ref())
+                            .parse()
+                            .context("failed to parse exact dependency version requirement")?,
+                    ),
                     default_features: request.default_features,
                     features: request
                         .extra_features

--- a/src/data_generation/progress.rs
+++ b/src/data_generation/progress.rs
@@ -1,47 +1,36 @@
+use std::borrow::Cow;
+
 #[allow(unused_variables)] // All default implementations are no-ops.
 pub(crate) trait ProgressCallbacks<'a> {
     fn generate_placeholder_project_start(
         &mut self,
-        crate_name: &'a str,
-        version: &'a str,
+        crate_name: &str,
+        version: &str,
         is_baseline: bool,
     ) {
     }
 
     fn generate_placeholder_project_success(
         &mut self,
-        crate_name: &'a str,
-        version: &'a str,
+        crate_name: &str,
+        version: &str,
         is_baseline: bool,
     ) {
     }
 
-    fn rustdoc_cache_hit(&mut self, crate_name: &'a str, version: &'a str, is_baseline: bool) {}
+    fn rustdoc_cache_hit(&mut self, crate_name: &str, version: &str, is_baseline: bool) {}
 
-    fn generate_rustdoc_start(&mut self, crate_name: &'a str, version: &'a str, is_baseline: bool) {
-    }
+    fn generate_rustdoc_start(&mut self, crate_name: &str, version: &str, is_baseline: bool) {}
 
-    fn generate_rustdoc_success(
-        &mut self,
-        crate_name: &'a str,
-        version: &'a str,
-        is_baseline: bool,
-    ) {
-    }
+    fn generate_rustdoc_success(&mut self, crate_name: &str, version: &str, is_baseline: bool) {}
 
-    fn rustdoc_cache_populated(
-        &mut self,
-        crate_name: &'a str,
-        version: &'a str,
-        is_baseline: bool,
-    ) {
-    }
+    fn rustdoc_cache_populated(&mut self, crate_name: &str, version: &str, is_baseline: bool) {}
 
     fn parse_rustdoc_start(
         &mut self,
         cached: bool,
-        crate_name: &'a str,
-        version: &'a str,
+        crate_name: &str,
+        version: &str,
         is_baseline: bool,
     ) {
     }
@@ -49,16 +38,16 @@ pub(crate) trait ProgressCallbacks<'a> {
     fn parse_rustdoc_success(
         &mut self,
         cached: bool,
-        crate_name: &'a str,
-        version: &'a str,
+        crate_name: &str,
+        version: &str,
         is_baseline: bool,
     ) {
     }
 
     fn non_fatal_error(
         &mut self,
-        crate_name: &'a str,
-        version: &'a str,
+        crate_name: &str,
+        version: &str,
         is_baseline: bool,
         error: anyhow::Error,
     ) {
@@ -67,7 +56,7 @@ pub(crate) trait ProgressCallbacks<'a> {
 
 pub(crate) struct CallbackHandler<'a> {
     crate_name: &'a str,
-    version: &'a str,
+    version: Cow<'a, str>,
     is_baseline: bool,
     callbacks: &'a mut dyn ProgressCallbacks<'a>,
 }
@@ -85,13 +74,13 @@ impl std::fmt::Debug for CallbackHandler<'_> {
 impl<'a> CallbackHandler<'a> {
     pub(crate) fn new(
         crate_name: &'a str,
-        version: &'a str,
+        version: impl Into<Cow<'a, str>>,
         is_baseline: bool,
         callbacks: &'a mut dyn ProgressCallbacks<'a>,
     ) -> Self {
         Self {
             crate_name,
-            version,
+            version: version.into(),
             is_baseline,
             callbacks,
         }
@@ -100,7 +89,7 @@ impl<'a> CallbackHandler<'a> {
     pub(super) fn generate_placeholder_project_start(&mut self) {
         self.callbacks.generate_placeholder_project_start(
             self.crate_name,
-            self.version,
+            self.version.as_ref(),
             self.is_baseline,
         )
     }
@@ -108,47 +97,64 @@ impl<'a> CallbackHandler<'a> {
     pub(super) fn generate_placeholder_project_success(&mut self) {
         self.callbacks.generate_placeholder_project_success(
             self.crate_name,
-            self.version,
+            self.version.as_ref(),
             self.is_baseline,
         )
     }
 
     pub(super) fn rustdoc_cache_hit(&mut self) {
         self.callbacks
-            .rustdoc_cache_hit(self.crate_name, self.version, self.is_baseline)
+            .rustdoc_cache_hit(self.crate_name, self.version.as_ref(), self.is_baseline)
     }
 
     pub(super) fn generate_rustdoc_start(&mut self) {
-        self.callbacks
-            .generate_rustdoc_start(self.crate_name, self.version, self.is_baseline)
+        self.callbacks.generate_rustdoc_start(
+            self.crate_name,
+            self.version.as_ref(),
+            self.is_baseline,
+        )
     }
 
     pub(super) fn generate_rustdoc_success(&mut self) {
-        self.callbacks
-            .generate_rustdoc_success(self.crate_name, self.version, self.is_baseline)
+        self.callbacks.generate_rustdoc_success(
+            self.crate_name,
+            self.version.as_ref(),
+            self.is_baseline,
+        )
     }
 
     pub(super) fn rustdoc_cache_populated(&mut self) {
-        self.callbacks
-            .rustdoc_cache_populated(self.crate_name, self.version, self.is_baseline)
+        self.callbacks.rustdoc_cache_populated(
+            self.crate_name,
+            self.version.as_ref(),
+            self.is_baseline,
+        )
     }
 
     pub(super) fn parse_rustdoc_start(&mut self, cached: bool) {
-        self.callbacks
-            .parse_rustdoc_start(cached, self.crate_name, self.version, self.is_baseline)
+        self.callbacks.parse_rustdoc_start(
+            cached,
+            self.crate_name,
+            self.version.as_ref(),
+            self.is_baseline,
+        )
     }
 
     pub(super) fn parse_rustdoc_success(&mut self, cached: bool) {
         self.callbacks.parse_rustdoc_success(
             cached,
             self.crate_name,
-            self.version,
+            self.version.as_ref(),
             self.is_baseline,
         )
     }
 
     pub(super) fn non_fatal_error(&mut self, error: anyhow::Error) {
-        self.callbacks
-            .non_fatal_error(self.crate_name, self.version, self.is_baseline, error)
+        self.callbacks.non_fatal_error(
+            self.crate_name,
+            self.version.as_ref(),
+            self.is_baseline,
+            error,
+        )
     }
 }

--- a/src/data_generation/request.rs
+++ b/src/data_generation/request.rs
@@ -38,11 +38,13 @@ impl RequestKind<'_> {
         })
     }
 
-    pub(super) fn version(&self) -> anyhow::Result<&str> {
+    pub(super) fn version(&self) -> anyhow::Result<Cow<'_, str>> {
         Ok(match self {
-            Self::Registry(RegistryRequest { index_entry }) => index_entry.version.as_str(),
+            Self::Registry(RegistryRequest { index_entry }) => {
+                Cow::Borrowed(index_entry.version.as_str())
+            }
             Self::LocalProject(ProjectRequest { manifest }) => {
-                crate::manifest::get_package_version(manifest)?
+                Cow::Owned(crate::manifest::get_package_version(manifest)?)
             }
         })
     }
@@ -258,7 +260,7 @@ impl<'a> CrateDataRequest<'a> {
     }
 
     pub(crate) fn exact_version(&self) -> anyhow::Result<String> {
-        Ok(format!("={}", self.kind.version()?))
+        Ok(format!("={}", self.kind.version()?.as_ref()))
     }
 
     pub(crate) fn local_project_dir(&self) -> anyhow::Result<Option<PathBuf>> {
@@ -309,15 +311,17 @@ impl<'a> CrateDataRequest<'a> {
         generation_settings: GenerationSettings,
         callbacks: &'slf mut dyn ProgressCallbacks<'slf>,
     ) -> Result<VersionedStorage, TerminalError> {
+        let version = self
+            .kind
+            .version()
+            .context("failed to get crate version")
+            .into_terminal_result()?;
         let mut callbacks = CallbackHandler::new(
             self.kind
                 .name()
                 .context("failed to get crate name")
                 .into_terminal_result()?,
-            self.kind
-                .version()
-                .context("failed to get crate version")
-                .into_terminal_result()?,
+            version,
             self.is_baseline,
             callbacks,
         );
@@ -455,7 +459,7 @@ impl<'a> CrateDataRequest<'a> {
         Ok(format!(
             "{}-{}-{}-{}",
             slugify(self.kind.name()?),
-            slugify(self.kind.version()?),
+            slugify(self.kind.version()?.as_ref()),
             slugify(&build_environment.target_triple),
             self.artifact_fingerprint(build_environment)?,
         ))
@@ -481,7 +485,7 @@ impl<'a> CrateDataRequest<'a> {
             },
         );
         update_artifact_hash(&mut hasher, "name", self.kind.name()?);
-        update_artifact_hash(&mut hasher, "version", self.kind.version()?);
+        update_artifact_hash(&mut hasher, "version", self.kind.version()?.as_ref());
         update_artifact_hash(
             &mut hasher,
             "default_features",

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -50,7 +50,7 @@ pub(crate) fn get_package_name(manifest: &Manifest) -> anyhow::Result<&str> {
     Ok(&package.name)
 }
 
-pub(crate) fn get_package_version(manifest: &Manifest) -> anyhow::Result<&str> {
+pub(crate) fn get_package_version(manifest: &Manifest) -> anyhow::Result<String> {
     let package = manifest.parsed.package.as_ref().with_context(|| {
         format!(
             "failed to parse {}: no `package` table",
@@ -63,7 +63,7 @@ pub(crate) fn get_package_version(manifest: &Manifest) -> anyhow::Result<&str> {
             manifest.path.display()
         )
     })?;
-    Ok(version)
+    Ok(version.to_string())
 }
 
 /// Returns the Rust library target name that downstream code imports.


### PR DESCRIPTION
## Summary

- Upgrade `cargo_toml` from `0.22.1` to `1.0.0`.
- Adapt placeholder manifest generation to `cargo_toml`'s semver-typed package and dependency versions.
- Return local project versions as owned strings where needed.
- Relax progress callback version parameters to `&str` and store timing keys as owned strings.
- Refresh the lockfile, including removal of the now-unused old `toml 0.9` graph after rebasing onto `main`.

## Notes

`cargo_toml` 1.0 models package versions and dependency version requirements with semver types. The main behavioral point is that generated placeholder manifests now parse the hardcoded placeholder version and exact dependency requirement instead of storing raw strings.

This branch was rebased onto the latest `origin/main` before opening the PR. The rebase conflict was limited to the dependency block already changed by the no-code upgrades.

## Validation

- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets --no-deps --fix --allow-dirty --allow-staged -- -D warnings --allow deprecated`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items`
- `cargo test`