### PR TITLE
Fix lints about constructible structs to account for non-pub-API fields.

### DIFF
--- a/src/lints/constructible_struct_adds_field.ron
+++ b/src/lints/constructible_struct_adds_field.ron
@@ -1,7 +1,7 @@
 SemverQuery(
     id: "constructible_struct_adds_field",
-    human_readable_name: "externally-constructible struct adds field",
-    description: "A struct constructible with a struct literal added a new pub field.",
+    human_readable_name: "struct exhaustively constructible through public API adds field",
+    description: "A struct exhaustively constructible with a literal using only public API added a new pub field.",
     required_update: Major,
     lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/reference/expressions/struct-expr.html"),
@@ -42,10 +42,12 @@ SemverQuery(
             }
             baseline {
                 item {
-                    # The struct needs to previously have been constructible with a struct literal.
-                    # Both of the following need to be true for that to have been the case:
+                    # The struct needs to previously have been exhaustively constructible
+                    # with a struct literal using only public API.
+                    # All of the following need to be true for that to have been the case:
                     # 1. It needs to not have been marked `#[non_exhaustive]`.
                     # 2. It needs to not have had any non-public fields.
+                    # 3. All of its fields need to have been part of public API.
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"])
                         struct_type @filter(op: "=", value: ["%struct_type"])
@@ -63,7 +65,16 @@ SemverQuery(
                             visibility_limit @filter(op: "!=", value: ["$public"])
                         }
 
+                        # 3. All of its fields need to have been part of public API.
+                        field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            public_api_eligible @filter(op: "!=", value: ["$true"])
+                        }
+
                         # The new field did not previously exist.
+                        #
+                        # Do not require the new field to be part of public API.
+                        # Adding a pub field makes existing exhaustive literals not work
+                        # even if the field is `#[doc(hidden)]` or unstable.
                         field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                             name @filter(op: "=", value: ["%field_name"])
                             visibility_limit @filter(op: "=", value: ["$public"])
@@ -79,6 +90,6 @@ SemverQuery(
         "true": true,
         "zero": 0,
     },
-    error_message: "A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.",
+    error_message: "A pub struct that could be exhaustively constructed with a literal using only public API has a new pub field, breaking existing exhaustive literals.",
     per_result_error_template: Some("field {{struct_name}}.{{field_name}} in {{span_filename}}:{{span_begin_line}}"),
 )

--- a/src/lints/constructible_struct_adds_private_field.ron
+++ b/src/lints/constructible_struct_adds_private_field.ron
@@ -1,7 +1,7 @@
 SemverQuery(
     id: "constructible_struct_adds_private_field",
     human_readable_name: "struct no longer constructible due to new private field",
-    description: "A struct is no longer constructible with a struct literal due to a new private field.",
+    description: "A struct is no longer constructible with a struct expression due to a new private field.",
     required_update: Major,
     lint_level: Deny,
     reference_link: Some("https://doc.rust-lang.org/reference/expressions/struct-expr.html"),
@@ -42,8 +42,9 @@ SemverQuery(
             }
             baseline {
                 item {
-                    # The struct needs to previously have been constructible with a struct literal.
-                    # Both of the following need to be true for that to have been the case:
+                    # The struct needs to previously have supported downstream construction with a
+                    # struct expression, including functional-update syntax when a base value is
+                    # available. Both of the following need to be true for that to have been the case:
                     # 1. It needs to not have been marked `#[non_exhaustive]`.
                     # 2. It needs to not have had any non-public fields.
                     ... on Struct {
@@ -59,6 +60,10 @@ SemverQuery(
                         }
 
                         # 2. It needs to not have had any non-public fields.
+                        #
+                        # Do not require the fields to be part of public API. Unstable and
+                        # `#[doc(hidden)]` pub fields still permit downstream functional-update
+                        # expressions, and adding a private field breaks those expressions.
                         field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                             visibility_limit @filter(op: "!=", value: ["$public"])
                         }
@@ -79,6 +84,6 @@ SemverQuery(
         "true": true,
         "zero": 0,
     },
-    error_message: "A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.",
+    error_message: "A struct has a new non-public field that causes downstream code to be unable to construct it with a struct expression, including functional-update syntax.",
     per_result_error_template: Some("field {{struct_name}}.{{field_name}} in {{span_filename}}:{{span_begin_line}}"),
 )

--- a/test_crates/constructible_struct_adds_field/new/src/lib.rs
+++ b/test_crates/constructible_struct_adds_field/new/src/lib.rs
@@ -63,3 +63,28 @@ pub struct TupleToPlainStruct {
     pub bar: i64,
     pub new_field: bool,
 }
+
+// Exhaustively constructing this struct requires using non-public API,
+// so adding another field should not be reported.
+pub struct PlainStructWithDocHiddenField {
+    pub foo: usize,
+    #[doc(hidden)]
+    pub hidden: i64,
+    pub new_field: bool,
+}
+
+// This struct can be constructed using only public API. Adding a pub field
+// should be reported even if the new field is not itself part of public API.
+pub struct PlainStructGainsDocHiddenField {
+    pub foo: usize,
+    #[doc(hidden)]
+    pub new_field: bool,
+}
+
+pub fn make_plain_struct_with_doc_hidden_field() -> PlainStructWithDocHiddenField {
+    PlainStructWithDocHiddenField {
+        foo: 0,
+        hidden: 0,
+        new_field: false,
+    }
+}

--- a/test_crates/constructible_struct_adds_field/old/src/lib.rs
+++ b/test_crates/constructible_struct_adds_field/old/src/lib.rs
@@ -56,3 +56,21 @@ pub struct PlainToTupleStruct {
 // The tuple -> plain change takes priority as a separate breaking change,
 // so this should not be reported by this lint.
 pub struct TupleToPlainStruct(pub usize, pub i64);
+
+// Exhaustively constructing this struct requires using non-public API,
+// so adding another field should not be reported.
+pub struct PlainStructWithDocHiddenField {
+    pub foo: usize,
+    #[doc(hidden)]
+    pub hidden: i64,
+}
+
+// This struct can be constructed using only public API. Adding a pub field
+// should be reported even if the new field is not itself part of public API.
+pub struct PlainStructGainsDocHiddenField {
+    pub foo: usize,
+}
+
+pub fn make_plain_struct_with_doc_hidden_field() -> PlainStructWithDocHiddenField {
+    PlainStructWithDocHiddenField { foo: 0, hidden: 0 }
+}

--- a/test_crates/constructible_struct_adds_private_field/new/src/lib.rs
+++ b/test_crates/constructible_struct_adds_private_field/new/src/lib.rs
@@ -63,3 +63,21 @@ pub struct TupleToPlainStruct {
     pub bar: i64,
     new_field: bool
 }
+
+// Even though naming every field requires using non-public API, downstream
+// code can construct this struct with functional-update syntax.
+// Adding a private field breaks that expression, so this should be reported.
+pub struct StructWithDocHiddenFieldGainsPrivateField {
+    pub foo: usize,
+    #[doc(hidden)]
+    pub hidden: i64,
+    new_private_field: bool,
+}
+
+pub fn make_struct_with_doc_hidden_field() -> StructWithDocHiddenFieldGainsPrivateField {
+    StructWithDocHiddenFieldGainsPrivateField {
+        foo: 0,
+        hidden: 0,
+        new_private_field: false,
+    }
+}

--- a/test_crates/constructible_struct_adds_private_field/old/src/lib.rs
+++ b/test_crates/constructible_struct_adds_private_field/old/src/lib.rs
@@ -56,3 +56,15 @@ pub struct PlainToTupleStruct {
 // The tuple -> plain change takes priority as a separate breaking change,
 // so this should not be reported by this lint.
 pub struct TupleToPlainStruct(pub usize, pub i64);
+
+// Even though naming every field requires using non-public API, downstream
+// code can construct this struct with functional-update syntax.
+pub struct StructWithDocHiddenFieldGainsPrivateField {
+    pub foo: usize,
+    #[doc(hidden)]
+    pub hidden: i64,
+}
+
+pub fn make_struct_with_doc_hidden_field() -> StructWithDocHiddenFieldGainsPrivateField {
+    StructWithDocHiddenFieldGainsPrivateField { foo: 0, hidden: 0 }
+}

--- a/test_crates/stability_aware_mode/new/src/lib.rs
+++ b/test_crates/stability_aware_mode/new/src/lib.rs
@@ -70,3 +70,48 @@ pub fn stable_item_to_unstable() {}
 pub const fn const_stable_to_unstable() -> usize {
     1
 }
+
+#[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+pub struct PublicFieldAddedToStructWithUnstableField {
+    #[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+    pub stable: usize,
+    #[unstable(feature = "stability_aware_mode_unstable_fields", issue = "none")]
+    pub unstable: i64,
+    #[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+    pub added: bool,
+}
+
+#[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+pub struct UnstableFieldAddedToConstructibleStruct {
+    #[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+    pub stable: usize,
+    #[unstable(feature = "stability_aware_mode_unstable_fields", issue = "none")]
+    pub unstable: i64,
+}
+
+#[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+pub struct PrivateFieldAddedToStructWithUnstableField {
+    #[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+    pub stable: usize,
+    #[unstable(feature = "stability_aware_mode_unstable_fields", issue = "none")]
+    pub unstable: i64,
+    new_private_field: bool,
+}
+
+#[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+pub fn make_public_field_struct() -> PublicFieldAddedToStructWithUnstableField {
+    PublicFieldAddedToStructWithUnstableField {
+        stable: 0,
+        unstable: 0,
+        added: false,
+    }
+}
+
+#[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+pub fn make_private_field_struct() -> PrivateFieldAddedToStructWithUnstableField {
+    PrivateFieldAddedToStructWithUnstableField {
+        stable: 0,
+        unstable: 0,
+        new_private_field: false,
+    }
+}

--- a/test_crates/stability_aware_mode/old/src/lib.rs
+++ b/test_crates/stability_aware_mode/old/src/lib.rs
@@ -85,3 +85,41 @@ pub fn stable_item_to_unstable() {}
 pub const fn const_stable_to_unstable() -> usize {
     1
 }
+
+#[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+pub struct PublicFieldAddedToStructWithUnstableField {
+    #[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+    pub stable: usize,
+    #[unstable(feature = "stability_aware_mode_unstable_fields", issue = "none")]
+    pub unstable: i64,
+}
+
+#[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+pub struct UnstableFieldAddedToConstructibleStruct {
+    #[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+    pub stable: usize,
+}
+
+#[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+pub struct PrivateFieldAddedToStructWithUnstableField {
+    #[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+    pub stable: usize,
+    #[unstable(feature = "stability_aware_mode_unstable_fields", issue = "none")]
+    pub unstable: i64,
+}
+
+#[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+pub fn make_public_field_struct() -> PublicFieldAddedToStructWithUnstableField {
+    PublicFieldAddedToStructWithUnstableField {
+        stable: 0,
+        unstable: 0,
+    }
+}
+
+#[stable(feature = "stability_aware_mode_fixture", since = "1.0.0")]
+pub fn make_private_field_struct() -> PrivateFieldAddedToStructWithUnstableField {
+    PrivateFieldAddedToStructWithUnstableField {
+        stable: 0,
+        unstable: 0,
+    }
+}

--- a/test_outputs/integration_snapshots__stability_aware_mode.snap
+++ b/test_outputs/integration_snapshots__stability_aware_mode.snap
@@ -22,6 +22,26 @@ success: false
 exit_code: 100
 ----- stdout -----
 
+--- failure constructible_struct_adds_field: struct exhaustively constructible through public API adds field ---
+
+Description:
+A pub struct that could be exhaustively constructed with a literal using only public API has a new pub field, breaking existing exhaustive literals.
+        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/[VERSION]/src/lints/constructible_struct_adds_field.ron
+
+Failed in:
+  field UnstableFieldAddedToConstructibleStruct.unstable in src/lib.rs:89
+
+--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---
+
+Description:
+A struct has a new non-public field that causes downstream code to be unable to construct it with a struct expression, including functional-update syntax.
+        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/[VERSION]/src/lints/constructible_struct_adds_private_field.ron
+
+Failed in:
+  field PrivateFieldAddedToStructWithUnstableField.new_private_field in src/lib.rs:98
+
 --- failure function_const_removed: pub fn is no longer const ---
 
 Description:
@@ -51,8 +71,8 @@ A pub function is now #[doc(hidden)], removing it from the crate's public API.
        impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/[VERSION]/src/lints/function_now_doc_hidden.ron
 
 Failed in:
-  function stable_item_to_unstable in file src/lib.rs:60
   function stable_now_doc_hidden in file src/lib.rs:23
+  function stable_item_to_unstable in file src/lib.rs:60
 
 --- failure trait_associated_const_default_removed: non-sealed trait removed the default value for an associated constant ---
 
@@ -87,7 +107,7 @@ Failed in:
 
 ----- stderr -----
     Checking <unknown> v0.1.0 -> v0.1.0 (assume minor change)
-     Checked [TIME] [TOTAL] checks: [PASS] pass, 6 fail, 0 warn, [SKIP] skip
+     Checked [TIME] [TOTAL] checks: [PASS] pass, 8 fail, 0 warn, [SKIP] skip
 
-     Summary semver requires new major version: 6 major and 0 minor checks failed
+     Summary semver requires new major version: 8 major and 0 minor checks failed
     Finished [TIME] <unknown>

--- a/test_outputs/query_execution/constructible_struct_adds_field.snap
+++ b/test_outputs/query_execution/constructible_struct_adds_field.snap
@@ -51,6 +51,18 @@ source: src/query.rs
       "struct_name": String("ExhaustiveTupleStruct"),
       "struct_type": String("tuple"),
     },
+    {
+      "field_name": String("new_field"),
+      "path": List([
+        String("constructible_struct_adds_field"),
+        String("PlainStructGainsDocHiddenField"),
+      ]),
+      "span_begin_line": Uint64(81),
+      "span_end_line": Uint64(81),
+      "span_filename": String("src/lib.rs"),
+      "struct_name": String("PlainStructGainsDocHiddenField"),
+      "struct_type": String("plain"),
+    },
   ],
   "./test_crates/constructible_struct_adds_private_field/": [
     {
@@ -89,6 +101,32 @@ source: src/query.rs
       "span_end_line": Uint64(82),
       "span_filename": String("src/lib.rs"),
       "struct_name": String("StructWithAddition"),
+      "struct_type": String("plain"),
+    },
+  ],
+  "./test_crates/stability_aware_mode/": [
+    {
+      "field_name": String("added"),
+      "path": List([
+        String("stability_aware_mode"),
+        String("PublicFieldAddedToStructWithUnstableField"),
+      ]),
+      "span_begin_line": Uint64(81),
+      "span_end_line": Uint64(81),
+      "span_filename": String("src/lib.rs"),
+      "struct_name": String("PublicFieldAddedToStructWithUnstableField"),
+      "struct_type": String("plain"),
+    },
+    {
+      "field_name": String("unstable"),
+      "path": List([
+        String("stability_aware_mode"),
+        String("UnstableFieldAddedToConstructibleStruct"),
+      ]),
+      "span_begin_line": Uint64(89),
+      "span_end_line": Uint64(89),
+      "span_filename": String("src/lib.rs"),
+      "struct_name": String("UnstableFieldAddedToConstructibleStruct"),
       "struct_type": String("plain"),
     },
   ],

--- a/test_outputs/query_execution/constructible_struct_adds_private_field.snap
+++ b/test_outputs/query_execution/constructible_struct_adds_private_field.snap
@@ -77,5 +77,31 @@ source: src/query.rs
       "struct_name": String("ExhaustiveTupleStruct"),
       "struct_type": String("tuple"),
     },
+    {
+      "field_name": String("new_private_field"),
+      "path": List([
+        String("constructible_struct_adds_private_field"),
+        String("StructWithDocHiddenFieldGainsPrivateField"),
+      ]),
+      "span_begin_line": Uint64(74),
+      "span_end_line": Uint64(74),
+      "span_filename": String("src/lib.rs"),
+      "struct_name": String("StructWithDocHiddenFieldGainsPrivateField"),
+      "struct_type": String("plain"),
+    },
+  ],
+  "./test_crates/stability_aware_mode/": [
+    {
+      "field_name": String("new_private_field"),
+      "path": List([
+        String("stability_aware_mode"),
+        String("PrivateFieldAddedToStructWithUnstableField"),
+      ]),
+      "span_begin_line": Uint64(98),
+      "span_end_line": Uint64(98),
+      "span_filename": String("src/lib.rs"),
+      "struct_name": String("PrivateFieldAddedToStructWithUnstableField"),
+      "struct_type": String("plain"),
+    },
   ],
 }


### PR DESCRIPTION
Refine the struct-constructibility lints to distinguish exhaustive literals using only public API from functional-update syntax. Ignore field additions to structs already containing unstable or `#[doc(hidden)]` fields, while continuing to report private-field additions that break functional updates.
