### PR TITLE
fix(cli): honor --package with --workspace

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,8 +154,7 @@ impl Default for ScopeMode {
 #[derive(Default, Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct PackageSelection {
     selection: ScopeSelection,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    included_packages: Vec<String>,
+    explicitly_included_packages: Vec<String>,
     excluded_packages: Vec<String>,
 }
 
@@ -163,13 +162,13 @@ impl PackageSelection {
     pub fn new(selection: ScopeSelection) -> Self {
         Self {
             selection,
-            included_packages: vec![],
+            explicitly_included_packages: vec![],
             excluded_packages: vec![],
         }
     }
 
-    pub fn set_included_packages(&mut self, packages: Vec<String>) -> &mut Self {
-        self.included_packages = packages;
+    pub fn set_explicitly_included_packages(&mut self, packages: Vec<String>) -> &mut Self {
+        self.explicitly_included_packages = packages;
         self
     }
 
@@ -202,7 +201,7 @@ impl Scope {
         let base_ids: HashSet<&PackageId> = match &self.mode {
             ScopeMode::DenyList(PackageSelection {
                 selection,
-                included_packages: _,
+                explicitly_included_packages: _,
                 excluded_packages,
             }) => {
                 let packages = match selection {
@@ -518,8 +517,9 @@ note: skipped the following crates since they have no library target: {skipped}"
                         let is_explicitly_included = match &self.scope.mode {
                             ScopeMode::AllowList(packages) => packages.contains(&selected.name),
                             ScopeMode::DenyList(PackageSelection {
-                                included_packages, ..
-                            }) => included_packages.contains(&selected.name),
+                                explicitly_included_packages,
+                                ..
+                            }) => explicitly_included_packages.contains(&selected.name),
                         };
                         let is_implied = !is_explicitly_included
                             && metadata.workspace_members.len() > 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,7 @@ impl Default for ScopeMode {
 #[derive(Default, Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct PackageSelection {
     selection: ScopeSelection,
+    included_packages: Vec<String>,
     excluded_packages: Vec<String>,
 }
 
@@ -161,8 +162,14 @@ impl PackageSelection {
     pub fn new(selection: ScopeSelection) -> Self {
         Self {
             selection,
+            included_packages: vec![],
             excluded_packages: vec![],
         }
+    }
+
+    pub fn set_included_packages(&mut self, packages: Vec<String>) -> &mut Self {
+        self.included_packages = packages;
+        self
     }
 
     pub fn set_excluded_packages(&mut self, packages: Vec<String>) -> &mut Self {
@@ -194,6 +201,7 @@ impl Scope {
         let base_ids: HashSet<&PackageId> = match &self.mode {
             ScopeMode::DenyList(PackageSelection {
                 selection,
+                included_packages: _,
                 excluded_packages,
             }) => {
                 let packages = match selection {
@@ -506,7 +514,13 @@ note: skipped the following crates since they have no library target: {skipped}"
                         // ignore `publish = false` crates unless they are specifically selected.
                         // If the manifest points to a specific crate, then check the crate
                         // even if `publish = false` is set.
-                        let is_implied = matches!(self.scope.mode, ScopeMode::DenyList(..))
+                        let is_explicitly_included = match &self.scope.mode {
+                            ScopeMode::AllowList(packages) => packages.contains(&selected.name),
+                            ScopeMode::DenyList(PackageSelection {
+                                included_packages, ..
+                            }) => included_packages.contains(&selected.name),
+                        };
+                        let is_implied = !is_explicitly_included
                             && metadata.workspace_members.len() > 1
                             && selected.publish == Some(vec![]);
                         if is_implied {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,7 @@ impl Default for ScopeMode {
 #[derive(Default, Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct PackageSelection {
     selection: ScopeSelection,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     included_packages: Vec<String>,
     excluded_packages: Vec<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -594,6 +594,7 @@ impl From<CheckRelease> for cargo_semver_checks::Check {
         if value.workspace.all || value.workspace.workspace {
             // Specified explicit `--workspace` or `--all`.
             let mut selection = PackageSelection::new(ScopeSelection::Workspace);
+            selection.set_included_packages(value.workspace.package);
             selection.set_excluded_packages(value.workspace.exclude);
             check.set_package_selection(selection);
         } else if !value.workspace.package.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -594,7 +594,7 @@ impl From<CheckRelease> for cargo_semver_checks::Check {
         if value.workspace.all || value.workspace.workspace {
             // Specified explicit `--workspace` or `--all`.
             let mut selection = PackageSelection::new(ScopeSelection::Workspace);
-            selection.set_included_packages(value.workspace.package);
+            selection.set_explicitly_included_packages(value.workspace.package);
             selection.set_excluded_packages(value.workspace.exclude);
             check.set_package_selection(selection);
         } else if !value.workspace.package.is_empty() {

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -294,10 +294,10 @@ fn workspace_publish_false_explicit() {
     )
 }
 
-/// Running `cargo semver-checks` on a workspace with a `package = false` member,
-/// explicitly including that member with `--package` and also specifying `--workspace`.
-/// The workspace selection should still apply, but the explicitly included package should
-/// be semver-checked even if it has `publish = false`.
+/// Running `cargo semver-checks` on a workspace with `publish = false` members,
+/// explicitly including one such member with `--package` and also specifying `--workspace`.
+/// The explicitly included package and the publishable workspace member should be
+/// semver-checked, while the implicitly selected `publish = false` package should be skipped.
 ///
 /// Regression test for:
 /// https://github.com/obi1kenobi/cargo-semver-checks/issues/868
@@ -309,9 +309,9 @@ fn workspace_publish_false_workspace_flag() {
             "cargo",
             "semver-checks",
             "--manifest-path",
-            "test_crates/manifest_tests/workspace_all_publish_false/new",
+            "test_crates/manifest_tests/workspace_publish_false_mixed/new",
             "--baseline-root",
-            "test_crates/manifest_tests/workspace_all_publish_false/old",
+            "test_crates/manifest_tests/workspace_publish_false_mixed/old",
             "--workspace",
             "--package",
             "a",

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -296,10 +296,10 @@ fn workspace_publish_false_explicit() {
 
 /// Running `cargo semver-checks` on a workspace with a `package = false` member,
 /// explicitly including that member with `--package` and also specifying `--workspace`.
-/// Currently, `--workspace` overrides `--package` and the `publish = false` member is not
-/// semver-checked, and `cargo-semver-checks` silently exits 0.
+/// The workspace selection should still apply, but the explicitly included package should
+/// be semver-checked even if it has `publish = false`.
 ///
-/// Changing this behavior to make it more consistent is tracked in:
+/// Regression test for:
 /// https://github.com/obi1kenobi/cargo-semver-checks/issues/868
 #[test]
 fn workspace_publish_false_workspace_flag() {
@@ -315,8 +315,6 @@ fn workspace_publish_false_workspace_flag() {
             "--workspace",
             "--package",
             "a",
-            // use verbose mode to show what is being skipped
-            "--verbose",
         ],
     )
 }

--- a/test_crates/manifest_tests/workspace_publish_false_mixed/new/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_publish_false_mixed/new/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+resolver = "2"
+members = ["a", "b", "c"]

--- a/test_crates/manifest_tests/workspace_publish_false_mixed/new/a/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_publish_false_mixed/new/a/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "a"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]

--- a/test_crates/manifest_tests/workspace_publish_false_mixed/new/a/src/lib.rs
+++ b/test_crates/manifest_tests/workspace_publish_false_mixed/new/a/src/lib.rs
@@ -1,0 +1,1 @@
+// `private_explicit()` was removed in this version.

--- a/test_crates/manifest_tests/workspace_publish_false_mixed/new/b/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_publish_false_mixed/new/b/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "b"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]

--- a/test_crates/manifest_tests/workspace_publish_false_mixed/new/b/src/lib.rs
+++ b/test_crates/manifest_tests/workspace_publish_false_mixed/new/b/src/lib.rs
@@ -1,0 +1,1 @@
+// `private_implicit()` was removed in this version.

--- a/test_crates/manifest_tests/workspace_publish_false_mixed/new/c/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_publish_false_mixed/new/c/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "c"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/workspace_publish_false_mixed/new/c/src/lib.rs
+++ b/test_crates/manifest_tests/workspace_publish_false_mixed/new/c/src/lib.rs
@@ -1,0 +1,1 @@
+// `public_workspace_member()` was removed in this version.

--- a/test_crates/manifest_tests/workspace_publish_false_mixed/old/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_publish_false_mixed/old/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+resolver = "2"
+members = ["a", "b", "c"]

--- a/test_crates/manifest_tests/workspace_publish_false_mixed/old/a/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_publish_false_mixed/old/a/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "a"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]

--- a/test_crates/manifest_tests/workspace_publish_false_mixed/old/a/src/lib.rs
+++ b/test_crates/manifest_tests/workspace_publish_false_mixed/old/a/src/lib.rs
@@ -1,0 +1,1 @@
+pub fn private_explicit() {}

--- a/test_crates/manifest_tests/workspace_publish_false_mixed/old/b/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_publish_false_mixed/old/b/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "b"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]

--- a/test_crates/manifest_tests/workspace_publish_false_mixed/old/b/src/lib.rs
+++ b/test_crates/manifest_tests/workspace_publish_false_mixed/old/b/src/lib.rs
@@ -1,0 +1,1 @@
+pub fn private_implicit() {}

--- a/test_crates/manifest_tests/workspace_publish_false_mixed/old/c/Cargo.toml
+++ b/test_crates/manifest_tests/workspace_publish_false_mixed/old/c/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "c"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/manifest_tests/workspace_publish_false_mixed/old/c/src/lib.rs
+++ b/test_crates/manifest_tests/workspace_publish_false_mixed/old/c/src/lib.rs
@@ -1,0 +1,1 @@
+pub fn public_workspace_member() {}

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__multiple_ambiguous_package_name_definitions-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__multiple_ambiguous_package_name_definitions-input.snap
@@ -6,6 +6,7 @@ Check(
   scope: Scope(
     mode: DenyList(PackageSelection(
       selection: DefaultMembers,
+      explicitly_included_packages: [],
       excluded_packages: [],
     )),
   ),

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__semver_trick_self_referential-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__semver_trick_self_referential-input.snap
@@ -6,6 +6,7 @@ Check(
   scope: Scope(
     mode: DenyList(PackageSelection(
       selection: DefaultMembers,
+      explicitly_included_packages: [],
       excluded_packages: [],
     )),
   ),

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_all_publish_false-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_all_publish_false-input.snap
@@ -6,6 +6,7 @@ Check(
   scope: Scope(
     mode: DenyList(PackageSelection(
       selection: Workspace,
+      explicitly_included_packages: [],
       excluded_packages: [],
     )),
   ),

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_baseline_compile_error-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_baseline_compile_error-input.snap
@@ -6,6 +6,7 @@ Check(
   scope: Scope(
     mode: DenyList(PackageSelection(
       selection: Workspace,
+      explicitly_included_packages: [],
       excluded_packages: [],
     )),
   ),

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_baseline_conditional_compile_error-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_baseline_conditional_compile_error-input.snap
@@ -6,6 +6,7 @@ Check(
   scope: Scope(
     mode: DenyList(PackageSelection(
       selection: Workspace,
+      explicitly_included_packages: [],
       excluded_packages: [],
     )),
   ),

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_no_lib_targets-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_no_lib_targets-input.snap
@@ -6,6 +6,7 @@ Check(
   scope: Scope(
     mode: DenyList(PackageSelection(
       selection: Workspace,
+      explicitly_included_packages: [],
       excluded_packages: [],
     )),
   ),

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_publish_false_workspace_flag-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_publish_false_workspace_flag-input.snap
@@ -6,7 +6,7 @@ Check(
   scope: Scope(
     mode: DenyList(PackageSelection(
       selection: Workspace,
-      included_packages: [
+      explicitly_included_packages: [
         "a",
       ],
       excluded_packages: [],

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_publish_false_workspace_flag-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_publish_false_workspace_flag-input.snap
@@ -6,6 +6,9 @@ Check(
   scope: Scope(
     mode: DenyList(PackageSelection(
       selection: Workspace,
+      included_packages: [
+        "a",
+      ],
       excluded_packages: [],
     )),
   ),

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_publish_false_workspace_flag-input.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_publish_false_workspace_flag-input.snap
@@ -13,10 +13,10 @@ Check(
     )),
   ),
   current: Rustdoc(
-    source: Root("test_crates/manifest_tests/workspace_all_publish_false/new"),
+    source: Root("test_crates/manifest_tests/workspace_publish_false_mixed/new"),
   ),
   baseline: Rustdoc(
-    source: Root("test_crates/manifest_tests/workspace_all_publish_false/old"),
+    source: Root("test_crates/manifest_tests/workspace_publish_false_mixed/old"),
   ),
   release_type: None,
   current_feature_config: FeatureConfig(

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_publish_false_workspace_flag-output.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_publish_false_workspace_flag-output.snap
@@ -2,9 +2,30 @@
 source: src/snapshot_tests.rs
 expression: result
 ---
-success: true
+success: false
 --- stdout ---
 
+--- failure function_missing: pub fn removed or renamed ---
+
+Description:
+A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/[VERSION]/src/lints/function_missing.ron
+
+Failed in:
+  function a::should_not_run, previously in file [ROOT]/test_crates/manifest_tests/workspace_all_publish_false/old/a/src/lib.rs:6
+
 --- stderr ---
-    Skipping a v0.1.0 (current)
-    Skipping b v0.1.0 (current)
+    Building a v0.1.0 (current)
+       Built [TIME] (current)
+     Parsing a v0.1.0 (current)
+      Parsed [TIME] (current)
+    Building a v0.1.0 (baseline)
+       Built [TIME] (baseline)
+     Parsing a v0.1.0 (baseline)
+      Parsed [TIME] (baseline)
+    Checking a v0.1.0 -> v0.1.0 (no change; assume minor)
+     Checked [TIME] [TOTAL] checks: [PASS] pass, 1 fail, 0 warn, [SKIP] skip
+
+     Summary semver requires new major version: 1 major and 0 minor checks failed
+    Finished [TIME] a

--- a/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_publish_false_workspace_flag-output.snap
+++ b/test_outputs/snapshot_tests/cargo_semver_checks__snapshot_tests__workspace_publish_false_workspace_flag-output.snap
@@ -13,7 +13,17 @@ A publicly-visible function cannot be imported by its prior path. A `pub use` ma
        impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/[VERSION]/src/lints/function_missing.ron
 
 Failed in:
-  function a::should_not_run, previously in file [ROOT]/test_crates/manifest_tests/workspace_all_publish_false/old/a/src/lib.rs:6
+  function a::private_explicit, previously in file [ROOT]/test_crates/manifest_tests/workspace_publish_false_mixed/old/a/src/lib.rs:1
+
+--- failure function_missing: pub fn removed or renamed ---
+
+Description:
+A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/[VERSION]/src/lints/function_missing.ron
+
+Failed in:
+  function c::public_workspace_member, previously in file [ROOT]/test_crates/manifest_tests/workspace_publish_false_mixed/old/c/src/lib.rs:1
 
 --- stderr ---
     Building a v0.1.0 (current)
@@ -29,3 +39,16 @@ Failed in:
 
      Summary semver requires new major version: 1 major and 0 minor checks failed
     Finished [TIME] a
+    Building c v0.1.0 (current)
+       Built [TIME] (current)
+     Parsing c v0.1.0 (current)
+      Parsed [TIME] (current)
+    Building c v0.1.0 (baseline)
+       Built [TIME] (baseline)
+     Parsing c v0.1.0 (baseline)
+      Parsed [TIME] (baseline)
+    Checking c v0.1.0 -> v0.1.0 (no change; assume minor)
+     Checked [TIME] [TOTAL] checks: [PASS] pass, 1 fail, 0 warn, [SKIP] skip
+
+     Summary semver requires new major version: 1 major and 0 minor checks failed
+    Finished [TIME] c


### PR DESCRIPTION
## Summary

- preserve the packages named with `--package` when `--workspace` is also set
- check explicitly named `publish = false` workspace packages instead of treating them as implied workspace members
- update the existing workspace/package snapshot to cover the fixed behavior

## Why

Fixes #868. `--workspace --package a` currently skips `a` when it has `publish = false`, even though the package was explicitly requested.

## Validation

- `cargo fmt --check` — passed
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_BUILD_JOBS=1 cargo test workspace_publish_false -- --nocapture` — passed
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_BUILD_JOBS=1 cargo test --bin cargo-semver-checks snapshot_tests -- --nocapture` — passed
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=1 cargo build --bin cargo-semver-checks` — passed
- `target/debug/cargo-semver-checks semver-checks --manifest-path test_crates/manifest_tests/workspace_all_publish_false/new --baseline-root test_crates/manifest_tests/workspace_all_publish_false/old --workspace --package a` — exited 1 with `function_missing` for `a::should_not_run`
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=1 cargo clippy --all-targets --no-deps -- -D warnings --allow deprecated` — passed
- `RUSTDOCFLAGS="-D warnings" CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=1 cargo doc --no-deps --document-private-items` — passed
- `git diff --check` — passed
- `cargo test` — attempted, but this checkout is missing the documented first-run `localdata/test_data/.../metadata.json` rustdoc fixtures
