### PR TITLE
Apply cargo clippy --fix

### DIFF
--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -159,7 +159,7 @@ fn print_triggered_lint(
         config.log_at_lint_level(lint_level, |config| {
             writeln!(config.stdout(), "{}Description:{}\n{}\n{:>12} {}\n{:>12} https://github.com/obi1kenobi/cargo-semver-checks/tree/v{}/src/lints/{}.ron\n",
                 Style::new().bold(), Reset,
-                &semver_query.error_message,
+                semver_query.error_message,
                 "ref:",
                 ref_link,
                 "impl:",
@@ -175,7 +175,7 @@ fn print_triggered_lint(
                 "{}Description:{}\n{}\n{:>12} https://github.com/obi1kenobi/cargo-semver-checks/tree/v{}/src/lints/{}.ron",
                 Style::new().bold(),
                 Reset,
-                &semver_query.error_message,
+                semver_query.error_message,
                 "impl:",
                 crate_version!(),
                 semver_query.id,

--- a/src/rustdoc_gen.rs
+++ b/src/rustdoc_gen.rs
@@ -602,7 +602,7 @@ impl RustdocFromProjectRoot {
                 duplicate_packages.insert(name, vec![prev_path, path]);
             }
         }
-        for (_package, paths) in duplicate_packages.iter_mut() {
+        for paths in duplicate_packages.values_mut() {
             paths.sort_unstable();
         }
 


### PR DESCRIPTION
These changes are just the result of running `cargo clippy --fix`.

No manual code changes are included beyond the clippy-produced fixes.

Validation:
- `cargo clippy --fix`
- `cargo clippy --all-targets --no-deps --fix --allow-dirty --allow-staged -- -D warnings --allow deprecated`
- `cargo fmt --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items`
- `cargo test` currently fails locally because generated rustdoc fixture metadata is missing under `localdata/test_data/.../metadata.json`; the test output says to rerun `./scripts/regenerate_test_rustdocs.sh`.