### PR TITLE
Test explicit selection of the default feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ This behavior can be overridden. Checked feature set can be changed to:
 
 Additionally, features can be enabled one-by-one, using flags `--features`, `--baseline-features` and `--current-features`.
 
+The feature named `default` can be selected explicitly just like any other feature. For example, `--only-explicit-features --features default` disables implicit default-feature selection and then explicitly enables the feature named `default` in both versions. Use `--baseline-features default` or `--current-features default` to select it for only one version.
+
+This is different from `--default-features`: if a package does not define a `default` feature, `--default-features` selects no features. Explicitly adding `default` treats it like any other requested feature name; it is not another spelling of `--default-features`.
+
 For example, consider crate [serde](https://github.com/serde-rs/serde), with the following features (per v1.0.163):
 
 - `std` - the crate's only default feature,
@@ -192,6 +196,7 @@ For example, consider crate [serde](https://github.com/serde-rs/serde), with the
 | `--default-features`                           | `std`                                      | The crate has only one default feature.                            |
 | `--default-features --features derive`         | `std`, `derive`                            | Feature `derive` is used along with crate's default features.      |
 | `--only-explicit-features`                     | none                                       | No explicit features are passed.                                   |
+| `--only-explicit-features --features default`  | `std`                                      | The feature named `default` is selected explicitly.                |
 | `--only-explicit-features --features unstable` | `unstable`                                 | All features can be added explicitly, regardless of their name.    |
 
 ### My crate uses `--cfg` conditional compilation. Can `cargo-semver-checks` scan it?

--- a/tests/feature_config.rs
+++ b/tests/feature_config.rs
@@ -118,6 +118,59 @@ fn simple_validation_feature_flags() {
 }
 
 #[test]
+fn default_feature_name_can_be_selected_explicitly() {
+    // This fixture fails to compile unless both `std` and `alloc` are enabled.
+    // Its `default` feature enables both, making every case sensitive to whether
+    // the explicitly named feature was actually selected.
+    CargoSemverChecks::new(
+        "test_crates/feature_flags_validation/old/",
+        "test_crates/feature_flags_validation/old/Cargo.toml",
+    )
+    .add_arg("--only-explicit-features")
+    .add_arg("--features")
+    .add_arg("default")
+    .run_all()
+    .into_iter()
+    .for_each(|a| {
+        a.success();
+    });
+
+    // Select `default` for only the baseline, while spelling out the equivalent
+    // features for the current crate.
+    CargoSemverChecks::new(
+        "test_crates/feature_flags_validation/old/",
+        "test_crates/feature_flags_validation/old/Cargo.toml",
+    )
+    .add_arg("--only-explicit-features")
+    .add_arg("--baseline-features")
+    .add_arg("default")
+    .add_arg("--current-features")
+    .add_arg("std,alloc")
+    .run_all()
+    .into_iter()
+    .for_each(|a| {
+        a.success();
+    });
+
+    // Select `default` for only the current crate, while spelling out the
+    // equivalent features for the baseline.
+    CargoSemverChecks::new(
+        "test_crates/feature_flags_validation/old/",
+        "test_crates/feature_flags_validation/old/Cargo.toml",
+    )
+    .add_arg("--only-explicit-features")
+    .add_arg("--baseline-features")
+    .add_arg("std,alloc")
+    .add_arg("--current-features")
+    .add_arg("default")
+    .run_all()
+    .into_iter()
+    .for_each(|a| {
+        a.success();
+    });
+}
+
+#[test]
 fn simple_heuristic_features() {
     CargoSemverChecks::new(
         "test_crates/features_simple/new/",
@@ -360,6 +413,22 @@ fn default_features_when_default_undefined() {
     .add_arg("--default-features")
     .add_arg("--features")
     .add_arg("B")
+    .run_all()
+    .into_iter()
+    .for_each(|a| {
+        a.failure();
+    });
+}
+
+#[test]
+fn explicitly_named_default_must_exist() {
+    CargoSemverChecks::new(
+        "test_crates/features_no_default/new/",
+        "test_crates/features_no_default/old/Cargo.toml",
+    )
+    .add_arg("--only-explicit-features")
+    .add_arg("--features")
+    .add_arg("default")
     .run_all()
     .into_iter()
     .for_each(|a| {


### PR DESCRIPTION
Fixes #916.

## Summary

- document that `default` can be selected through the shared, baseline-only, and current-only explicit feature flags
- distinguish explicitly selecting the feature named `default` from enabling implicit default features
- add integration coverage where omitting `default` would make the fixture fail to compile
- cover explicit selection when no feature named `default` exists

## Testing

- `cargo test --test feature_config` (13 passed)
- `cargo clippy --all-targets --no-deps --fix --allow-dirty --allow-staged -- -D warnings --allow deprecated`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items`
- `cargo fmt --all -- --check`
- `git diff --check`
