### PR TITLE
Add `--stability-aware` unstable CLI option for Rust stdlib use.

### DIFF
--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -17,7 +17,9 @@ use crate::query::{
     ActualSemverUpdate, LintLevel, OverrideStack, RequiredSemverUpdate, SemverQuery,
 };
 use crate::witness_gen;
-use crate::{Bumps, CrateReport, GlobalConfig, ReleaseType, WitnessGeneration};
+use crate::{
+    Bumps, CrateReport, GlobalConfig, ReleaseType, RustdocIndexingMode, WitnessGeneration,
+};
 
 /// Represents a change between two semantic versions
 #[derive(Debug, PartialEq, Eq)]
@@ -260,15 +262,25 @@ fn print_triggered_lint(
     Ok(())
 }
 
+pub(super) struct CheckReleaseSettings {
+    pub(super) release_type: Option<ReleaseType>,
+    pub(super) rustdoc_indexing_mode: RustdocIndexingMode,
+}
+
 pub(super) fn run_check_release(
     config: &mut GlobalConfig,
     data_storage: &DataStorage,
     crate_name: &str,
-    release_type: Option<ReleaseType>,
+    settings: CheckReleaseSettings,
     overrides: &OverrideStack,
     witness_generation: &WitnessGeneration,
     witness_data: witness_gen::WitnessGenerationData,
 ) -> anyhow::Result<PendingCrateReport> {
+    let CheckReleaseSettings {
+        release_type,
+        rustdoc_indexing_mode,
+    } = settings;
+
     let current_version = data_storage.current_crate().crate_version();
     let baseline_version = data_storage.baseline_crate().crate_version();
 
@@ -314,7 +326,7 @@ pub(super) fn run_check_release(
         VersionChangeKind::Minimum => format!("no change; {assume}{change}"),
     };
 
-    let index_storage = data_storage.create_indexes();
+    let index_storage = data_storage.create_indexes(rustdoc_indexing_mode);
     let adapter = index_storage.create_adapter();
 
     let mut queries_to_run = SemverQuery::all_queries();

--- a/src/data_generation/mod.rs
+++ b/src/data_generation/mod.rs
@@ -5,6 +5,8 @@ mod request;
 
 use trustfall_rustdoc::{VersionedIndex, VersionedRustdocAdapter, VersionedStorage};
 
+use crate::RustdocIndexingMode;
+
 pub(crate) use error::{IntoTerminalResult, TerminalError};
 pub(crate) use generate::GenerationSettings;
 pub(crate) use generate::effective_witness_rustflags;
@@ -32,10 +34,21 @@ impl DataStorage {
 }
 
 impl DataStorage {
-    pub(crate) fn create_indexes(&self) -> IndexStorage<'_> {
+    pub(crate) fn create_indexes(&self, mode: RustdocIndexingMode) -> IndexStorage<'_> {
+        let (current_crate, baseline_crate) = match mode {
+            RustdocIndexingMode::Ordinary => (
+                VersionedIndex::from_storage(&self.current),
+                VersionedIndex::from_storage(&self.baseline),
+            ),
+            RustdocIndexingMode::StabilityAware => (
+                VersionedIndex::from_rust_std_component_storage(&self.current),
+                VersionedIndex::from_rust_std_component_storage(&self.baseline),
+            ),
+        };
+
         IndexStorage {
-            current_crate: VersionedIndex::from_storage(&self.current),
-            baseline_crate: VersionedIndex::from_storage(&self.baseline),
+            current_crate,
+            baseline_crate,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use check_release::{LintResult, PendingCrateReport, run_check_release};
+use check_release::{CheckReleaseSettings, LintResult, PendingCrateReport, run_check_release};
 use rustdoc_gen::CrateDataForRustdoc;
 
 pub use config::{FeatureFlag, GlobalConfig};
@@ -41,6 +41,13 @@ pub struct Check {
     scope: Scope,
     current: Rustdoc,
     baseline: Rustdoc,
+
+    /// Whether we should consider stability attributes when determining public API status.
+    /// Stability attributes are not currently stable, and are only used internally
+    /// in the Rust standard library crates themselves.
+    #[serde(skip_serializing_if = "RustdocIndexingMode::is_ordinary")]
+    rustdoc_indexing_mode: RustdocIndexingMode,
+
     release_type: Option<ReleaseType>,
     current_feature_config: rustdoc_gen::FeatureConfig,
     baseline_feature_config: rustdoc_gen::FeatureConfig,
@@ -66,6 +73,24 @@ pub enum ReleaseType {
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct Rustdoc {
     source: RustdocSource,
+}
+
+/// How rustdoc JSON should be indexed for semver checking.
+#[doc(hidden)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+pub enum RustdocIndexingMode {
+    /// Index rustdoc JSON using ordinary crate public API rules.
+    #[default]
+    Ordinary,
+    /// Index rustdoc JSON while honoring structured stability metadata.
+    StabilityAware,
+}
+
+impl RustdocIndexingMode {
+    fn is_ordinary(&self) -> bool {
+        matches!(self, Self::Ordinary)
+    }
 }
 
 impl Rustdoc {
@@ -272,6 +297,7 @@ impl Check {
             scope: Scope::default(),
             current,
             baseline: Rustdoc::from_registry_latest_crate_version(),
+            rustdoc_indexing_mode: RustdocIndexingMode::default(),
             release_type: None,
             current_feature_config: rustdoc_gen::FeatureConfig::default_for_current(),
             baseline_feature_config: rustdoc_gen::FeatureConfig::default_for_baseline(),
@@ -297,6 +323,12 @@ impl Check {
 
     pub fn set_release_type(&mut self, release_type: ReleaseType) -> &mut Self {
         self.release_type = Some(release_type);
+        self
+    }
+
+    #[doc(hidden)]
+    pub fn set_rustdoc_indexing_mode(&mut self, mode: RustdocIndexingMode) -> &mut Self {
+        self.rustdoc_indexing_mode = mode;
         self
     }
 
@@ -597,7 +629,10 @@ note: skipped the following crates since they have no library target: {skipped}"
                     config,
                     &data_storage,
                     &name,
-                    self.release_type,
+                    CheckReleaseSettings {
+                        release_type: self.release_type,
+                        rustdoc_indexing_mode: self.rustdoc_indexing_mode,
+                    },
                     &selected.overrides,
                     &self.witness_generation,
                     witness_data,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,8 @@ use anstream::ColorChoice as AnstreamChoice;
 use anstyle::{AnsiColor, Color, Reset, Style};
 use cargo_config2::Config;
 use cargo_semver_checks::{
-    FeatureFlag, GlobalConfig, PackageSelection, ReleaseType, Rustdoc, ScopeSelection, SemverQuery,
-    WitnessGeneration,
+    FeatureFlag, GlobalConfig, PackageSelection, ReleaseType, Rustdoc, RustdocIndexingMode,
+    ScopeSelection, SemverQuery, WitnessGeneration,
 };
 use clap::{Args, CommandFactory, Parser, Subcommand};
 
@@ -356,6 +356,10 @@ struct UnstableOptions {
     /// Enable running witness-based consistency checks for lints whose witness purpose is `ConsistencyCheck`.
     #[arg(long, hide = true)]
     consistency_check: bool,
+
+    /// Interpret structured rustdoc stability metadata while deciding public API.
+    #[arg(long = "stability-aware", hide = true)]
+    stability_aware: bool,
 }
 
 impl UnstableOptions {
@@ -380,6 +384,7 @@ impl UnstableOptions {
         let Self {
             witness_hints,
             consistency_check,
+            stability_aware,
         } = self;
 
         if *witness_hints {
@@ -388,6 +393,10 @@ impl UnstableOptions {
 
         if *consistency_check {
             list.push("--consistency-check".into())
+        }
+
+        if *stability_aware {
+            list.push("--stability-aware".into());
         }
 
         list
@@ -666,6 +675,10 @@ impl From<CheckRelease> for cargo_semver_checks::Check {
             check.set_build_target(build_target);
         }
 
+        if value.unstable_options.stability_aware {
+            check.set_rustdoc_indexing_mode(RustdocIndexingMode::StabilityAware);
+        }
+
         let mut witness_generation = WitnessGeneration::new();
         witness_generation.show_hints = value.unstable_options.witness_hints;
         witness_generation.run_consistency_checks = value.unstable_options.consistency_check;
@@ -865,5 +878,50 @@ fn current_rustdoc_conflict_errors() {
                 "main",
             ])
             .is_err()
+    );
+}
+
+#[test]
+fn stability_aware_is_unstable_option() {
+    let Cargo::SemverChecks(args) = Cargo::try_parse_from([
+        "cargo",
+        "semver-checks",
+        "check-release",
+        "--stability-aware",
+        "--current-rustdoc",
+        "current.json",
+        "--baseline-rustdoc",
+        "baseline.json",
+    ])
+    .expect("args should parse before unstable option validation");
+
+    let mut config = GlobalConfig::new();
+    let err = validate_feature_flags(&mut config, &args)
+        .expect_err("--stability-aware should require -Z unstable-options");
+
+    assert!(
+        err.to_string().contains("--stability-aware"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
+fn stability_aware_adds_no_extra_validation_requirements() {
+    // This implies "check the current project vs the default baseline, with stability-aware rules."
+    let Cargo::SemverChecks(args) = Cargo::try_parse_from([
+        "cargo",
+        "semver-checks",
+        "check-release",
+        "-Z",
+        "unstable-options",
+        "--stability-aware",
+    ])
+    .expect("args should parse");
+
+    let mut config = GlobalConfig::new();
+    config.set_feature_flags(HashSet::from_iter(args.unstable_features.clone()));
+
+    validate_feature_flags(&mut config, &args).expect(
+        "--stability-aware should not add validation requirements beyond -Z unstable-options",
     );
 }

--- a/src/witness_gen/test_support.rs
+++ b/src/witness_gen/test_support.rs
@@ -6,7 +6,7 @@ use std::{
 use rand::RngExt as _;
 
 use crate::{
-    LintLevel, RequiredSemverUpdate,
+    LintLevel, RequiredSemverUpdate, RustdocIndexingMode,
     data_generation::{
         CacheSettings, CrateDataRequest, DataStorage, GenerationSettings, ProgressCallbacks,
     },
@@ -177,6 +177,7 @@ pub(super) fn run_smoke_witness(
         &baseline_request,
         &current_request,
         temp_dir.path().join("target"),
+        RustdocIndexingMode::Ordinary,
     );
 
     (report, lint_results, temp_dir, config)
@@ -189,6 +190,7 @@ pub(super) fn run_witness_with_requests(
     baseline_request: &CrateDataRequest<'_>,
     current_request: &CrateDataRequest<'_>,
     target_dir: PathBuf,
+    rustdoc_indexing_mode: RustdocIndexingMode,
 ) -> (WitnessRunReport, Vec<LintResult>, GlobalConfig) {
     let witness_data =
         WitnessGenerationData::new(Some(baseline_request), Some(current_request), target_dir);
@@ -206,7 +208,7 @@ pub(super) fn run_witness_with_requests(
         current_request,
         witness_data.target_dir.as_path(),
     );
-    let index_storage = data_storage.create_indexes();
+    let index_storage = data_storage.create_indexes(rustdoc_indexing_mode);
     let adapter = index_storage.create_adapter();
 
     let report = run_witness_checks(

--- a/src/witness_gen/tests.rs
+++ b/src/witness_gen/tests.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, collections::BTreeMap, path::Path};
 
+use crate::RustdocIndexingMode;
 use tame_index::IndexVersion;
 
 use super::{
@@ -143,6 +144,7 @@ fn feature_gated_witness_preserves_selected_features() {
         &baseline_request,
         &current_request,
         temp_dir.path().join("target"),
+        RustdocIndexingMode::Ordinary,
     );
 
     assert!(report.statistics.is_none());

--- a/test_crates/stability_aware_mode/new/Cargo.toml
+++ b/test_crates/stability_aware_mode/new/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "stability_aware_mode"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/stability_aware_mode/new/src/lib.rs
+++ b/test_crates/stability_aware_mode/new/src/lib.rs
@@ -1,0 +1,72 @@
+#![no_std]
+#![allow(internal_features)]
+#![feature(associated_type_defaults)]
+#![feature(rustc_attrs)]
+#![feature(staged_api)]
+#![stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+
+#[stable(feature = "stability_aware_mode_stable_kept", since = "1.0.0")]
+pub fn stable_kept() {}
+
+#[stable(feature = "stability_aware_mode_const_stable", since = "1.0.0")]
+pub fn const_stable_to_non_const() -> usize {
+    1
+}
+
+#[stable(feature = "stability_aware_mode_const_facet", since = "1.0.0")]
+pub fn const_unstable_to_non_const() -> usize {
+    1
+}
+
+#[stable(feature = "stability_aware_mode_doc_hidden", since = "1.0.0")]
+#[doc(hidden)]
+pub fn stable_now_doc_hidden() {}
+
+#[stable(feature = "stability_aware_mode_default_stability", since = "1.0.0")]
+pub trait DefaultStability {
+    #[stable(feature = "stability_aware_mode_stable_default_body", since = "1.0.0")]
+    fn stable_default_body_removed(&self);
+
+    #[stable(feature = "stability_aware_mode_unstable_default_body", since = "1.0.0")]
+    fn unstable_default_body_removed(&self);
+
+    #[stable(feature = "stability_aware_mode_stable_default_const", since = "1.0.0")]
+    const STABLE_DEFAULT_CONST_REMOVED: usize;
+
+    #[stable(feature = "stability_aware_mode_unstable_default_const", since = "1.0.0")]
+    const UNSTABLE_DEFAULT_CONST_REMOVED: usize;
+
+    #[stable(feature = "stability_aware_mode_stable_default_type", since = "1.0.0")]
+    type StableDefaultTypeRemoved;
+
+    #[stable(feature = "stability_aware_mode_unstable_default_type", since = "1.0.0")]
+    type UnstableDefaultTypeRemoved;
+
+    #[stable(
+        feature = "stability_aware_mode_stable_default_body_to_unstable",
+        since = "1.0.0"
+    )]
+    #[rustc_default_body_unstable(
+        feature = "stability_aware_mode_stable_default_body_now_unstable",
+        issue = "none"
+    )]
+    fn stable_default_body_to_unstable(&self) {}
+}
+
+#[unstable(
+    feature = "stability_aware_mode_stable_item_now_unstable",
+    issue = "none"
+)]
+pub fn stable_item_to_unstable() {}
+
+#[stable(
+    feature = "stability_aware_mode_const_stable_to_unstable",
+    since = "1.0.0"
+)]
+#[rustc_const_unstable(
+    feature = "stability_aware_mode_const_stable_now_unstable",
+    issue = "none"
+)]
+pub const fn const_stable_to_unstable() -> usize {
+    1
+}

--- a/test_crates/stability_aware_mode/old/Cargo.toml
+++ b/test_crates/stability_aware_mode/old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+publish = false
+name = "stability_aware_mode"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/stability_aware_mode/old/src/lib.rs
+++ b/test_crates/stability_aware_mode/old/src/lib.rs
@@ -1,0 +1,87 @@
+#![no_std]
+#![allow(internal_features)]
+#![feature(associated_type_defaults)]
+#![feature(rustc_attrs)]
+#![feature(staged_api)]
+#![stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+
+#[stable(feature = "stability_aware_mode_stable_kept", since = "1.0.0")]
+pub fn stable_kept() {}
+
+#[stable(feature = "stability_aware_mode_stable_removed", since = "1.0.0")]
+pub fn stable_removed() {}
+
+#[unstable(feature = "stability_aware_mode_unstable_removed", issue = "none")]
+pub fn unstable_removed() {}
+
+#[stable(feature = "stability_aware_mode_const_stable", since = "1.0.0")]
+#[rustc_const_stable(feature = "stability_aware_mode_const_stable", since = "1.0.0")]
+pub const fn const_stable_to_non_const() -> usize {
+    1
+}
+
+#[stable(feature = "stability_aware_mode_const_facet", since = "1.0.0")]
+#[rustc_const_unstable(feature = "stability_aware_mode_const_unstable", issue = "none")]
+pub const fn const_unstable_to_non_const() -> usize {
+    1
+}
+
+#[stable(feature = "stability_aware_mode_doc_hidden", since = "1.0.0")]
+pub fn stable_now_doc_hidden() {}
+
+#[stable(feature = "stability_aware_mode_default_stability", since = "1.0.0")]
+pub trait DefaultStability {
+    #[stable(feature = "stability_aware_mode_stable_default_body", since = "1.0.0")]
+    fn stable_default_body_removed(&self) {}
+
+    #[stable(feature = "stability_aware_mode_unstable_default_body", since = "1.0.0")]
+    #[rustc_default_body_unstable(
+        feature = "stability_aware_mode_unstable_default_body_value",
+        issue = "none"
+    )]
+    fn unstable_default_body_removed(&self) {}
+
+    #[stable(feature = "stability_aware_mode_stable_default_const", since = "1.0.0")]
+    const STABLE_DEFAULT_CONST_REMOVED: usize = 1;
+
+    #[stable(feature = "stability_aware_mode_unstable_default_const", since = "1.0.0")]
+    #[rustc_default_body_unstable(
+        feature = "stability_aware_mode_unstable_default_const_value",
+        issue = "none"
+    )]
+    const UNSTABLE_DEFAULT_CONST_REMOVED: usize = 2;
+
+    #[stable(feature = "stability_aware_mode_stable_default_type", since = "1.0.0")]
+    type StableDefaultTypeRemoved = u8;
+
+    #[stable(feature = "stability_aware_mode_unstable_default_type", since = "1.0.0")]
+    #[rustc_default_body_unstable(
+        feature = "stability_aware_mode_unstable_default_type_value",
+        issue = "none"
+    )]
+    type UnstableDefaultTypeRemoved = u16;
+
+    #[stable(
+        feature = "stability_aware_mode_stable_default_body_to_unstable",
+        since = "1.0.0"
+    )]
+    fn stable_default_body_to_unstable(&self) {}
+}
+
+#[stable(
+    feature = "stability_aware_mode_stable_item_to_unstable",
+    since = "1.0.0"
+)]
+pub fn stable_item_to_unstable() {}
+
+#[stable(
+    feature = "stability_aware_mode_const_stable_to_unstable",
+    since = "1.0.0"
+)]
+#[rustc_const_stable(
+    feature = "stability_aware_mode_const_stable_to_unstable",
+    since = "1.0.0"
+)]
+pub const fn const_stable_to_unstable() -> usize {
+    1
+}

--- a/test_outputs/integration_snapshots__stability_aware_mode.snap
+++ b/test_outputs/integration_snapshots__stability_aware_mode.snap
@@ -1,0 +1,93 @@
+---
+source: tests/integration_snapshots.rs
+info:
+  program: cargo-semver-checks
+  args:
+    - semver-checks
+    - "-Z"
+    - unstable-options
+    - "--stability-aware"
+    - "--release-type"
+    - minor
+    - "--baseline-rustdoc"
+    - localdata/test_data/stability_aware_mode/old/rustdoc.json
+    - "--current-rustdoc"
+    - localdata/test_data/stability_aware_mode/new/rustdoc.json
+  env:
+    CARGO_TERM_COLOR: never
+    CARGO_TERM_UNICODE: "false"
+    RUST_BACKTRACE: "0"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+--- failure function_const_removed: pub fn is no longer const ---
+
+Description:
+A publicly-visible function is no longer `const` and can no longer be used in a `const` context.
+        ref: https://doc.rust-lang.org/reference/const_eval.html
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/[VERSION]/src/lints/function_const_removed.ron
+
+Failed in:
+  function stability_aware_mode::const_stable_to_non_const in file src/lib.rs:12
+  function stability_aware_mode::const_stable_to_unstable in file src/lib.rs:70
+
+--- failure function_missing: pub fn removed or renamed ---
+
+Description:
+A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/[VERSION]/src/lints/function_missing.ron
+
+Failed in:
+  function stability_aware_mode::stable_removed, previously in file src/lib.rs:12
+
+--- failure function_now_doc_hidden: pub function is now #[doc(hidden)] ---
+
+Description:
+A pub function is now #[doc(hidden)], removing it from the crate's public API.
+        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/[VERSION]/src/lints/function_now_doc_hidden.ron
+
+Failed in:
+  function stable_item_to_unstable in file src/lib.rs:60
+  function stable_now_doc_hidden in file src/lib.rs:23
+
+--- failure trait_associated_const_default_removed: non-sealed trait removed the default value for an associated constant ---
+
+Description:
+A non-sealed trait associated constant lost its default value, which breaks downstream implementations of the trait
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/[VERSION]/src/lints/trait_associated_const_default_removed.ron
+
+Failed in:
+  trait constant stability_aware_mode::DefaultStability::STABLE_DEFAULT_CONST_REMOVED in file src/lib.rs:34
+
+--- failure trait_associated_type_default_removed: non-sealed trait removed the default value for an associated type ---
+
+Description:
+A non-sealed trait associated type lost its default value, which breaks downstream implementations of the trait
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/[VERSION]/src/lints/trait_associated_type_default_removed.ron
+
+Failed in:
+  trait type stability_aware_mode::DefaultStability::StableDefaultTypeRemoved in file src/lib.rs:40
+
+--- failure trait_method_default_impl_removed: pub trait default method impl removed ---
+
+Description:
+A method's default impl in an unsealed trait has been removed, breaking trait implementations that relied on that default
+        ref: https://doc.rust-lang.org/book/ch10-02-traits.html#default-implementations
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/[VERSION]/src/lints/trait_method_default_impl_removed.ron
+
+Failed in:
+  trait method stability_aware_mode::DefaultStability::stable_default_body_removed in file src/lib.rs:28
+  trait method stability_aware_mode::DefaultStability::stable_default_body_to_unstable in file src/lib.rs:53
+
+----- stderr -----
+    Checking <unknown> v0.1.0 -> v0.1.0 (assume minor change)
+     Checked [TIME] [TOTAL] checks: [PASS] pass, 6 fail, 0 warn, [SKIP] skip
+
+     Summary semver requires new major version: 6 major and 0 minor checks failed
+    Finished [TIME] <unknown>

--- a/test_outputs/integration_snapshots__z_help.snap
+++ b/test_outputs/integration_snapshots__z_help.snap
@@ -26,4 +26,7 @@ Unstable options:
       --consistency-check
           Enable running witness-based consistency checks for lints whose witness purpose is `ConsistencyCheck`
 
+      --stability-aware
+          Interpret structured rustdoc stability metadata while deciding public API
+
 ----- stderr -----

--- a/test_outputs/query_execution/function_const_removed.snap
+++ b/test_outputs/query_execution/function_const_removed.snap
@@ -15,4 +15,28 @@ source: src/query.rs
       "visibility_limit": String("public"),
     },
   ],
+  "./test_crates/stability_aware_mode/": [
+    {
+      "name": String("const_stable_to_non_const"),
+      "path": List([
+        String("stability_aware_mode"),
+        String("const_stable_to_non_const"),
+      ]),
+      "span_begin_line": Uint64(12),
+      "span_end_line": Uint64(14),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("const_unstable_to_non_const"),
+      "path": List([
+        String("stability_aware_mode"),
+        String("const_unstable_to_non_const"),
+      ]),
+      "span_begin_line": Uint64(17),
+      "span_end_line": Uint64(19),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
 }

--- a/test_outputs/query_execution/function_missing.snap
+++ b/test_outputs/query_execution/function_missing.snap
@@ -148,4 +148,28 @@ source: src/query.rs
       "visibility_limit": String("public"),
     },
   ],
+  "./test_crates/stability_aware_mode/": [
+    {
+      "name": String("stable_removed"),
+      "path": List([
+        String("stability_aware_mode"),
+        String("stable_removed"),
+      ]),
+      "span_begin_line": Uint64(12),
+      "span_end_line": Uint64(12),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "name": String("unstable_removed"),
+      "path": List([
+        String("stability_aware_mode"),
+        String("unstable_removed"),
+      ]),
+      "span_begin_line": Uint64(15),
+      "span_end_line": Uint64(15),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
 }

--- a/test_outputs/query_execution/function_now_doc_hidden.snap
+++ b/test_outputs/query_execution/function_now_doc_hidden.snap
@@ -47,4 +47,16 @@ source: src/query.rs
       "span_filename": String("src/lib.rs"),
     },
   ],
+  "./test_crates/stability_aware_mode/": [
+    {
+      "function_name": String("stable_now_doc_hidden"),
+      "path": List([
+        String("stability_aware_mode"),
+        String("stable_now_doc_hidden"),
+      ]),
+      "span_begin_line": Uint64(23),
+      "span_end_line": Uint64(23),
+      "span_filename": String("src/lib.rs"),
+    },
+  ],
 }

--- a/test_outputs/query_execution/trait_associated_const_default_removed.snap
+++ b/test_outputs/query_execution/trait_associated_const_default_removed.snap
@@ -2,6 +2,32 @@
 source: src/query.rs
 ---
 {
+  "./test_crates/stability_aware_mode/": [
+    {
+      "associated_constant": String("STABLE_DEFAULT_CONST_REMOVED"),
+      "default": Null,
+      "path": List([
+        String("stability_aware_mode"),
+        String("DefaultStability"),
+      ]),
+      "span_begin_line": Uint64(34),
+      "span_end_line": Uint64(34),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "associated_constant": String("UNSTABLE_DEFAULT_CONST_REMOVED"),
+      "default": Null,
+      "path": List([
+        String("stability_aware_mode"),
+        String("DefaultStability"),
+      ]),
+      "span_begin_line": Uint64(37),
+      "span_end_line": Uint64(37),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
   "./test_crates/trait_associated_const_default_removed/": [
     {
       "associated_constant": String("ONE"),

--- a/test_outputs/query_execution/trait_associated_type_default_removed.snap
+++ b/test_outputs/query_execution/trait_associated_type_default_removed.snap
@@ -2,6 +2,32 @@
 source: src/query.rs
 ---
 {
+  "./test_crates/stability_aware_mode/": [
+    {
+      "associated_type": String("StableDefaultTypeRemoved"),
+      "has_default": Boolean(false),
+      "path": List([
+        String("stability_aware_mode"),
+        String("DefaultStability"),
+      ]),
+      "span_begin_line": Uint64(40),
+      "span_end_line": Uint64(40),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "associated_type": String("UnstableDefaultTypeRemoved"),
+      "has_default": Boolean(false),
+      "path": List([
+        String("stability_aware_mode"),
+        String("DefaultStability"),
+      ]),
+      "span_begin_line": Uint64(43),
+      "span_end_line": Uint64(43),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
   "./test_crates/trait_associated_type_default_removed/": [
     {
       "associated_type": String("Foo"),

--- a/test_outputs/query_execution/trait_method_default_impl_removed.snap
+++ b/test_outputs/query_execution/trait_method_default_impl_removed.snap
@@ -2,6 +2,32 @@
 source: src/query.rs
 ---
 {
+  "./test_crates/stability_aware_mode/": [
+    {
+      "method_name": String("stable_default_body_removed"),
+      "name": String("DefaultStability"),
+      "path": List([
+        String("stability_aware_mode"),
+        String("DefaultStability"),
+      ]),
+      "span_begin_line": Uint64(28),
+      "span_end_line": Uint64(28),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+    {
+      "method_name": String("unstable_default_body_removed"),
+      "name": String("DefaultStability"),
+      "path": List([
+        String("stability_aware_mode"),
+        String("DefaultStability"),
+      ]),
+      "span_begin_line": Uint64(31),
+      "span_end_line": Uint64(31),
+      "span_filename": String("src/lib.rs"),
+      "visibility_limit": String("public"),
+    },
+  ],
   "./test_crates/trait_method_default_impl_removed/": [
     {
       "method_name": String("method_default_impl_removed"),

--- a/test_outputs/witnesses/function_const_removed.snap
+++ b/test_outputs/witnesses/function_const_removed.snap
@@ -10,3 +10,21 @@ const fn witness() {
     function_const_removed::add(...);
 }
 """
+
+[["./test_crates/stability_aware_mode/"]]
+filename = "src/lib.rs"
+begin_line = 12
+hint = """
+const fn witness() {
+    stability_aware_mode::const_stable_to_non_const(...);
+}
+"""
+
+[["./test_crates/stability_aware_mode/"]]
+filename = "src/lib.rs"
+begin_line = 17
+hint = """
+const fn witness() {
+    stability_aware_mode::const_unstable_to_non_const(...);
+}
+"""

--- a/test_outputs/witnesses/function_missing.snap
+++ b/test_outputs/witnesses/function_missing.snap
@@ -61,3 +61,13 @@ hint = "hidden_reexports::hidden_per_item_then_public_per_item_removed(...);"
 filename = "src/lib.rs"
 begin_line = 101
 hint = "hidden_reexports::hidden_glob_then_public_per_item_removed(...);"
+
+[["./test_crates/stability_aware_mode/"]]
+filename = "src/lib.rs"
+begin_line = 12
+hint = "stability_aware_mode::stable_removed(...);"
+
+[["./test_crates/stability_aware_mode/"]]
+filename = "src/lib.rs"
+begin_line = 15
+hint = "stability_aware_mode::unstable_removed(...);"

--- a/tests/integration_snapshots.rs
+++ b/tests/integration_snapshots.rs
@@ -119,6 +119,37 @@ fn z_help() {
     })
 }
 
+#[test]
+fn stability_aware_mode() {
+    let baseline_rustdoc = "localdata/test_data/stability_aware_mode/old/rustdoc.json";
+    let current_rustdoc = "localdata/test_data/stability_aware_mode/new/rustdoc.json";
+
+    // TODO: Remove this block when the oldest rustdoc JSON version we support is v60+.
+    if rustdoc_format_version(baseline_rustdoc) < 60 || rustdoc_format_version(current_rustdoc) < 60
+    {
+        eprintln!(
+            "stability_aware_mode fixture needs rustdoc JSON v60+ for structured stability data"
+        );
+        return;
+    }
+
+    assert_integration_test("stability_aware_mode", |cmd, settings| {
+        cmd.args([
+            "-Z",
+            "unstable-options",
+            "--stability-aware",
+            "--release-type",
+            "minor",
+            "--baseline-rustdoc",
+            baseline_rustdoc,
+            "--current-rustdoc",
+            current_rustdoc,
+        ]);
+
+        set_snapshot_filters(settings);
+    });
+}
+
 /// Pin down the behavior when running `cargo-semver-checks` on a package that
 /// relies on `--cfg` based conditional compilation to enable or disable functionality.
 ///
@@ -206,4 +237,12 @@ fn executable_path() -> PathBuf {
     assert_cmd::cargo::cargo_bin!("cargo-semver-checks")
         .canonicalize()
         .expect("error canonicalizing")
+}
+
+fn rustdoc_format_version(path: &str) -> u64 {
+    let rustdoc = fs_err::read_to_string(path).expect("failed to read rustdoc JSON");
+    let json: serde_json::Value = serde_json::from_str(&rustdoc).expect("failed to parse JSON");
+    json["format_version"]
+        .as_u64()
+        .expect("rustdoc JSON missing numeric format_version")
 }


### PR DESCRIPTION
In order to lint the Rust standard library for accidental breakage, we need to instruct `cargo-semver-checks` to consider Rust's internal stability attributes when determining what is and is not public API. This relies on structured stability information present in rustdoc JSON v60 onward.

Add an unstable CLI flag, meant to be used as `-Z unstable-options --stability-aware`, to accomplish this.

There's a small ergonomics bug left, which we can address in the future: https://github.com/obi1kenobi/cargo-semver-checks/issues/1672
